### PR TITLE
examples,src: remove `scope: tree` for now

### DIFF
--- a/example/fedora/osbuild/stage/hostname.yaml
+++ b/example/fedora/osbuild/stage/hostname.yaml
@@ -1,7 +1,6 @@
 type: org.osbuild.hostname
 options:
   otk.customization.hostname:
-    scope: tree
     default:
       hostname: localhost.localdomain
     if-set:

--- a/example/fedora/osbuild/stage/locale.yaml
+++ b/example/fedora/osbuild/stage/locale.yaml
@@ -1,7 +1,6 @@
 type: org.osbuild.locale
 options:
   otk.customization.locale:
-    scope: tree
     default:
       language: en_US
     if-set:

--- a/example/fedora/osbuild/stage/timezone.yaml
+++ b/example/fedora/osbuild/stage/timezone.yaml
@@ -1,7 +1,6 @@
 type: org.osbuild.timezone
 options:
   otk.customization.language:
-    scope: tree
     default:
       zone: UTC
     if-set:

--- a/src/otk/directive.py
+++ b/src/otk/directive.py
@@ -155,7 +155,7 @@ def op_map_merge(ctx: Context, tree: dict[str, Any]) -> Any:
 
 
 @tree.must_be(dict)
-@tree.must_pass(tree.has_keys(["scope", "if-set"]))
+@tree.must_pass(tree.has_keys(["if-set"]))
 def customization(ctx: Context, tree: dict[str, Any], key) -> Any:
     """Apply a customization."""
     log.debug("applying customization %r", key)


### PR DESCRIPTION
This directive is not described or implemented yet and has only a single value. Let's remove it for now and re-add it with documentation and use-cases.