### PR TITLE
spec: Add a basic spec and Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,33 @@ format:
 test:
 	@pytest
 	pre-commit run --all-files
+
+.PHONY: git-diff-check
+git-diff-check:
+	@git diff --exit-code
+	@git diff --cached --exit-code
+
+## Package building
+COMMIT = $(shell (cd "$(SRCDIR)" && git rev-parse HEAD))
+RPM_SPECFILE=rpmbuild/SPECS/otk-$(COMMIT).spec
+RPM_TARBALL=rpmbuild/SOURCES/otk-$(COMMIT).tar.gz
+
+$(RPM_SPECFILE):
+	mkdir -p $(CURDIR)/rpmbuild/SPECS
+	(echo "%global commit $(COMMIT)"; git show HEAD:otk.spec) > $(RPM_SPECFILE)
+
+$(RPM_TARBALL):
+	mkdir -p $(CURDIR)/rpmbuild/SOURCES
+	git archive --prefix=otk-$(COMMIT)/ --format=tar.gz HEAD > $(RPM_TARBALL)
+
+.PHONY: srpm
+srpm: git-diff-check $(RPM_SPECFILE) $(RPM_TARBALL)
+	rpmbuild -bs \
+		--define "_topdir $(CURDIR)/rpmbuild" \
+		$(RPM_SPECFILE)
+
+.PHONY: rpm
+rpm: git-diff-check $(RPM_SPECFILE) $(RPM_TARBALL)
+	rpmbuild -bb \
+		--define "_topdir $(CURDIR)/rpmbuild" \
+		$(RPM_SPECFILE)

--- a/otk.spec
+++ b/otk.spec
@@ -1,0 +1,54 @@
+%global forgeurl https://github.com/osbuild/otk
+
+Version:        2024.0.0
+%forgemeta
+
+Name:           otk
+Release:        1
+License:        Apache-2.0
+URL:            %{forgeurl}
+Source0:        %{forgesource}
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-wheel
+BuildRequires:  pyproject-rpm-macros
+
+
+Summary: The omnifest toolkit
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+%description
+The omnifest toolkit is a YAML transpiler to take omnifest inputs and
+translate them into osbuild manifests.
+
+%prep
+%forgeautosetup
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+
+# Install the examples
+mkdir -p %{buildroot}%{_datadir}/otk/example/
+cp -a example/* %{buildroot}%{_datadir}/otk/example/
+
+
+%files
+%license LICENSE
+%doc doc
+%{_datadir}/otk
+%{_bindir}/otk
+%{_bindir}/otk-osbuild
+%{python3_sitelib}/otk
+%{python3_sitelib}/otk_osbuild
+%{python3_sitelib}/otk-%{version}.dist-info
+
+
+%changelog
+* Wed May 08 2024 Brian C. Lane <bcl@redhat.com> - 2024.0.0-1
+- Initial package creation


### PR DESCRIPTION
This adds the srpm and rpm build makefile targets (borrowed from osbuild), and uses the pyproject rpm macros to support pyproject.toml The version is hard-coded into the spec so it will need to be changed at the same time as the version in pyproject.toml

Fixes #44