### PR TITLE
directive: define fix

### DIFF
--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -76,8 +76,8 @@ class CommonContext(Context):
                     self._variables[name],
                     value,
                 )
-        else:
-            self._variables[name] = value
+
+        self._variables[name] = value
 
     def variable(self, name: str) -> Any:
         parts = name.split(".")

--- a/test/test_directive.py
+++ b/test/test_directive.py
@@ -2,26 +2,7 @@ import pytest
 
 from otk.context import CommonContext
 from otk.error import TransformDirectiveArgumentError, TransformDirectiveTypeError
-from otk.directive import define, desugar, include, op_join
-
-
-def test_define():
-    ctx = CommonContext()
-
-    define(ctx, {"a": "b", "c": 1})
-
-    assert ctx.variable("a") == "b"
-    assert ctx.variable("c") == 1
-
-
-def test_define_unhappy():
-    ctx = CommonContext()
-
-    with pytest.raises(TransformDirectiveTypeError):
-        define(ctx, 1)
-
-    with pytest.raises(TransformDirectiveTypeError):
-        define(ctx, "str")
+from otk.directive import desugar, include, op_join
 
 
 def test_include_unhappy():

--- a/test/test_directive_define.py
+++ b/test/test_directive_define.py
@@ -1,0 +1,38 @@
+import pytest
+
+from otk.context import CommonContext
+from otk.error import TransformDirectiveTypeError
+from otk.directive import define
+
+
+def test_define():
+    ctx = CommonContext()
+
+    define(ctx, {"a": "b", "c": 1})
+
+    assert ctx.variable("a") == "b"
+    assert ctx.variable("c") == 1
+
+
+def test_define_duplicate():
+    ctx = CommonContext()
+
+    define(ctx, {"a": "b", "c": 1})
+
+    assert ctx.variable("a") == "b"
+    assert ctx.variable("c") == 1
+
+    define(ctx, {"a": "a", "c": 2})
+
+    assert ctx.variable("a") == "a"
+    assert ctx.variable("c") == 2
+
+
+def test_define_unhappy():
+    ctx = CommonContext()
+
+    with pytest.raises(TransformDirectiveTypeError):
+        define(ctx, 1)
+
+    with pytest.raises(TransformDirectiveTypeError):
+        define(ctx, "str")


### PR DESCRIPTION
`otk.define` is incorrectly handling overwriting values by not overwriting them at all. Let's fix it and add a test.