### PR TITLE
container: use distro packages

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,15 +2,16 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal AS build
 
 RUN \
     microdnf install -y \
-        python3-pip && \
-        microdnf clean all
+        python3-pip \
+        python3-pyyaml \
+        && microdnf clean all
 
 WORKDIR /src
 
 COPY pyproject.toml /src/
 COPY src /src/src
 
-RUN pip install .
+RUN pip install --no-dependencies .
 RUN rm -rf src/*
 
 ENTRYPOINT ["otk"]


### PR DESCRIPTION
Use the distribution packages in the container instead of downloading them from pypi.