### PR TITLE
RFC: use otk files instead of otk.arguments

### DIFF
--- a/doc/directives.md
+++ b/doc/directives.md
@@ -29,19 +29,6 @@ otk.define:
   boot_mode: uefi
 ```
 
-## otk.argument
-
-Define arguments that **MUST** be passed on the command line to `otk` with
-`otk compile -A`.
-
-Expects a `seq` for its value.
-
-```yaml
-otk.argument:
-  - version
-  - architecture
-```
-
 ## Usage of `${}`
 
 Use a previously defined variable. String values can be used inside other

--- a/example/fedora/fedora-39-amd64.yaml
+++ b/example/fedora/fedora-39-amd64.yaml
@@ -1,0 +1,6 @@
+otk.define:
+  version: 39
+  architecture: amd64
+
+otk.include:
+  path: minimal.yaml

--- a/example/fedora/minimal.yaml
+++ b/example/fedora/minimal.yaml
@@ -1,9 +1,5 @@
 otk.version: 1
 
-otk.argument:
-  - version
-  - architecture
-
 otk.include:
   path: repositories/${version}.yaml
 


### PR DESCRIPTION
The use-case given (and maybe I'm missing other use-cases here) for the otk.arguments is currently "version" and "architecture".

We could do this instead via a `fedora-39-amd64.yaml` file that just define those arguments. The upside of this is that we can easily see what combinations of version and architecture we support by looking at the top-level dir. It also simplifies the spec and we would not have to worry about validating arguments, i.e. how do we know that "-Dversion=41" is valid or not (if not valid it would probably mean down the line an include based on the version cannot be found and that presents challenges for a nice error message).

It would also allow us to have symlinks when things do not change, e.g.
```
rhel-9.3.yaml -> rhel-9.4.yaml
```

But maybe I'm missing another use case for this? Even then I think the `fedora/39-amd64.yaml` has some merrits and is worth considering.