### PR TITLE
RFC directive: remove `otk.meta` and use `target.*` instead

### DIFF
--- a/doc/03-omnifest/01-directive.md
+++ b/doc/03-omnifest/01-directive.md
@@ -173,27 +173,6 @@ otk.define:
         - ${b}
 ```
 
-## `otk.meta.<name>`
-
-Under the `otk.meta` namespace any data can be stored that other applications
-need to use from an omnifest.
-
-Expects a `map` for its value.
-
-```yaml
-otk.meta.osbuild-composer:
-  boot_mode: uefi
-  export: image
-  pipelines:
-    build:
-      - root
-    system:
-      - tree
-
-otk.meta.kiwi:
-  label: "A Label"
-```
-
 ## `otk.customization`
 
 Customizations are conditional blocks that receive separate input through

--- a/doc/07-integration.md
+++ b/doc/07-integration.md
@@ -6,7 +6,7 @@
 
 The osbuild-composer integration allows for [omnifests](./03-omnifest/index.md) to be consumed by images. This provides an API and jobqueue to facilitate building artifacts in Image Builder, Image Builder Frontend, and Cockpit Composer.
 
-There will be requirements on an omnifest to be consumed by images. Most likely an [otk.meta.\<name\>](./03-omnifest/01-directive.md#otkmetaname) directive will be required. This directive will contain information necessary for the integration.
+There will be requirements on an omnifest to be consumed by images. Most likely an [otk.target.\<name\>](./03-omnifest/01-directive.md) directive will be required. This directive will contain information necessary for the integration.
 
 ## koji
 

--- a/example/fedora/minimal-40-aarch64.yaml
+++ b/example/fedora/minimal-40-aarch64.yaml
@@ -49,3 +49,12 @@ otk.target.osbuild:
     - otk.include: "osbuild/pipeline/tree.yaml"
     - otk.include: "osbuild/pipeline/raw.yaml"
     - otk.include: "osbuild/pipeline/xz.yaml"
+
+otk.target.osbuild-composer:
+  boot_mode: uefi
+  export: image
+  pipelines:
+    build:
+      - buildroot
+    system:
+      - tree


### PR DESCRIPTION
This is (very much) a RFC/brainstorm commit. Right now the use of `otk.meta` is a bit unclear, there is an open bug about this (c.f. https://github.com/osbuild/otk/issues/2).

But it seems to me that `meta` is really about writing json data from an omnifest for a specific tool (in this case "composer"). Which makes me think that we have support for this already with out `target` directive. So `otk -t osbuild-composer` would generate the needed meta information.