### PR TITLE
transform: copy the tree instead of in-place

### DIFF
--- a/src/otk/transform/__init__.py
+++ b/src/otk/transform/__init__.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from copy import deepcopy
 from typing import Any, Type
 
 from .context import Context
@@ -116,6 +117,8 @@ resolvers: dict[Type, Any] = {
 def resolve(ctx: Context, tree: Any) -> Any:
     """Resolves a (sub)tree of any type into a new tree. Each type has its own
     specific handler to rewrite the tree."""
+
+    tree = deepcopy(tree)
 
     if type(tree) not in resolvers:
         log.fatal("could not look up %r in resolvers", type(tree))

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -1,0 +1,10 @@
+from otk.transform import resolve
+from otk.transform.context import Context
+
+
+def test_tree_copy():
+    # Ensure that the tree is copied
+    t0 = {"a": "b"}
+    t1 = resolve(Context(), t0)
+
+    assert id(t0) != id(t1)


### PR DESCRIPTION
This copies the tree for each transform giving the lower lying transforms a new tree every time.