### PR TITLE
RFC: define a single `otk.op.join`

### DIFF
--- a/doc/03-omnifest/01-directive.md
+++ b/doc/03-omnifest/01-directive.md
@@ -127,13 +127,16 @@ otk.include: file.yaml
 
 Perform various operations on variables.
 
-### `otk.op.seq.join`
+### `otk.op.join`
 
-Join two or more variables of type sequence together, trying to join other types
-will cause an error.
+Join two or more variables of type `sequence` or `map` together, trying to
+join other types or mix types will cause an error. Duplicate keys in
+maps are considered an error.
 
 Expects a `map` for its value that contains a `values` key with a value of type
-`seq`
+`seq` or `map`.
+
+Example when using with a `sequence` as input:
 
 ```yaml
 otk.define:
@@ -144,21 +147,15 @@ otk.define:
     - 3
     - 4
   c:
-    otk.op.seq.join:
+    otk.op.join:
       values:
         - ${a}
         - ${b}
-        - - 5
-          - 6
+
+-> Result c: [1, 2, 3, 4]
 ```
 
-### `otk.op.map.join`
-
-Join two or more variables of type map together. Trying to merge other types
-will cause an error. Duplicate keys in the maps are considered an error.
-
-Expects a `map` for its value that contains a `values` key with a value of type
-`seq`
+Example when using with a `map` as input:
 
 ```yaml
 otk.define:
@@ -167,10 +164,15 @@ otk.define:
   b:
     b: 2
   c:
-    otk.op.map.merge:
+    otk.op.join:
       values:
         - ${a}
         - ${b}
+
+-> Result
+  c:
+   a: 1
+   b: 2
 ```
 
 ## `otk.meta.<name>`

--- a/src/otk/directive.py
+++ b/src/otk/directive.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 import itertools
 import logging
 import pathlib
-from typing import Any
+from typing import Any, List
 
 import yaml
 
@@ -96,53 +96,50 @@ def op(ctx: Context, tree: Any, key: str) -> Any:
     """Dispatch the various `otk.op` directives while handling unknown
     operations."""
 
-    if key == "otk.op.seq.merge":
-        return op_seq_merge(ctx, tree)
-    elif key == "otk.op.map.merge":
-        return op_map_merge(ctx, tree)
+    if key == "otk.op.join":
+        return op_join(ctx, tree)
     else:
         raise TransformDirectiveUnknownError("nonexistent op %r", key)
 
 
 @tree.must_be(dict)
 @tree.must_pass(tree.has_keys(["values"]))
-def op_seq_merge(ctx: Context, tree: dict[str, Any]) -> Any:
-    """Merge to sequences by concatenating them together."""
+def op_join(ctx: Context, tree: dict[str, Any]) -> Any:
+    """Join a map/seq."""
 
     values = tree["values"]
-
     if not isinstance(values, list):
         raise TransformDirectiveTypeError(
-            "seq merge received values of the wrong type, was expecting a list of lists but got %r",
+            "seq join received values of the wrong type, was expecting a list of lists but got %r",
             values,
         )
+    if all(isinstance(sl, list) for sl in values):
+        return _op_seq_join(ctx, values)
+    elif all(isinstance(sl, dict) for sl in values):
+        return _op_map_join(ctx, values)
+    else:
+        raise TransformDirectiveTypeError(f"cannot join {values}")
+
+
+def _op_seq_join(ctx: Context, values: List[list]) -> Any:
+    """Join to sequences by concatenating them together."""
 
     if not all(isinstance(sl, list) for sl in values):
         raise TransformDirectiveTypeError(
-            "seq merge received values of the wrong type, was expecting a list of lists but got %r",
+            "seq join received values of the wrong type, was expecting a list of lists but got %r",
             values,
         )
 
     return list(itertools.chain.from_iterable(values))
 
 
