### PR TITLE
otk: some tweaks in the process() recurision

### DIFF
--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -8,6 +8,7 @@ from .context import CommonContext
 from .context import registry as context_registry
 from .document import Omnifest
 from .help.log import JSONSequenceHandler
+from .parserstate import ParserState
 from .target import CommonTarget
 from .target import registry as target_registry
 from .transform import resolve
@@ -84,8 +85,14 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
         log.fatal("requested target %r does not exist in INPUT", target_requested)
         return 1
 
+    # XXX: make this nicer
+    if arguments.input is None:
+        path = cwd / "<stdin>"
+    else:
+        path = pathlib.Path(arguments.input)
+    state = ParserState(path=path)
     # resolve the full tree first
-    tree = resolve(ctx, doc.tree)
+    tree = resolve(ctx, state, doc.tree)
 
     # and also for the specific target
     try:
@@ -101,7 +108,8 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
     # re-resolve the specific target with the specific context and target if
     # applicable
     spec = context_registry.get(kind, CommonContext)(ctx)
-    tree = resolve(spec, tree[f"{PREFIX_TARGET}{kind}.{name}"])
+    state = ParserState(path=path)
+    tree = resolve(spec, state, tree[f"{PREFIX_TARGET}{kind}.{name}"])
 
     # and then output by writing to the output
     if not dry_run:

--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -35,7 +35,6 @@ class CommonContext(Context):
     duplicate_definitions_warning: bool
 
     _version: Optional[int]
-    _path: pathlib.Path
     _variables: dict[str, Any]
 
     def __init__(
@@ -46,7 +45,6 @@ class CommonContext(Context):
         duplicate_definitions_warning: bool = False,
     ) -> None:
         self._version = None
-        self._path = path if path else pathlib.Path(".")
         self._variables = {}
 
         self.duplicate_definitions_allowed = duplicate_definitions_allowed
@@ -124,10 +122,6 @@ class OSBuildContext(Context):
 
     def variable(self, name: str) -> Any:
         return self._context.variable(name)
