### PR TITLE
examples: de-duplicate, add one more arch

### DIFF
--- a/example/fedora/minimal-40-aarch64.yaml
+++ b/example/fedora/minimal-40-aarch64.yaml
@@ -3,49 +3,5 @@ otk.version: 1
 otk.define:
   version: 40
   architecture: "aarch64"
-  packages:
-    # Repositories to fetch packages from
-    repositories:
-      otk.include: "repository/${version}/repositories.yaml"
-    # GPG keys to verify packages with
-    keys:
-      otk.include: "repository/${version}/keys.yaml"
-    # These packages are used in the buildroot
-    buildroot:
-      docs: false
-      weak: false
-      packages:
-        otk.include: "packages/${version}/_buildroot.yaml"
-    # These packages are used for the operating system tree which is what ends
-    # up in the outputs.
-    tree:
-      docs: false
-      weak: false
-      packages:
-        otk.include: "packages/${version}/minimal.yaml"
-  filesystem:
-    root:
-      uuid: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
-      vfs_type: "ext4"
-      path: "/"
-      options: "defaults"
-    boot:
-      uuid: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
-      vfs_type: "ext4"
-      path: "/boot"
-      options: "defaults"
-    boot-efi:
-      uuid: "7B77-95E7"
-      vfs_type: "vfat"
-      path: "/boot/efi"
-      options: "defaults,uid=0,gid=0,umask=077,shortname=winnt"
-      passno: 2
 
 otk.include: "minimal-common.yaml"
-
-otk.target.osbuild:
-  pipelines:
-    - otk.include: "osbuild/buildroot.yaml"
-    - otk.include: "osbuild/pipeline/tree.yaml"
-    - otk.include: "osbuild/pipeline/raw.yaml"
-    - otk.include: "osbuild/pipeline/xz.yaml"

--- a/example/fedora/minimal-40-x86_64.yaml
+++ b/example/fedora/minimal-40-x86_64.yaml
@@ -1,0 +1,7 @@
+otk.version: 1
+
+otk.define:
+  version: 40
+  architecture: "x86_64"
+
+otk.include: "minimal-common.yaml"

--- a/example/fedora/minimal-common.yaml
+++ b/example/fedora/minimal-common.yaml
@@ -2,53 +2,46 @@ otk.define:
   isolabel: Fedora-${version}-${architecture}
 
   packages:
+    # Repositories to fetch packages from
+    repositories:
+      otk.include: "repository/${version}/repositories.yaml"
+    # GPG keys to verify packages with
+    keys:
+      otk.include: "repository/${version}/keys.yaml"
     # These packages are used in the buildroot
     buildroot:
       docs: false
       weak: false
       packages:
-        include:
-          - "@core"
-        # TODO We can't merge nonexistent vars
-        exclude:
-          - "nonexistent"
+        otk.include: "packages/${version}/_buildroot.yaml"
     # These packages are used for the operating system tree which is what ends
     # up in the outputs.
     tree:
       docs: false
       weak: false
       packages:
-        include:
-          - "@core"
-          - "initial-setup"
-          - "libxkbcommon"
-          - "NetworkManager-wifi"
-          - "brcmfmac-firmware"
-          - "realtek-firmware"
-          - "iwlwifi-mvm-firmware"
-        # TODO We can't merge nonexistent vars
-        exclude:
-          - "nonexistent"
-    # Repositories to fetch packages from
-    repositories:
-      otk.include: repository/${version}.yaml
-    # GPG keys to verify packages with
-    keys:
-      otk.include: repository/${version}-gpg.yaml
+        otk.include: "packages/${version}/minimal.yaml"
   filesystem:
     root:
-      uuid: 6e4ff95f-f662-45ee-a82a-bdf44a2d0b75
-      vfs_type: ext4
-      path: /
-      options: defaults
+      uuid: "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75"
+      vfs_type: "ext4"
+      path: "/"
+      options: "defaults"
     boot:
-      uuid: 0194fdc2-fa2f-4cc0-81d3-ff12045b73c8
-      vfs_type: ext4
-      path: /boot
-      options: defaults
+      uuid: "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8"
+      vfs_type: "ext4"
+      path: "/boot"
+      options: "defaults"
     boot-efi:
-      uuid: 7B77-95E7
-      vfs_type: vfat
-      path: /boot/efi
-      options: defaults,uid=0,gid=0,umask=077,shortname=winnt
+      uuid: "7B77-95E7"
+      vfs_type: "vfat"
+      path: "/boot/efi"
+      options: "defaults,uid=0,gid=0,umask=077,shortname=winnt"
       passno: 2
+
+otk.target.osbuild:
+  pipelines:
+    - otk.include: "osbuild/buildroot.yaml"
+    - otk.include: "osbuild/pipeline/tree.yaml"
+    - otk.include: "osbuild/pipeline/raw.yaml"
+    - otk.include: "osbuild/pipeline/xz.yaml"


### PR DESCRIPTION
Without at least two consumers of `minimal-common.yaml` the extraction
of the common definitions is a bit pointless :) So this commmits
adds one more consumer.

---

Recent commits adds content from "minimal-common.yaml" to the
"minimal-40-aarch64.yaml". This commit de-duplicates that again.

[I'm not sure I got this 100% correct, please double check that I really transferred the pieces in the right places]