### PR TITLE
[RFC] examples: split out "fedora/minimal-common.yaml" and define two archs

### DIFF
--- a/example/fedora/minimal-40-aarch64.yaml
+++ b/example/fedora/minimal-40-aarch64.yaml
@@ -2,6 +2,6 @@ otk.version: 1
 
 otk.define:
   version: 40
-  architecture: x86_64
+  architecture: aarch64
 
 otk.include: "minimal-common.yaml"

--- a/example/fedora/minimal-common.yaml
+++ b/example/fedora/minimal-common.yaml
@@ -1,0 +1,69 @@
+otk.define:
+  isolabel: Fedora-${version}-${architecture}
+
+  packages:
+    # These packages are used in the buildroot
+    buildroot:
+      docs: false
+      weak: false
+      packages:
+        include:
+          - "@core"
+        # TODO We can't merge nonexistent vars
+        exclude:
+          - "nonexistent"
+    # These packages are used for the operating system tree which is what ends
+    # up in the outputs.
+    tree:
+      docs: false
+      weak: false
+      packages:
+        include:
+          - "@core"
+          - "initial-setup"
+          - "libxkbcommon"
+          - "NetworkManager-wifi"
+          - "brcmfmac-firmware"
+          - "realtek-firmware"
+          - "iwlwifi-mvm-firmware"
+        # TODO We can't merge nonexistent vars
+        exclude:
+          - "nonexistent"
+    todo:
+      packages:
+        include:
+          - "@bar"
+          - "@baz"
+        # TODO We can't merge nonexistent vars
+        exclude:
+          - "nonexistent"
+    # Repositories to fetch packages from
+    repositories:
+      otk.include: repository/${version}.yaml
+    # GPG keys to verify packages with
+    keys:
+      otk.include: repository/${version}-gpg.yaml
+  filesystem:
+    root:
+      uuid: 6e4ff95f-f662-45ee-a82a-bdf44a2d0b75
+      vfs_type: ext4
+      path: /
+      options: defaults
+    boot:
+      uuid: 0194fdc2-fa2f-4cc0-81d3-ff12045b73c8
+      vfs_type: ext4
+      path: /boot
+      options: defaults
+    boot-efi:
+      uuid: 7B77-95E7
+      vfs_type: vfat
+      path: /boot/efi
+      options: defaults,uid=0,gid=0,umask=077,shortname=winnt
+      passno: 2
+
+otk.target.osbuild:
+  pipelines:
+    - otk.include: "osbuild/buildroot.yaml"
+    - otk.include: "osbuild/pipeline/tree.yaml"
+    - otk.include: "osbuild/pipeline/raw.yaml"
+    - otk.include: "osbuild/pipeline/xz.yaml"


### PR DESCRIPTION
Tweak the example to be slightly more realistic and have two arches for fedora and a common yaml. This will probably see more refactor when an additonal fedora that is not minimal is added.

Tiny starting point, if this looks okay I will play a bit more with how fedora maybe in two arches and two flaviors could look like :)