-
-    @property
-    def _path(self):
-        return self._context._path
 
     def for_external(self):
         return {

--- a/src/otk/directive.py
+++ b/src/otk/directive.py
@@ -51,7 +51,8 @@ import yaml
 from . import tree
 from .constant import PREFIX
 from .context import Context
-from .error import TransformDirectiveTypeError, TransformDirectiveUnknownError
+from .error import IncludeError, TransformDirectiveTypeError, TransformDirectiveUnknownError
+from .parserstate import ParserState
 
 log = logging.getLogger(__name__)
 
@@ -61,82 +62,80 @@ def is_directive(needle: Any) -> bool:
     return isinstance(needle, str) and needle.startswith(PREFIX)
 
 
-@tree.must_be(dict)
-def define(ctx: Context, tree: Any) -> Any:
-    """Takes an `otk.define` block (which must be a dictionary and registers
-    everything in it as variables in the context."""
-
-    for key, value in tree.items():
-        ctx.define(key, value)
-
-    return tree
-
-
 @tree.must_be(str)
-def include(ctx: Context, tree: Any) -> Any:
+def include(ctx: Context, state: ParserState, rel_path: str) -> (Any, pathlib.Path):
     """Include a separate file."""
 
-    tree = desugar(ctx, tree)
+    tree = desugar(ctx, state, rel_path)
 
-    file = ctx._path / pathlib.Path(tree)
+    file = state.path.parent / pathlib.Path(rel_path)
 
     # TODO str'ed for json log, lets add a serializer for posixpath
     # TODO instead
     log.info("otk.include=%s", str(file))
 
     # TODO
-    return yaml.safe_load(file.read_text())
+    content = file.read_text()
+    try:
+        return yaml.safe_load(content), file
+    except Exception as exc:
+        raise IncludeError(f"cannot include {file}") from exc
 
 
-def op(ctx: Context, tree: Any, key: str) -> Any:
+def op(ctx: Context, state: ParserState, tree: Any, key: str) -> Any:
     """Dispatch the various `otk.op` directives while handling unknown
     operations."""
 
     if key == "otk.op.join":
-        return op_join(ctx, tree)
+        return op_join(ctx, state, tree)
     else:
-        raise TransformDirectiveUnknownError("nonexistent op %r", key)
+        raise TransformDirectiveUnknownError("nonexistent op %r in %s" % (key, state.path))
 
 
 @tree.must_be(dict)
 @tree.must_pass(tree.has_keys(["values"]))
-def op_join(ctx: Context, tree: dict[str, Any]) -> Any:
+def op_join(ctx: Context, state: ParserState, tree: dict[str, Any]) -> Any:
     """Join a map/seq."""
 
     values = tree["values"]
     if not isinstance(values, list):
         raise TransformDirectiveTypeError(
-            "seq join received values of the wrong type, was expecting a list of lists but got %r",
-            values,
+            "seq join received values of the wrong type, was expecting a list of lists but got %r in %s" %
+            (values,
+             state.path),
         )
     if all(isinstance(sl, list) for sl in values):
-        return _op_seq_join(ctx, values)
+        return _op_seq_join(ctx, state, values)
     elif all(isinstance(sl, dict) for sl in values):
-        return _op_map_join(ctx, values)
+        return _op_map_join(ctx, state, values)
     else:
-        raise TransformDirectiveTypeError(f"cannot join {values}")
+        raise TransformDirectiveTypeError(f"cannot join {values} in {state.path}")
 
 
-def _op_seq_join(ctx: Context, values: List[list]) -> Any:
+def _op_seq_join(ctx: Context, state: ParserState, values: List[list]) -> Any:
     """Join to sequences by concatenating them together."""
 
     if not all(isinstance(sl, list) for sl in values):
         raise TransformDirectiveTypeError(
-            "seq join received values of the wrong type, was expecting a list of lists but got %r",
-            values,
+            "seq join received values of the wrong type, was expecting a list of lists but got %r in %s" % (
+                values,
+                state.path,
+            )
         )
 
     return list(itertools.chain.from_iterable(values))
 
 
-def _op_map_join(ctx: Context, values: List[dict]) -> Any:
+def _op_map_join(ctx: Context, state: ParserState, values: List[dict]) -> Any:
     """Join two dictionaries. Keys from the second dictionary overwrite keys
     in the first dictionary."""
 
     if not all(isinstance(sl, dict) for sl in values):
         raise TransformDirectiveTypeError(
-            "map join received values of the wrong type, was expecting a list of dicts but got %r",
-            values,
+            "map join received values of the wrong type, was expecting a list of dicts but got %r in %s" % (
+                values,
+                state.path,
+            )
         )
 
     result = {}
@@ -148,7 +147,7 @@ def _op_map_join(ctx: Context, values: List[dict]) -> Any:
 
 
 @tree.must_be(str)
-def desugar(ctx: Context, tree: str) -> Any:
+def desugar(ctx: Context, state: ParserState, tree: str) -> Any:
     """Desugar a string. If the string consists of a single `${name}` value
     then we return the object it refers to by looking up its name in the
     variables.
@@ -182,8 +181,10 @@ def desugar(ctx: Context, tree: str) -> Any:
             # Any other type we do not
             if not isinstance(data, str):
                 raise TransformDirectiveTypeError(
-                    "string sugar resolves to an incorrect type, expected int, float, or str but got %r",
-                    data,
+                    "string sugar resolves to an incorrect type, expected int, float, or str but got %r in %s" % (
+                        data,
+                        state.path,
+                    )
                 )
 
             # Replace all occurences of this name in the str

--- a/src/otk/error.py
+++ b/src/otk/error.py
@@ -98,3 +98,7 @@ class TransformDirectiveUnknownError(TransformError):
     """Unknown directive."""
 
     pass
+
+
+class IncludeError(OTKError):
+    pass

--- a/src/otk/parserstate.py
+++ b/src/otk/parserstate.py
@@ -1,0 +1,6 @@
+import pathlib
+
+
+class ParserState:
+    def __init__(self, path):
+        self.path = path

--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -8,9 +8,11 @@ collection types we want to recursively resolve the elements of the collection.
 In the dictionary case we apply our directives. Directives are based on the
 keys in the dictionaries."""
 
+import copy
 import logging
 from typing import Any, Type
 
+from . import tree
 from .constant import (
     NAME_VERSION,
     PREFIX_DEFINE,
@@ -19,23 +21,24 @@ from .constant import (
     PREFIX_TARGET,
 )
 from .context import Context, OSBuildContext
-from .directive import define, desugar, include, is_directive, op
+from .directive import desugar, include, is_directive, op
 from .external import call
+from .parserstate import ParserState
 
 log = logging.getLogger(__name__)
 
 
-def resolve(ctx: Context, tree: Any) -> Any:
+def resolve(ctx: Context, state: ParserState, tree: Any) -> Any:
     """Resolves a (sub)tree of any type into a new tree. Each type has its own
     specific handler to rewrite the tree."""
 
     typ = type(tree)
     if typ == dict:
-        return resolve_dict(ctx, tree)
+        return resolve_dict(ctx, state, tree)
     elif typ == list:
-        return resolve_list(ctx, tree)
+        return resolve_list(ctx, state, tree)
     elif typ == str:
-        return resolve_str(ctx, tree)
+        return resolve_str(ctx, state, tree)
     elif typ in [int, float, bool, type(None)]:
         return tree
     else:
@@ -43,53 +46,67 @@ def resolve(ctx: Context, tree: Any) -> Any:
         raise Exception(type(tree))
 
 
-def resolve_dict(ctx: Context, tree: dict[str, Any]) -> Any:
+def resolve_dict(ctx: Context, state: ParserState, tree: dict[str, Any]) -> Any:
     """...."""
 
-    for key, val in tree.items():
+    for key in list(tree.keys()):
+        val = tree[key]
         if is_directive(key):
             # Define, target, and version are done separately, they allow
             # sibling elements thus they return the tree with their key set to their
             # (resolved) value.
             if key.startswith(PREFIX_DEFINE):
-                return tree | {"otk.define": resolve(ctx, define(ctx, val))}
+                define(ctx, state, val)
+                print(ctx,state,val)
+                del tree[key]
             elif key == NAME_VERSION:
                 continue
             elif key.startswith(PREFIX_TARGET):
                 continue
 
-            # Other directives do *not* allow siblings
-            if len(tree) > 1:
-                raise Exception("no siblings!")
-
             if key.startswith(PREFIX_INCLUDE):
-                return resolve(ctx, include(ctx, val))
+                new_val, new_path = include(ctx, state, val)
+                # XXX make this nice
+                new_state = copy.copy(state)
+                new_state.path = new_path
+                return resolve(ctx, new_state, new_val)
             elif key.startswith(PREFIX_OP):
-                return resolve(ctx, op(ctx, resolve(ctx, val), key))
+                return resolve(ctx, op(ctx, state, resolve(ctx, state, val), key))
             elif key.startswith("otk.external."):
                 if isinstance(ctx, OSBuildContext):
-                    return resolve(ctx, call(key, resolve(ctx, val)))
+                    return resolve(ctx, state, call(key, resolve(ctx, val)))
                 else:
                     log.error("%r:%r", key, ctx)
 
-        tree[key] = resolve(ctx, val)
+        tree[key] = resolve(ctx, state, val)
 
     return tree
 
 
-def resolve_list(ctx, tree: list[Any]) -> list[Any]:
+def resolve_list(ctx: Context, state: ParserState, tree: list[Any]) -> list[Any]:
     """Resolving a list means applying the resolve function to each element in
     the list."""
 
     log.debug("resolving list %r", tree)
 
-    return [resolve(ctx, val) for val in tree]
+    return [resolve(ctx, state, val) for val in tree]
 
 
-def resolve_str(ctx, tree: str) -> Any:
+def resolve_str(ctx: Context, state: ParserState, tree: str) -> Any:
     """Resolving strings means they are parsed for any variable
     interpolation."""
 
     log.debug("resolving str %r", tree)
 
-    return desugar(ctx, tree)
+    return desugar(ctx, state, tree)
+
+
+@tree.must_be(dict)
+def define(ctx: Context, state: ParserState, tree: Any) -> Any:
+    """Takes an `otk.define` block (which must be a dictionary and registers
+    everything in it as variables in the context."""
+
+    for key, value in tree.items():
+        ctx.define(key, resolve(ctx, state, value))
+
+    return tree

--- a/src/otk/tree.py
+++ b/src/otk/tree.py
@@ -17,9 +17,9 @@ def must_be(kind: Type):
     def decorator(function):
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
-            if not isinstance(args[1], kind):
+            if not isinstance(args[2], kind):
                 raise TransformDirectiveTypeError(
-                    "otk.define expects a %r as its argument but received a `%s`: `%r`" % (kind, type(args[1]), args[1])
+                    "otk.define expects a %r as its argument but received a `%s`: `%r`" % (kind, type(args[2]), args[2])
                 )
             return function(*args, **kwargs)
 
@@ -35,7 +35,7 @@ def must_pass(*vs):
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
             for v in vs:
-                v(args[1])
+                v(args[2])
             return function(*args, **kwargs)
 
         return wrapper

--- a/test/data/base/02-include/example-in-subdir.yaml
+++ b/test/data/base/02-include/example-in-subdir.yaml
@@ -1,0 +1,3 @@
+foo: "bar"
+bar: "foo"
+

--- a/test/data/base/02-include/example.yaml
+++ b/test/data/base/02-include/example.yaml
@@ -1,3 +1,2 @@
 # Example file to be included in `02-include.yaml`
-foo: "bar"
-bar: "foo"
+otk.include: "example-in-subdir.yaml"

--- a/test/test_directive.py
+++ b/test/test_directive.py
@@ -1,72 +1,92 @@
+import os
+import pathlib
+
 import pytest
 
 from otk.context import CommonContext
-from otk.error import TransformDirectiveArgumentError, TransformDirectiveTypeError
+from otk.error import IncludeError, TransformDirectiveArgumentError, TransformDirectiveTypeError
 from otk.directive import desugar, include, op_join
+from otk.parserstate import ParserState
 
 
 def test_include_unhappy():
     ctx = CommonContext()
+    state = ParserState(path=pathlib.Path("."))
 
     with pytest.raises(TransformDirectiveTypeError):
-        include(ctx, 1)
+        include(ctx, state, 1)
 
 
 def test_include_file_missing_errors(tmp_path):
     ctx = CommonContext()
+    state = ParserState(path=pathlib.Path("."))
 
-    with pytest.raises(FileNotFoundError):
-        include(ctx, "non-existing.yml")
+    with pytest.raises(FileNotFoundError) as exc:
+        include(ctx, state, "non-existing.yml")
+
+
+def test_include_file_invalid_errors(tmp_path):
+    bad_yaml = tmp_path / "bad.yaml"
+    bad_yaml.write_text("!bad::")
+
+    ctx = CommonContext()
+    state = ParserState(path=bad_yaml)
+    with pytest.raises(IncludeError) as exc:
+        include(ctx, state, os.fspath(bad_yaml))
+    assert f"cannot include {tmp_path}/bad.yaml" == str(exc.value)
 
 
 def test_op_seq_join():
     ctx = CommonContext()
+    state = ParserState(path="test")
 
     l1 = [1, 2, 3]
     l2 = [4, 5, 6]
 
     d = {"values": [l1, l2]}
 
-    assert op_join(ctx, d) == [1, 2, 3, 4, 5, 6]
+    assert op_join(ctx, state, d) == [1, 2, 3, 4, 5, 6]
 
 
 def test_op_join_unhappy():
     ctx = CommonContext()
+    state = ParserState(path="test")
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, 1)
+        op_join(ctx, state, 1)
 
     with pytest.raises(TransformDirectiveArgumentError):
-        op_join(ctx, {})
+        op_join(ctx, state, {})
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, {"values": 1})
+        op_join(ctx, state, {"values": 1})
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, {"values": [1, {2: 3}]})
+        op_join(ctx, state, {"values": [1, {2: 3}]})
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, 1)
+        op_join(ctx, state, 1)
 
     with pytest.raises(TransformDirectiveArgumentError):
