### PR TITLE
RFC: use curl dollar (`${}`) for var substituion

### DIFF
--- a/doc/directives.md
+++ b/doc/directives.md
@@ -42,7 +42,7 @@ otk.argument:
   - architecture
 ```
 
-## Usage of `$`
+## Usage of `${}`
 
 Use a previously defined variable. String values can be used inside other
 string values, non-string values *must* stand on their own.
@@ -51,10 +51,10 @@ string values, non-string values *must* stand on their own.
 otk.define:
   variable: "foo"
 
-otk.include: $variable
+otk.include: ${variable}
 ```
 
-If a `$` appears in a `str` value then its string value as it appears
+If a `${}` appears in a `str` value then its string value as it appears
 in `otk.define` is replaced into the string. Note that using the sugared form
 in this form requires the value to be a string in the `otk.define`. 
 
@@ -63,7 +63,7 @@ in this form requires the value to be a string in the `otk.define`.
 otk.define:
   variable: aarch64
 
-otk.include: path/$variable.yaml
+otk.include: path/${variable}.yaml
 ```
 
 The following example is an error as the value of `variable` is a `seq`, which
@@ -76,10 +76,10 @@ otk.define:
     - 1
     - 2
 
-otk.include: path/$variable.yaml
+otk.include: path/${variable}.yaml
 ```
 
-This is okay because "$variable" is there on it's own so it's unambiguous.
+This is okay because "${variable}" is there on it's own so it's unambiguous.
 ```yaml
 # this is OK
 otk.define:
@@ -88,7 +88,7 @@ otk.define:
     - 2
 
 some:
- thing: $variable
+ thing: ${variable}
 ```
 
 ## otk.include
@@ -128,8 +128,8 @@ otk.define:
   c:
     otk.op.seq.join:
       values:
-        - $a
-        - $b
+        - ${a}
+        - ${b}
 ```
 
 ### otk.op.map.join
@@ -149,8 +149,8 @@ otk.define:
   c:
     otk.op.hash.merge:
       values:
-        - $a
-        - $b
+        - ${a}
+        - ${b}
 ```
 
 ## otk.meta
@@ -191,9 +191,9 @@ otk.customization.name:
       options: none
   defined:
     - type: org.osbuild.stage
-      options: $this.data  # it's not going to be `this`
+      options: ${this.data}  # it's not going to be `this`
     - type: org.osbuild.stage
