### PR TITLE
ci: enable lint workflow on merge queue

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
 
 jobs:
   lint:


### PR DESCRIPTION
Enable ci on the merge queue, thanks @ondrejbudai.