-        op_join(ctx, {})
+        op_join(ctx, state, {})
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, {"values": 1})
+        op_join(ctx, state, {"values": 1})
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, {"values": [1, {2: 3}]})
+        op_join(ctx, state, {"values": [1, {2: 3}]})
 
 
 def test_op_map_join():
     ctx = CommonContext()
+    state = ParserState(path="test")
 
     d1 = {"foo": "bar"}
     d2 = {"bar": "foo"}
 
     d = {"values": [d1, d2]}
 
-    assert op_join(ctx, d) == {"foo": "bar", "bar": "foo"}
+    assert op_join(ctx, state, d) == {"foo": "bar", "bar": "foo"}
 
 
 def test_desugar():
@@ -74,22 +94,24 @@ def test_desugar():
     ctx.define("str", "bar")
     ctx.define("int", 1)
     ctx.define("float", 1.1)
+    state = ParserState(path="test")
 
-    assert desugar(ctx, "") == ""
-    assert desugar(ctx, "${str}") == "bar"
-    assert desugar(ctx, "a${str}b") == "abarb"
-    assert desugar(ctx, "${int}") == 1
-    assert desugar(ctx, "a${int}b") == "a1b"
-    assert desugar(ctx, "${float}") == 1.1
-    assert desugar(ctx, "a${float}b") == "a1.1b"
+    assert desugar(ctx, state, "") == ""
+    assert desugar(ctx, state, "${str}") == "bar"
+    assert desugar(ctx, state, "a${str}b") == "abarb"
+    assert desugar(ctx, state, "${int}") == 1
+    assert desugar(ctx, state, "a${int}b") == "a1b"
+    assert desugar(ctx, state, "${float}") == 1.1
+    assert desugar(ctx, state, "a${float}b") == "a1.1b"
 
 
 def test_desugar_unhappy():
     ctx = CommonContext()
     ctx.define("dict", {})
