### PR TITLE
examples: fix architecture

### DIFF
--- a/example/fedora/minimal-40-x86_64.yaml
+++ b/example/fedora/minimal-40-x86_64.yaml
@@ -2,7 +2,7 @@ otk.version: 1
 
 otk.define:
   version: 40
-  architecture: "aarch64"
+  architecture: "x86_64"
   isolabel: Fedora-${version}-${architecture}
 
   packages:

--- a/example/fedora/repository/40/repositories.yaml
+++ b/example/fedora/repository/40/repositories.yaml
@@ -1,2 +1,2 @@
 - id: "fedora"
-  metalink: https://mirrors.fedoraproject.org/metalink?repo=fedora-${version}&arch=aarch64
+  metalink: https://mirrors.fedoraproject.org/metalink?repo=fedora-${version}&arch=${architecture}


### PR DESCRIPTION
Set the correct architecture for x86 and use the variable in the repositories.