### PR TITLE
ci: tag main builds with their git commit SHA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,7 @@ jobs:
           tags: |
             type=ref,event=tag,enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=raw,value=latest
+            type=sha,format=long,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push
         uses: docker/build-push-action@v4


### PR DESCRIPTION
This is useful when you want pin the image. Also, it's very helpful
to easily see which commit was used to build container image.