+    state = ParserState(path="test")
 
     with pytest.raises(TransformDirectiveTypeError):
-        desugar(ctx, 1)
+        desugar(ctx, state, 1)
 
     with pytest.raises(TransformDirectiveTypeError):
-        desugar(ctx, "a${dict}b")
+        desugar(ctx, state, "a${dict}b")

--- a/test/test_directive_define.py
+++ b/test/test_directive_define.py
@@ -2,13 +2,14 @@ import pytest
 
 from otk.context import CommonContext
 from otk.error import TransformDirectiveTypeError
-from otk.directive import define
-
+from otk.transform import define
+from otk.parserstate import ParserState
 
 def test_define():
     ctx = CommonContext()
+    state = ParserState(path="test")
 
-    define(ctx, {"a": "b", "c": 1})
+    define(ctx, state, {"a": "b", "c": 1})
 
     assert ctx.variable("a") == "b"
     assert ctx.variable("c") == 1
@@ -16,13 +17,14 @@ def test_define():
 
 def test_define_duplicate():
     ctx = CommonContext()
+    state = ParserState(path="test")
 
-    define(ctx, {"a": "b", "c": 1})
+    define(ctx, state, {"a": "b", "c": 1})
 
     assert ctx.variable("a") == "b"
     assert ctx.variable("c") == 1
 
