### PR TITLE
deps: remove parsimonious

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ requires-python = ">= 3.9"
 
 dependencies = [
     "click >= 8.0",
-    "parsimonious >= 0.10",
     "pyyaml >= 6.0",
     "rich >= 13.0",
 ]


### PR DESCRIPTION
Due to #43 we won't be able to use parsimonious. This PR drops it as it wasn't in use yet. 