### PR TITLE
otk: use file handles instead of paths when reading files

### DIFF
--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -54,9 +54,7 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
 
     # the working directory is either the current directory for stdin or the
     # directory the omnifest is located in
-    cwd = (
-        pathlib.Path.cwd() if arguments.input is None else pathlib.Path(src.name).parent
-    )
+    cwd = pathlib.Path.cwd() if arguments.input is None else pathlib.Path(src.name).parent
 
     ctx = CommonContext(cwd)
     doc = Omnifest.from_yaml_file(src)

--- a/src/otk/directive.py
+++ b/src/otk/directive.py
@@ -84,10 +84,6 @@ def include(ctx: Context, tree: Any) -> Any:
     # TODO instead
     log.info("otk.include=%s", str(file))
 
-    if not file.exists():
-        # TODO, better error type
-        raise Exception("otk.include nonexistent file %r" % file)
-
     # TODO
     return yaml.safe_load(file.read_text())
 

--- a/src/otk/document.py
+++ b/src/otk/document.py
@@ -1,5 +1,5 @@
+import io
 import logging
-import pathlib
 from copy import deepcopy
 from typing import Any
 
@@ -27,17 +27,10 @@ class Omnifest:
         return cls(deserialized_data)
 
     @classmethod
-    def from_yaml_path(cls, path: pathlib.Path) -> "Omnifest":
+    def from_yaml_file(cls, file: io.IOBase) -> "Omnifest":
         """Read a YAML file into an Omnifest instance."""
-
-        log.debug("reading yaml from path %r", str(path))
-
-        # This is an invariant that should be handled at the calling side of
-        # this function
-        assert path.exists(), "path to exist"
-
-        with path.open("rb") as file:
-            return cls.from_yaml_bytes(file.read())
+        log.debug("reading yaml from path %r", str(file.name))
+        return cls.from_yaml_bytes(file.read())
 
     @classmethod
     def read(cls, deserialized_data: Any) -> dict[str, Any]:

--- a/src/otk/document.py
+++ b/src/otk/document.py
@@ -29,7 +29,7 @@ class Omnifest:
     @classmethod
     def from_yaml_file(cls, file: io.IOBase) -> "Omnifest":
         """Read a YAML file into an Omnifest instance."""
-        log.debug("reading yaml from path %r", str(file.name))
+        log.debug("reading yaml from path %r", file.name)
         return cls.from_yaml_bytes(file.read())
 
     @classmethod

--- a/test/test_directive.py
+++ b/test/test_directive.py
@@ -12,6 +12,13 @@ def test_include_unhappy():
         include(ctx, 1)
 
 
+def test_include_file_missing_errors(tmp_path):
+    ctx = CommonContext()
+
+    with pytest.raises(FileNotFoundError):
+        include(ctx, "non-existing.yml")
+
+
 def test_op_seq_join():
     ctx = CommonContext()
 


### PR DESCRIPTION
The upside of using file descriptors is that there are less TOCTOU issues, i.e. `if not src.exists()` on a path is racy but this can easily be avoided by just opening the file and keeping it open.

It will also make testing for stdin/stdout easier from the test POV there is nothing special about them (i.e. it's not even needed to test that they work just that when "-" is passed on the commandline (or nothing) stdin/stdout is opened).

Note that there is probably more needed but this is enough to satify the tests (but I suspect the recursive loading will break with this change so it might be a good place to add a test with an `otk.include` to ensure this is covered.