### PR TITLE
examples: remove the `custom/file.yaml` file example

### DIFF
--- a/example/fedora/osbuild/custom/file.yaml
+++ b/example/fedora/osbuild/custom/file.yaml
@@ -1,4 +1,0 @@
-mtk.define:
-  file_customization_packages:
-    include:
-      - example


### PR DESCRIPTION
This example seems to be outdated (it still uses the `mtk` prefix) and it's not used.