### PR TITLE
RFC: start without `otk.variable` just `$`

### DIFF
--- a/doc/directives.md
+++ b/doc/directives.md
@@ -42,24 +42,10 @@ otk.argument:
   - architecture
 ```
 
-## otk.variable
+## Usage of `$`
 
-Use a previously defined variable.
-
-The short form expects a `str` for its value, the long form expects a `map` for
-its value.
-
-```yaml
-otk.define:
-  variable: "foo"
-
-otk.include:
-  otk.variable: variable
-```
-
-It is also possible to use a sugared form of `otk.variable`. For any `str` 
-value that starts with `$` the value is replaced with the value as defined
-in the `otk.define` block.
+Use a previously defined variable. String values can be used inside other
+string values, non-string values *must* stand on their own.
 
 ```yaml
 otk.define:
@@ -68,9 +54,9 @@ otk.define:
 otk.include: $variable
 ```
 
-If a `$` appears later in a `str` value then its string value as it appears
+If a `$` appears in a `str` value then its string value as it appears
 in `otk.define` is replaced into the string. Note that using the sugared form
-in this form requires the value to be a string in the `otk.define`.
+in this form requires the value to be a string in the `otk.define`. 
 
 ```yaml
 # this is OK
@@ -91,6 +77,18 @@ otk.define:
     - 2
 
 otk.include: path/$variable.yaml
+```
+
+This is okay because "$variable" is there on it's own so it's unambiguous.
+```yaml
+# this is OK
+otk.define:
+  variable:
+    - 1
+    - 2
+
+some:
+ thing: $variable
 ```
 
 ## otk.include


### PR DESCRIPTION
The spec currently defines two ways to use variables. All the examples use only a single one even in places that are technically not allowing it. But I have to say I really like the short form this RFC advocates to just start with that short form and see if we actually have a use case for the long form.

The rule would be simple:
- string vars can be used inside strings "foo: hello $world" works if "world" is a string
- non-string vars must stand on their own, so "foo: $world" is the only allowed form for maps/seq etc.