### PR TITLE
otk_osbuild: Override default osbuild-depsolve-dnf with OSBUILD_DEPSOLVE

### DIFF
--- a/src/otk_osbuild/command.py
+++ b/src/otk_osbuild/command.py
@@ -7,6 +7,7 @@ import sys
 import json
 import hashlib
 import base64
+import os
 import pathlib
 import subprocess
 
@@ -68,8 +69,10 @@ def depsolve_dnf4():
         },
     }
 
+    cmd = os.environ.get("OSBUILD_DEPSOLVE", "/usr/libexec/osbuild-depsolve-dnf")
+
     process = subprocess.run(
-        ["/usr/libexec/osbuild-depsolve-dnf"],
+        [cmd],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         input=json.dumps(request),


### PR DESCRIPTION
This lets you point to a different location than the default for the depsolver script and makes it easier to experiment with uninstalled versions of osbuild.

Set OSBUILD_DEPSOLVE to the full path of the replacement script or wrapper:

OSBUILD_DEPSOLVE=$HOME/bin/depsolve-wrapper otk compile example/fedora/minimal-40-x86_64.yaml
    
Where the depsolve-wrapper looks like this:
    
PYTHONPATH=/home/user/osbuild/osbuild/ /home/user/osbuild/tools/osbuild-depsolve-dnf $@