-    define(ctx, {"a": "a", "c": 2})
+    define(ctx, state, {"a": "a", "c": 2})
 
     assert ctx.variable("a") == "a"
     assert ctx.variable("c") == 2
@@ -30,9 +32,10 @@ def test_define_duplicate():
 
 def test_define_unhappy():
     ctx = CommonContext()
+    state = ParserState(path="test")
 
     with pytest.raises(TransformDirectiveTypeError):
-        define(ctx, 1)
+        define(ctx, state, 1)
 
     with pytest.raises(TransformDirectiveTypeError):
-        define(ctx, "str")
+        define(ctx, state, "str")

--- a/test/test_directive_sugar.py
+++ b/test/test_directive_sugar.py
@@ -3,47 +3,53 @@ import pytest
 from otk.context import CommonContext
 from otk.error import TransformDirectiveTypeError
 from otk.directive import desugar
+from otk.parserstate import ParserState
 
 
 def test_simple_sugar():
     context = CommonContext()
     context.define("my_var", "foo")
+    state = ParserState(path="test")
 
-    assert desugar(context, "${my_var}") == "foo"
+    assert desugar(context, state, "${my_var}") == "foo"
 
 
 def test_simple_sugar_nested():
     context = CommonContext()
     context.define("my_var", [1, 2])
+    state = ParserState(path="test")
 
-    assert desugar(context, "${my_var}") == [1, 2]
+    assert desugar(context, state, "${my_var}") == [1, 2]
 
 
 def test_simple_sugar_nested_fail():
     context = CommonContext()
     context.define("my_var", [1, 2])
+    state = ParserState(path="test")
 
-    expected_error = "string sugar resolves to an incorrect type, expected int, float, or str but got %r"
+    expected_error = r"string sugar resolves to an incorrect type, expected int, float, or str but got \[1, 2\] in test"
 
     with pytest.raises(TransformDirectiveTypeError, match=expected_error):
-        desugar(context, "a${my_var}")
+        desugar(context, state, "a${my_var}")
 
 
 def test_sugar_multiple():
     context = CommonContext()
     context.define("a", "foo")
     context.define("b", "bar")
+    state = ParserState(path="test")
 
-    assert desugar(context, "${a}-${b}") == "foo-bar"
+    assert desugar(context, state, "${a}-${b}") == "foo-bar"
 
 
 def test_sugar_multiple_fail():
     context = CommonContext()
     context.define("a", "foo")
     context.define("b", [1, 2])