-@tree.must_be(dict)
-@tree.must_pass(tree.has_keys(["values"]))
-def op_map_merge(ctx: Context, tree: dict[str, Any]) -> Any:
-    """Merge two dictionaries. Keys from the second dictionary overwrite keys
+def _op_map_join(ctx: Context, values: List[dict]) -> Any:
+    """Join two dictionaries. Keys from the second dictionary overwrite keys
     in the first dictionary."""
-
-    values = tree["values"]
-
-    if not isinstance(values, list):
-        raise TransformDirectiveTypeError(
-            "map merge received values of the wrong type, was expecting a list of lists but got %r",
-            values,
-        )
 
     if not all(isinstance(sl, dict) for sl in values):
         raise TransformDirectiveTypeError(
-            "map merge received values of the wrong type, was expecting a list of dicts but got %r",
+            "map join received values of the wrong type, was expecting a list of dicts but got %r",
             values,
         )
 

--- a/test/test_directive.py
+++ b/test/test_directive.py
@@ -2,7 +2,7 @@ import pytest
 
 from otk.context import CommonContext
 from otk.error import TransformDirectiveArgumentError, TransformDirectiveTypeError
-from otk.directive import define, desugar, include, op_map_merge, op_seq_merge
+from otk.directive import define, desugar, include, op_join
 
 
 def test_define():
@@ -31,7 +31,7 @@ def test_include_unhappy():
         include(ctx, 1)
 
 
-def test_op_seq_merge():
+def test_op_seq_join():
     ctx = CommonContext()
 
     l1 = [1, 2, 3]
@@ -39,26 +39,38 @@ def test_op_seq_merge():
 
     d = {"values": [l1, l2]}
 
-    assert op_seq_merge(ctx, d) == [1, 2, 3, 4, 5, 6]
+    assert op_join(ctx, d) == [1, 2, 3, 4, 5, 6]
 
 
-def test_op_seq_merge_unhappy():
+def test_op_join_unhappy():
     ctx = CommonContext()
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_seq_merge(ctx, 1)
+        op_join(ctx, 1)
 
     with pytest.raises(TransformDirectiveArgumentError):
-        op_seq_merge(ctx, {})
+        op_join(ctx, {})
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_seq_merge(ctx, {"values": 1})
+        op_join(ctx, {"values": 1})
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_seq_merge(ctx, {"values": [1, {2: 3}]})
+        op_join(ctx, {"values": [1, {2: 3}]})
+
+    with pytest.raises(TransformDirectiveTypeError):
+        op_join(ctx, 1)
+
+    with pytest.raises(TransformDirectiveArgumentError):
+        op_join(ctx, {})
+
+    with pytest.raises(TransformDirectiveTypeError):
+        op_join(ctx, {"values": 1})
+
+    with pytest.raises(TransformDirectiveTypeError):
+        op_join(ctx, {"values": [1, {2: 3}]})
 
 
-def test_op_map_merge():
+def test_op_map_join():
     ctx = CommonContext()
 
     d1 = {"foo": "bar"}
@@ -66,23 +78,7 @@ def test_op_map_merge():
 
     d = {"values": [d1, d2]}
 
-    assert op_map_merge(ctx, d) == {"foo": "bar", "bar": "foo"}
-
-
-def test_op_map_merge_unhappy():
-    ctx = CommonContext()
-
-    with pytest.raises(TransformDirectiveTypeError):
-        op_map_merge(ctx, 1)
-
-    with pytest.raises(TransformDirectiveArgumentError):
-        op_map_merge(ctx, {})
-
-    with pytest.raises(TransformDirectiveTypeError):
-        op_map_merge(ctx, {"values": 1})
-
-    with pytest.raises(TransformDirectiveTypeError):
-        op_map_merge(ctx, {"values": [1, {2: 3}]})
+    assert op_join(ctx, d) == {"foo": "bar", "bar": "foo"}
 
 
 def test_desugar():


### PR DESCRIPTION
I wonder if we can simply avoid having the user care about the type when doing a join operation. It seems mostly a burden to the user and we need to check during compilation of the otk file anyway so maybe we can just leave it out?

P.S. Having an example use-case for both would be really good, I'm wonder if we only should add things to the spec once we actually use it in the example/* tree ?