### PR TITLE
CI: Add examples building for each PR / push

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -1,0 +1,27 @@
+name: Build examples
+
+on: [pull_request, push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint
+    - name: Analysing the code with pylint
+      run: |
+        python3 -m venv venv
+        . venv/bin/activate
+        pip install -e ".[dev]"
+        otk compile example/fedora/*yaml
+


### PR DESCRIPTION
OTK repo contains examples which can be used by users. This PR adds CI routine to be sure they are build each time without any errors.

Resolves: https://github.com/osbuild/otk/issues/65