### PR TITLE
[RFC] doc,example: rename `root` to `buildroot`

### DIFF
--- a/doc/directives.md
+++ b/doc/directives.md
@@ -205,7 +205,7 @@ be in the tree.
 ```yaml
 otk.target.osbuild:
   pipelines:
-    - otk.include: pipelines/root.yaml
+    - otk.include: pipelines/buildroot.yaml
     - otk.include: pipelines/tree.yaml
 ```
 

--- a/example/fedora/minimal-40-x86_64.yaml
+++ b/example/fedora/minimal-40-x86_64.yaml
@@ -5,7 +5,7 @@ otk.define:
   architecture: "aarch64"
   packages:
     # These packages are used in the buildroot
-    root:
+    buildroot:
       docs: false
       weak: false
       packages:
@@ -65,7 +65,7 @@ otk.define:
 
 otk.target.osbuild:
   pipelines:
-    - otk.include: "osbuild/root.yaml"
+    - otk.include: "osbuild/buildroot.yaml"
     - otk.include: "osbuild/pipeline/tree.yaml"
     - otk.include: "osbuild/pipeline/raw.yaml"
     - otk.include: "osbuild/pipeline/xz.yaml"

--- a/example/fedora/osbuild/buildroot.yaml
+++ b/example/fedora/osbuild/buildroot.yaml
@@ -1,24 +1,24 @@
-# `root.yaml` sets up the buildroot for `osbuild`.
-name: root
+# `buildroot.yaml` sets up the buildroot for `osbuild`.
+name: buildroot
 source-epoch: 1659397331
 stages:
   - otk.external.osbuild.depsolve-dnf4:
       architecture: ${architecture}
       module_platform_id: f${version}
-      docs: ${packages.root.docs}
-      weak: ${packages.root.weak}
+      docs: ${packages.buildroot.docs}
+      weak: ${packages.buildroot.weak}
       repositories: ${packages.repositories}
       gpgkeys: ${packages.keys}
       packages:
         include:
           otk.op.seq.merge:
             values:
-              - ${packages.root.packages.include}
+              - ${packages.buildroot.packages.include}
               - ${packages.todo.packages.include}
         exclude:
           otk.op.seq.merge:
             values:
-              - ${packages.root.packages.exclude}
+              - ${packages.buildroot.packages.exclude}
               - ${packages.todo.packages.exclude}
   - type: org.osbuild.selinux
     options:


### PR DESCRIPTION
The word `root` has many meanings and in minimal-40-x86_64 it is used twice, once for the buildroot and once for the root of the filesystem. It seems slightly nicer to spell the buildroot out as `buildroot` even if it's a little bit more typing.