-      options: $this.data  # it's not going to be `this`
+      options: ${this.data}  # it's not going to be `this`
 ```
 
 ## otk.target.<consumer>

--- a/example/fedora/minimal.yaml
+++ b/example/fedora/minimal.yaml
@@ -5,7 +5,7 @@ otk.argument:
   - architecture
 
 otk.include:
-  path: repositories/$version.yaml
+  path: repositories/${version}.yaml
 
 otk.define:
   # Packages used by the various pipelines, `root` is the buildroot, `tree` is
@@ -50,7 +50,7 @@ otk.define:
             options: defaults,uid=0,gid=0,umask=077,shortname=winnt
             passno: 2
         defined:
-          otk.external.osbuild.filesystem: $this
+          otk.external.osbuild.filesystem: ${this}
 
 
 otk.target.osbuild:

--- a/example/fedora/osbuild/pipelines/root.yaml
+++ b/example/fedora/osbuild/pipelines/root.yaml
@@ -2,13 +2,13 @@ name: root
 source-epoch: 1659397331
 stages:
   - otk.external.osbuild.depsolve-dnf4:
-    architecture: $architecture
-    module_platform_id: f$version
-    repositories: $repositories
-    gpgkeys: $gpgkeys
+    architecture: ${architecture}
+    module_platform_id: f${version}
+    repositories: ${repositories}
+    gpgkeys: ${gpgkeys}
     exclude:
       docs: true
-    packages: $packages.default.root
+    packages: ${packages.default.root}
   - name: org.osbuild.selinux
     options:
       file_contexts: etc/selinux/targeted/contexts/files/file_contexts

--- a/example/fedora/osbuild/pipelines/tree.yaml
+++ b/example/fedora/osbuild/pipelines/tree.yaml
@@ -3,49 +3,61 @@ build: name:root
 stages:
   - type: org.osbuild.kernel-cmdline
     options:
-      root_fs_uuid: $filesystems.raw.root.uuid
+      root_fs_uuid: ${filesystems.raw.root.uuid}
       kernel_opts: ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0
   - otk.external.osbuild.depsolve-dnf4:
-    architecture: $architecture
-    module_platform_id: f$version
-    repositories: $repositories
-    gpgkeys: $gpgkeys
+    architecture: ${architecture}
+    module_platform_id: f${version}
+    repositories: ${repositories}
+    gpgkeys: ${gpgkeys}
     exclude:
       docs: true
-    packages: $packages.default.tree
+    packages: ${packages.default.tree}
   - type: org.osbuild.fix-bls
     options:
       prefix: ''
-  - type: org.osbuild.locale
-      options:
-        language:
-          otk.customization.locale:
-            default: en_US
-            defined: $this.langauge
-  - type: org.osbuild.hostname
-    options:
-      hostname:
-        otk.customization.hostname:
-          default: localhost.localdomain
-          defined: $this.hostname
-  - type: org.osbuild.timezone
-    options:
-      zone:
-        otk.customization.timezone:
-          default: UTC
-          defined: $this.timezone
+  - otk.customization.locale:
+    scope: tree  # XXX docs
+    default:
+      - type: org.osbuild.locale
+        options:
+          language: en_US
+    defined:
+      - type: org.osbuild.locale
+        options:
+          language: ${this.language}
+  - otk.customization.hostname:
+    scope: tree
+    default:
+      - type: org.osbuild.hostname
+        options:
+          hostname: localhost.localdomain
+    defined:
+      - type: org.osbuild.hostname
+        options:
+          hostname: ${this.hostname}
+  - otk.customization.timezone:
+    scope: tree
+    default:
+      - type: org.osbuild.timezone
+        options:
+          zone: UTC
+    defined:
+      - type: org.osbuild.timezone
+        options:
+          zone: ${this.timezone}
   - type: org.osbuild.fstab
-    options: $filesystems.raw
+    options: ${filesystems.raw}
   - type: org.osbuild.grub2
     options:
-      root_fs_uuid: $filesystems.raw.root.uuid
-      boot_fs_uuid: $filesystems.raw.boot.uuid
+      root_fs_uuid: ${filesystems.raw.root.uuid}
+      boot_fs_uuid: ${filesystems.raw.boot.uuid}
       kernel_opts: ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0
       legacy: i386-pc
       uefi:
         vendor: fedora
         unified: true
-      saved_entry: "ffffffffffffffffffffffffffffffff-$packages.something.kernel-core.version"
+      saved_entry: "ffffffffffffffffffffffffffffffff-${packages.something.kernel-core.version}"
       write_cmdline: false
       config:
         default: saved

--- a/example/fedora/repositories/40.yaml
+++ b/example/fedora/repositories/40.yaml
@@ -1,6 +1,6 @@
 otk.define:
   repositories:
   - id: "fedora"
-    metalink: https://mirrors.fedoraproject.org/metalink?repo=fedora-$version&arch=$architecture
+    metalink: https://mirrors.fedoraproject.org/metalink?repo=fedora-${version}&arch=${architecture}
   gpgkeys:
   - "1234"


### PR DESCRIPTION
With curl dollar var substition some ambitious cases become slightly easier to see without knowning about the var content, e.g.:
```
$foo.bar
```
could mean "replace $foo" and add ".bar" if `$foo` is a string or "use member bar of map $foo". With
```
${foo}.bar
${foo.bar}
```
this would become easier to see without having context what type the var is.