### PR TITLE
deps: remove rich

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
     "click >= 8.0",
     "parsimonious >= 0.10",
     "pyyaml >= 6.0",
-    "rich >= 13.0",
 ]
 
 [project.scripts]

--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -5,8 +5,6 @@ import json
 from copy import deepcopy
 
 import click
-from rich.console import Console
-from rich.logging import RichHandler
 
 from .constant import PREFIX_TARGET
 from .context import CommonContext
@@ -59,11 +57,7 @@ def root(
             (
                 JSONSequenceHandler(identifier, stream=sys.stderr)
                 if json
-                else RichHandler(
-                    omit_repeated_times=False,
-                    show_path=False,
-                    console=Console(stderr=True),
-                )
+                else logging.StreamHandler()
             )
         ],
     )


### PR DESCRIPTION
Due to #43 we figured out that we can't use `rich`, the relevant issue for this is #68. Let's remove rich, it is only used for pretty logging output.