### PR TITLE
re-import documentation

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -20,3 +20,12 @@ fedoraproject
 Changelog
 entrypoint
 README
+Frontend
+jobqueue
+organise
+organised
+deprecations
+subdirectory
+kickstarts
+koji
+livemediacreator

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ manifests.
 
 ## Documentation
 
-You can find `otk`'s documentation on [our documentation website](https://osbuild.org/docs/developer-guide/projects/otk). This README contains a small summary of directly useful information.
+You can find `otk`'s documentation in the [/doc](./doc) subdirectory. This README contains a small summary of directly useful information.
 
 ## Usage
 

--- a/doc/00-installation.md
+++ b/doc/00-installation.md
@@ -1,0 +1,20 @@
+# Installation
+
+As `otk` is still in a proof of concept state it is not yet packaged for any distributions. Installation thus requires you to work from [source](https://github.com/osbuild/otk).
+
+To start hacking on `otk` you can:
+
+```
+€ git checkout https://github.com/osbuild/otk
+# ...
+€ python3 -m venv venv
+# ...
+€ . venv/bin/activate
+# ...
+€ pip install -e ".[dev]"
+# ...
+```
+
+This will get you an activated Python virtual environment with an editable install of `otk`. You can then run edit source in `src/` and run `otk` as long as your virtual environment is enabled.
+
+You can read more about [contributing](./contributing)

--- a/doc/00-installation.md
+++ b/doc/00-installation.md
@@ -17,4 +17,4 @@ To start hacking on `otk` you can:
 
 This will get you an activated Python virtual environment with an editable install of `otk`. You can then run edit source in `src/` and run `otk` as long as your virtual environment is enabled.
 
-You can read more about [contributing](./contributing)
+You can read more about [contributing](./01-contributing.md)

--- a/doc/01-contributing.md
+++ b/doc/01-contributing.md
@@ -1,0 +1,5 @@
+# Contributing
+
+`otk` is written in Python with a minimal version of `3.8`. It is licensed under the Apache License.
+
+You can find open [issues](https://github.com/osbuild/otk/issues) at its [GitHub](https://github.com/osbuild/otk) page.

--- a/doc/02-usage.md
+++ b/doc/02-usage.md
@@ -1,0 +1,3 @@
+# Usage
+
+After [installing](./installation) `otk` you'll probably want to start using it.

--- a/doc/02-usage.md
+++ b/doc/02-usage.md
@@ -1,3 +1,3 @@
 # Usage
 
-After [installing](./installation) `otk` you'll probably want to start using it.
+After [installing](./00-installation.md) `otk` you'll probably want to start using it.

--- a/doc/03-omnifest/01-directive.md
+++ b/doc/03-omnifest/01-directive.md
@@ -1,0 +1,235 @@
+# Directive
+
+In [omnifests](./) directives are sections of the document that get transformed by `otk` into something else.
+
+`otk` has various directives that can be used in an omnifest. Generally these directives can appear anywhere in the tree unless otherwise specified (see below) and they are replaced with other trees or values as produced by the directive.
+
+There are [example omnifests](https://github.com/osbuild/otk/tree/main/example) for various distributions and images in a [source checkout](../installation).
+
+## `otk.version`
+
+### Example
+
+```yaml
+otk.version: "1"
+```
+
+## `otk.target.<consumer>.<name>`
+
+Only act on this sub-tree if producing output for the specified consumer. Anything specific to the pipelines of e.g. osbuild would be put under `otk.target.osbuild`. This allows `otk` to infer context for the omnifest that is being processed.
+
+A target is necessary for `otk` to generate any outputs. The target is namespaced to a specific application. `otk` tries to keep little context but it does need to know what it is outputting for. This allows us to scope [otk.external](#otkexternal) things to only be allowed within specific targets and for those externals to assume certain things will be in the tree.
+
+The following values are valid for the `<consumer>` part of the key, this list can grow as other image build tooling is supported:
+
+- `osbuild`
+
+The `<name>` part of the key is free form and allows you to use a descriptive name for the export. Note that there MUST be no duplication of the `<consumer>.<name>` tuple.
+
+```yaml
+otk.target.osbuild.tree:
+  pipelines:
+    - otk.include: pipelines/root.yaml
+    - otk.include: pipelines/tree.yaml
+```
+
+---
+
+## `otk.define`
+
+Defines variables that can be used through the `otk.variable` directive in
+other parts of the omnifest.
+
+Variable scope is global, an `otk.define` directive anywhere in the omnifest
+tree will result in the defined names being hoisted to the global scope.
+
+Redefinitions of variables are allowed. This allows for setting up default
+values. If `-w duplicate-definition` is passed as an argument to `otk` then
+`otk` will warn on all duplicate definitions.
+
+Expects a `map` for its value.
+
+```yaml
+otk.define:
+  packages:
+    include:
+      - @core
+      - kernel
+    exclude:
+      - linux-util
+  boot_mode: uefi
+```
+
+## Usage of `${}`
+
+Use a previously defined variable. String values can be used inside other
+string values, non-string values *must* stand on their own.
+
+```yaml
+otk.define:
+  variable: "foo"
+
+otk.include: ${variable}
+```
+
+If a `${}` appears in a `str` value then its string value as it appears
+in `otk.define` is replaced into the string. Note that using the sugared form
+in this form requires the value to be a string in the `otk.define`.
+
+```yaml
+# this is OK
+otk.define:
+  variable: aarch64
+
+otk.include: path/${variable}.yaml
+```
+
+The following example is an error as the value of `variable` is a `seq`, which
+is not allowed inside a string format.
+
+```yaml
+# this is NOT OK
+otk.define:
+  variable:
+    - 1
+    - 2
+
+otk.include: path/${variable}.yaml
+```
+
+This is okay because `${variable}` is there on it's own so it's unambiguous.
+```yaml
+# this is OK
+otk.define:
+  variable:
+    - 1
+    - 2
+
+some:
+ thing: ${variable}
+```
+
+## `otk.include`
+
+Include a file at this position in the tree, replacing the directive with the
+contents of the file.
+
+Note that cyclical includes are forbidden and will cause an error.
+
+The short form expects a `str` for its value, the long form expects a `map` for
+its value.
+
+```yaml
+otk.include: file.yaml
+```
+
+## `otk.op`
+
+Perform various operations on variables.
+
+### `otk.op.seq.join`
+
+Join two or more variables of type sequence together, trying to join other types
+will cause an error.
+
+Expects a `map` for its value that contains a `values` key with a value of type
+`seq`
+
+```yaml
+otk.define:
+  a:
+    - 1
+    - 2
+  b:
+    - 3
+    - 4
+  c:
+    otk.op.seq.join:
+      values:
+        - ${a}
+        - ${b}
+        - - 5
+          - 6
+```
+
+### `otk.op.map.join`
+
+Join two or more variables of type map together. Trying to merge other types
+will cause an error. Duplicate keys in the maps are considered an error.
+
+Expects a `map` for its value that contains a `values` key with a value of type
+`seq`
+
+```yaml
+otk.define:
+  a:
+    a: 1
+  b:
+    b: 2
+  c:
+    otk.op.map.merge:
+      values:
+        - ${a}
+        - ${b}
+```
+
+## `otk.meta.<name>`
+
+Under the `otk.meta` namespace any data can be stored that other applications
+need to use from an omnifest.
+
+Expects a `map` for its value.
+
+```yaml
+otk.meta.osbuild-composer:
+  boot_mode: uefi
+  export: image
+  pipelines:
+    build:
+      - root
+    system:
+      - tree
+
+otk.meta.kiwi:
+  label: "A Label"
+```
+
+## `otk.customization`
+
+Customizations are conditional blocks that receive separate input through
+`otk compile -Cname=data`, a customization is considered to be active when it
+is passed data. If a customization is passed multiple times then the `defined`
+block is repeated multiple times, once for each input.
+
+Expects a `map` for its value which contains an `if-set` key. The `default` key
+is optional. If a `default` key is not passed and the customization is inactive
+then the customization block is effectively a no-op and will be removed from the
+tree. The values of `default` and `if-set` can be of any type.
+
+```yaml
+otk.customization.name:
+  default:
+    - type: org.osbuild.stage
+      options: none
+  if-set:
+    - type: org.osbuild.stage
+      options: ${this.data}  # it's not going to be `this`
+    - type: org.osbuild.stage
+      options: ${this.data}  # it's not going to be `this`
+```
+
+## `otk.external`
+
+External directives. Directives starting with `otk.external` are redirected
+to `/usr/libexec/otk/`-binaries. For example the directive
+`otk.external.osbuild.depsolve-dnf4` will execute `otk-osbuild depsolve-dnf4`
+with the tree under the directive on stdin and expect a new tree to replace
+the directive with on stdout.
+
+When `otk` processes omnifests initially it performs a "common" translation
+which processes all non-external directives. After this it processes each
+target in the omnifest with a context specific to the target. In this phase
+the `otk.external` directives are resolved.
+
+Read more about [external directives](./external) in their specific
+documentation section.

--- a/doc/03-omnifest/01-directive.md
+++ b/doc/03-omnifest/01-directive.md
@@ -1,10 +1,10 @@
 # Directive
 
-In [omnifests](./) directives are sections of the document that get transformed by `otk` into something else.
+In [omnifests](./index.md) directives are sections of the document that get transformed by `otk` into something else.
 
 `otk` has various directives that can be used in an omnifest. Generally these directives can appear anywhere in the tree unless otherwise specified (see below) and they are replaced with other trees or values as produced by the directive.
 
-There are [example omnifests](https://github.com/osbuild/otk/tree/main/example) for various distributions and images in a [source checkout](../installation).
+There are [example omnifests](https://github.com/osbuild/otk/tree/main/example) for various distributions and images in a [source checkout](../00-installation.md).
 
 ## `otk.version`
 
@@ -231,5 +231,5 @@ which processes all non-external directives. After this it processes each
 target in the omnifest with a context specific to the target. In this phase
 the `otk.external` directives are resolved.
 
-Read more about [external directives](./external) in their specific
+Read more about [external directives](./02-external.md) in their specific
 documentation section.

--- a/doc/03-omnifest/02-external.md
+++ b/doc/03-omnifest/02-external.md
@@ -1,0 +1,44 @@
+# External
+
+## osbuild
+
+These directives are only allowed within a [`otk.target.osbuild.<name>`](./directive#otktargetconsumername).
+
+### `otk.external.osbuild.depsolve-dnf4`
+
+Solves a list of package specifications to RPMs and specifies them in the
+osbuild manifest as sources.
+
+### `otk.external.osbuild.depsolve-dnf5`
+
+Expects a `map` as its value.
+
+`osbuild` directives to write files. **If a stage exists for the type of file
+you want to write: use it.** See the [best practices](../best-practices).
+
+### `otk.external.osbuild.file-from-text`
+
+Write inline text to a file. Creates a source in the manifest and copies that
+source to the destination in the tree.
+
+Path components up to the destination must be pre-existing in the tree.
+
+```yaml
+otk.external.osbuild.file-from-text:
+  destination: /path/to
+  text: |
+    Hello, World!
+```
+
+### `otk.external.osbuild.file-from-path`
+
+Copy a file. Source is relative to the path of the entrypoint omnifest. Creates
+a source in the manifest and copies that source to the destination in tree.
+
+Path components up to the destination must be pre-existing in the tree.
+
+```yaml
+otk.external.osbuild.file-from-path:
+  source: README.md
+  destination: /path/to
+```

--- a/doc/03-omnifest/02-external.md
+++ b/doc/03-omnifest/02-external.md
@@ -2,7 +2,7 @@
 
 ## osbuild
 
-These directives are only allowed within a [`otk.target.osbuild.<name>`](./directive#otktargetconsumername).
+These directives are only allowed within a [`otk.target.osbuild.<name>`](./01-directive.md#otktargetconsumername).
 
 ### `otk.external.osbuild.depsolve-dnf4`
 
@@ -14,7 +14,7 @@ osbuild manifest as sources.
 Expects a `map` as its value.
 
 `osbuild` directives to write files. **If a stage exists for the type of file
-you want to write: use it.** See the [best practices](../best-practices).
+you want to write: use it.** See the [best practices](../04-best-practices.md).
 
 ### `otk.external.osbuild.file-from-text`
 

--- a/doc/03-omnifest/index.md
+++ b/doc/03-omnifest/index.md
@@ -1,0 +1,42 @@
+# Omnifest
+
+An omnifest is the name for the YAML-based format that is used by `otk` as its input. `otk` transforms omnifests into inputs for other image build tools. To do so it works with [directives](./directive).
+
+## Entrypoint
+
+As omnifests can include other omnifests it is important to note that `otk` treats the entrypoint omnifest differently from included omnifests. The entrypoint omnifest is the file that is passed to `otk compile [file]`. This entrypoint is required to have:
+
+1. An [otk.version](./directive#otkversion) directive.
+1. An [otk.target](./directive#otktarget) directive.
+
+A minimal entrypoint would look like:
+
+```yaml
+otk.version: "1"
+
+otk.target.osbuild.example:
+  example: "data"
+```
+
+## Targets
+
+The [otk.target.\<consumer\>.\<name\>](./directive#otktargetconsumername) directives in the omnifest provide the umbrella to put exports under. They are namespaced to a specific consumer (e.g. `osbuild`) and tell `otk` which [external](./external) directives are available, how to format the export, and how to validate the export.
+
+An omnifest that contains a single target will use that target by default:
+
+```
+€ otk compile example.yaml  # example from above
+# ...
+```
+
+When a file contains multiple targets an error will be shown; you'll have to select the target you want to export.
+
+
+```
+€ otk compile example.yaml  # contains `osbuild.bar` and `osbuild.foo` targets
+[05/05/24 09:42:20] CRITICAL CRITICAL:otk.command:omnifest contains multiple targets, please select one with `-t`: ['osbuild.foo', 'osbuild.bar']
+€ otk compile example.yaml -t osbuild.foo
+# ...
+```
+
+Only a single target can be selected for export.

--- a/doc/03-omnifest/index.md
+++ b/doc/03-omnifest/index.md
@@ -1,13 +1,13 @@
 # Omnifest
 
-An omnifest is the name for the YAML-based format that is used by `otk` as its input. `otk` transforms omnifests into inputs for other image build tools. To do so it works with [directives](./directive).
+An omnifest is the name for the YAML-based format that is used by `otk` as its input. `otk` transforms omnifests into inputs for other image build tools. To do so it works with [directives](./01-directive.md).
 
 ## Entrypoint
 
 As omnifests can include other omnifests it is important to note that `otk` treats the entrypoint omnifest differently from included omnifests. The entrypoint omnifest is the file that is passed to `otk compile [file]`. This entrypoint is required to have:
 
-1. An [otk.version](./directive#otkversion) directive.
-1. An [otk.target](./directive#otktarget) directive.
+1. An [otk.version](./01-directive.md#otkversion) directive.
+1. An [otk.target](./01-directive.md#otktarget) directive.
 
 A minimal entrypoint would look like:
 
@@ -20,7 +20,7 @@ otk.target.osbuild.example:
 
 ## Targets
 
-The [otk.target.\<consumer\>.\<name\>](./directive#otktargetconsumername) directives in the omnifest provide the umbrella to put exports under. They are namespaced to a specific consumer (e.g. `osbuild`) and tell `otk` which [external](./external) directives are available, how to format the export, and how to validate the export.
+The [otk.target.\<consumer\>.\<name\>](./01-directive.md#otktargetconsumername) directives in the omnifest provide the umbrella to put exports under. They are namespaced to a specific consumer (e.g. `osbuild`) and tell `otk` which [external](./02-external.md) directives are available, how to format the export, and how to validate the export.
 
 An omnifest that contains a single target will use that target by default:
 

--- a/doc/04-best-practices.md
+++ b/doc/04-best-practices.md
@@ -1,0 +1,23 @@
+# Best Practices
+
+As [omnifests](./omnifest) can become quite large here are some best practices to organise. We are trying to provide examples in our [repository](https://github.com/osbuild/otk) that adhere to these.
+
+Since `otk` can produce outputs for different image build tools our best practices are organised.
+
+## Common
+
+Some best practices that apply to [omnifest](./omnifest) files in general.
+
+### Definitions in the entrypoint
+
+Keep variable definitions in the [entrypoint](./omnifest#entrypoint) as much as possible. This gives a single unified place to read which variables affect the build.
+
+## osbuild
+
+When an [osbuild](../osbuild) target is defined it is a good plan to follow these specific practices.
+
+### Embed a file or use a stage?
+
+`otk` makes it easy to [inline](./omnifest/external#otkexternalosbuildfile-from-text) or [include](./omnifest/external#otkexternalosbuildfile-from-path) files. This makes it appealing to use it for configuration files. It is however generally a better idea to use a domain specific [stage](../osbuild/modules/stages) to write these sorts of files.
+
+Using a stage to write configuration files comes with the benefit that the inputs can be verified at validation or build time. This allows `osbuild` to try and guarantee that the configuration file will work.

--- a/doc/04-best-practices.md
+++ b/doc/04-best-practices.md
@@ -1,16 +1,16 @@
 # Best Practices
 
-As [omnifests](./omnifest) can become quite large here are some best practices to organise. We are trying to provide examples in our [repository](https://github.com/osbuild/otk) that adhere to these.
+As [omnifests](./03-omnifest/index.md) can become quite large here are some best practices to organise. We are trying to provide examples in our [repository](https://github.com/osbuild/otk) that adhere to these.
 
 Since `otk` can produce outputs for different image build tools our best practices are organised.
 
 ## Common
 
-Some best practices that apply to [omnifest](./omnifest) files in general.
+Some best practices that apply to [omnifest](./03-omnifest/index.md) files in general.
 
 ### Definitions in the entrypoint
 
-Keep variable definitions in the [entrypoint](./omnifest#entrypoint) as much as possible. This gives a single unified place to read which variables affect the build.
+Keep variable definitions in the [entrypoint](./03-omnifest/index.md#entrypoint) as much as possible. This gives a single unified place to read which variables affect the build.
 
 ## osbuild
 
@@ -18,6 +18,6 @@ When an [osbuild](../osbuild) target is defined it is a good plan to follow thes
 
 ### Embed a file or use a stage?
 
-`otk` makes it easy to [inline](./omnifest/external#otkexternalosbuildfile-from-text) or [include](./omnifest/external#otkexternalosbuildfile-from-path) files. This makes it appealing to use it for configuration files. It is however generally a better idea to use a domain specific [stage](../osbuild/modules/stages) to write these sorts of files.
+`otk` makes it easy to [inline](./03-omnifest/02-external.md#otkexternalosbuildfile-from-text) or [include](./03-omnifest/02-external.md#otkexternalosbuildfile-from-path) files. This makes it appealing to use it for configuration files. It is however generally a better idea to use a domain specific stage to write these sorts of files.
 
 Using a stage to write configuration files comes with the benefit that the inputs can be verified at validation or build time. This allows `osbuild` to try and guarantee that the configuration file will work.

--- a/doc/05-deprecation.md
+++ b/doc/05-deprecation.md
@@ -1,0 +1,10 @@
+# Deprecation Policy
+
+`otk` has little in the way of deprecations. The important part is if or when [directives](./omnifest/directive) get deprecated. This will never happen with a [version](./omnifest/directive#otkversion). If in the future `otk` decides to deprecate an [omnifest](./omnifest) version then we will:
+
+0. Document the intent to deprecate.
+1. Emit warning level logs (shown by default) for at least 6 months.
+2. Disable the omnifest version by default for at least 6 months, with a flag to re-enable it.
+3. Remove the omnifest version.
+
+This gives users a one year migration path.

--- a/doc/05-deprecation.md
+++ b/doc/05-deprecation.md
@@ -1,6 +1,6 @@
 # Deprecation Policy
 
-`otk` has little in the way of deprecations. The important part is if or when [directives](./omnifest/directive) get deprecated. This will never happen with a [version](./omnifest/directive#otkversion). If in the future `otk` decides to deprecate an [omnifest](./omnifest) version then we will:
+`otk` has little in the way of deprecations. The important part is if or when [directives](./03-omnifest/01-directive.md) get deprecated. This will never happen with a [version](./03-omnifest/01-directive.md#otkversion). If in the future `otk` decides to deprecate an [omnifest](./03-omnifest/index.md) version then we will:
 
 0. Document the intent to deprecate.
 1. Emit warning level logs (shown by default) for at least 6 months.

--- a/doc/06-security.md
+++ b/doc/06-security.md
@@ -1,0 +1,1 @@
+# Security

--- a/doc/07-integration.md
+++ b/doc/07-integration.md
@@ -1,0 +1,13 @@
+# Integration
+
+`otk` will integrate with various build systems.
+
+## osbuild-composer
+
+The [osbuild-composer](../osbuild-composer) integration allows for [omnifests](./omnifest) to be consumed by [images](../images). This provides an API and jobqueue to facilitate building artifacts in [Image Builder](../image-builder), [Image Builder Frontend](../image-builder-frontend), and [Cockpit Composer](../cockpit-composer).
+
+There will be requirements on an omnifest to be consumed by [images](../images). Most likely an [otk.meta.\<name\>](./omnifest/directive#otkmetaname) directive will be required. This directive will contain information necessary for the integration.
+
+## koji
+
+The plan is to extend the koji-osbuild-plugin with additional tasks that make use of `otk`. We want to provide a workflow similar to kickstarts and livemediacreator.

--- a/doc/07-integration.md
+++ b/doc/07-integration.md
@@ -4,9 +4,9 @@
 
 ## osbuild-composer
 
-The [osbuild-composer](../osbuild-composer) integration allows for [omnifests](./omnifest) to be consumed by [images](../images). This provides an API and jobqueue to facilitate building artifacts in [Image Builder](../image-builder), [Image Builder Frontend](../image-builder-frontend), and [Cockpit Composer](../cockpit-composer).
+The osbuild-composer integration allows for [omnifests](./03-omnifest/index.md) to be consumed by images. This provides an API and jobqueue to facilitate building artifacts in Image Builder, Image Builder Frontend, and Cockpit Composer.
 
-There will be requirements on an omnifest to be consumed by [images](../images). Most likely an [otk.meta.\<name\>](./omnifest/directive#otkmetaname) directive will be required. This directive will contain information necessary for the integration.
+There will be requirements on an omnifest to be consumed by images. Most likely an [otk.meta.\<name\>](./03-omnifest/01-directive.md#otkmetaname) directive will be required. This directive will contain information necessary for the integration.
 
 ## koji
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,5 @@
+# otk
+
+`otk` is the omnifest toolkit. A program to transform [omnifests](./omnifest) to output formats such as `osbuild` [manifests](../osbuild/manifest).
+
+**`otk` is currently in a proof of concept state. We are exploring a workflow and where it fits into our stack.**

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,5 +1,5 @@
 # otk
 
-`otk` is the omnifest toolkit. A program to transform [omnifests](./omnifest) to output formats such as `osbuild` [manifests](../osbuild/manifest).
+`otk` is the omnifest toolkit. A program to transform [omnifests](./03-omnifest/index.md) to output formats such as `osbuild` manifests.
 
 **`otk` is currently in a proof of concept state. We are exploring a workflow and where it fits into our stack.**


### PR DESCRIPTION
I had moved the documentation into the main docs: https://github.com/osbuild/osbuild.github.io/pull/79

However it is more useful during the poc state of the project to have the documentation exist together with the source code.