### PR TITLE
example: change file.yaml to pass lint

### DIFF
--- a/example/fedora/osbuild/custom/file.yaml
+++ b/example/fedora/osbuild/custom/file.yaml
@@ -1,7 +1,4 @@
 mtk.define:
   file_customization_packages:
     include:
-      pass
-
-- type: org.osbuild.file
-  ...
+      - example


### PR DESCRIPTION
Makes `file.yaml` at least valid for now so #10 can be merged.