+    state = ParserState(path="test")
 
-    expected_error = "string sugar resolves to an incorrect type, expected int, float, or str but got %r"
+    expected_error = r"string sugar resolves to an incorrect type, expected int, float, or str but got \[1, 2\] in test"
 
     # Fails due to non-str type
     with pytest.raises(TransformDirectiveTypeError, match=expected_error):
-        desugar(context, "${a}-${b}")
+        desugar(context, state, "${a}-${b}")

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -1,9 +1,11 @@
 import argparse
 import json
 import pathlib
+import textwrap
 
 import pytest
 
+import otk
 from otk import command
 
 
@@ -12,9 +14,43 @@ def test_command_compile_on_base_examples(tmp_path, src_yaml):
     dst = tmp_path / "out.json"
 
     ns = argparse.Namespace(input=src_yaml, output=dst, target="osbuild")
-
     command.compile(ns)
 
     expected = json.load(src_yaml.with_suffix(".json").open())
     actual = json.load(dst.open())
     assert expected == actual
+
+
+# XXX: switch to parameterized test
+def test_error_from_include(tmp_path):
+    base_yaml = tmp_path / "base.yaml"
+    base_yaml.write_text(textwrap.dedent("""
+    otk.version: 1
+    otk.target.foo.bar:
+      otk.include: "subdir/bad.yaml"
+    """))
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "subdir/bad.yaml").write_text("otk.op.does-not-exist:")
+    
+    ns = argparse.Namespace(input=base_yaml, output=None, target="osbuild")
+    with pytest.raises(otk.error.TransformDirectiveUnknownError) as exc:
+        command.compile(ns)
+    assert f"nonexistent op 'otk.op.does-not-exist' in {tmp_path}/subdir/bad.yaml" == str(exc.value)
+
+
+def test_error_from_include_after(tmp_path):
+    base_yaml = tmp_path / "base.yaml"
+    base_yaml.write_text(textwrap.dedent("""
+    otk.version: 1
+    otk.target.foo.bar:
+      otk.include: "subdir/good.yaml"
+    otk.target.foo.bar:
+      otk.op.does-not-exist:
+    """))
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "subdir/good.yaml").write_text("foo: bar")
+    
+    ns = argparse.Namespace(input=base_yaml, output=None, target="osbuild")
+    with pytest.raises(otk.error.TransformDirectiveUnknownError) as exc:
+        command.compile(ns)
+    assert f"nonexistent op 'otk.op.does-not-exist' in {tmp_path}/base.yaml" == str(exc.value)

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -1,10 +1,13 @@
 from otk import transform
 from otk.context import CommonContext
+from otk.parserstate import ParserState
 
 
 def test_resolve_list():
+    ctx = CommonContext()
+    state = ParserState(path="/")
     assert transform.resolve_list(
-        CommonContext(),
+        ctx, state,
         [
             1,
         ],
@@ -14,5 +17,7 @@ def test_resolve_list():
 
 
 def test_resolve_dict():
-    assert transform.resolve_dict(CommonContext(), {1: 1}) == {1: 1}
-    assert transform.resolve_dict(CommonContext(), {"1": 1}) == {"1": 1}
+    ctx = CommonContext()
+    state = ParserState(path="/")
+    assert transform.resolve_dict(ctx, state, {1: 1}) == {1: 1}
+    assert transform.resolve_dict(ctx, state, {"1": 1}) == {"1": 1}

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -2,14 +2,6 @@ from otk import transform
 from otk.context import CommonContext
 
 
-def test_dont_resolve():
-    assert transform.dont_resolve(CommonContext(), 1) == 1
-    assert transform.dont_resolve(CommonContext(), 1.0) == 1.0
-    assert transform.dont_resolve(CommonContext(), "foo") == "foo"
-    assert transform.dont_resolve(CommonContext(), True)
-    assert transform.dont_resolve(CommonContext(), None) is None
-
-
 def test_resolve_list():
     assert transform.resolve_list(
         CommonContext(),


### PR DESCRIPTION
This is a first set of tweaks to make the recursive process() function a bit easier to follow and it also adds a new `ParserState` that is passed inside the recursion and updated as needed. For now it only carries the current active file to track includes and to allow includes relative to the current file that is being worked on. But it could also be used to keep track of e.g. if the parser is currently inside a `otk.define` context (if/when the need for this arises).

Draft because I would like to tweak/add some tests still.