### PR TITLE
Small refactors and cleanups in prep for bigger changes

### DIFF
--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -19,7 +19,7 @@ from .constant import (
     PREFIX_TARGET,
 )
 from .context import Context, OSBuildContext
-from .directive import define, desugar, include, is_directive, op
+from .directive import define, substitute_vars, include, is_directive, op
 from .external import call
 
 log = logging.getLogger(__name__)
@@ -92,4 +92,4 @@ def resolve_str(ctx, tree: str) -> Any:
 
     log.debug("resolving str %r", tree)
 
-    return desugar(ctx, tree)
+    return substitute_vars(ctx, tree)

--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -38,7 +38,15 @@ def resolve(ctx: Context, data: Any) -> Any:
 
 
 def resolve_dict(ctx: Context, tree: dict[str, Any]) -> Any:
-    """...."""
+    """
+    Dictionaries are iterated through and both the keys and values are processed.
+    Keys define how a value is interpreted:
+    - otk.include.* loads the file specified by the value.
+    - otk.op.* processes the value with the named operation.
+    - otk.define.* updates the defines dictionary with all the defined key-value
+      pairs.
+    - Values under any other key are processed based on their type (see resolve()).
+    """
 
     for key, val in tree.items():
         if is_directive(key):

--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -20,22 +20,21 @@ from .external import call
 log = logging.getLogger(__name__)
 
 
-def resolve(ctx: Context, tree: Any) -> Any:
-    """Resolves a (sub)tree of any type into a new tree. Each type has its own
-    specific handler to rewrite the tree."""
+def resolve(ctx: Context, data: Any) -> Any:
+    """Resolves a value of any supported type into a new value. Each type has
+    its own specific handler to replace the data value."""
 
-    typ = type(tree)
-    if typ == dict:
-        return resolve_dict(ctx, tree)
-    elif typ == list:
-        return resolve_list(ctx, tree)
-    elif typ == str:
-        return resolve_str(ctx, tree)
-    elif typ in [int, float, bool, type(None)]:
-        return tree
-    else:
-        log.fatal("could not look up %r in resolvers", type(tree))
-        raise Exception(type(tree))
+    if isinstance(data, dict):
+        return resolve_dict(ctx, data)
+    if isinstance(data, list):
+        return resolve_list(ctx, data)
+    if isinstance(data, str):
+        return resolve_str(ctx, data)
+    if isinstance(data, (int, float, bool, type(None))):
+        return data
+
+    log.fatal("could not look up %r in resolvers", type(data))
+    raise TypeError(type(data))
 
 
 def resolve_dict(ctx: Context, tree: dict[str, Any]) -> Any:

--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -9,17 +9,12 @@ In the dictionary case we apply our directives. Directives are based on the
 keys in the dictionaries."""
 
 import logging
-from typing import Any, Type
+from typing import Any
 
-from .constant import (
-    NAME_VERSION,
-    PREFIX_DEFINE,
-    PREFIX_OP,
-    PREFIX_INCLUDE,
-    PREFIX_TARGET,
-)
+from .constant import (NAME_VERSION, PREFIX_DEFINE, PREFIX_INCLUDE, PREFIX_OP,
+                       PREFIX_TARGET)
 from .context import Context, OSBuildContext
-from .directive import define, substitute_vars, include, is_directive, op
+from .directive import define, include, is_directive, op, substitute_vars
 from .external import call
 
 log = logging.getLogger(__name__)

--- a/test/data/base/09-include-with-var.json
+++ b/test/data/base/09-include-with-var.json
@@ -1,0 +1,10 @@
+{
+  "pipelines": [
+    {
+      "foo": "bar",
+      "bar": "foo"
+    }
+  ],
+  "version": "2",
+  "sources": {}
+}

--- a/test/data/base/09-include-with-var.yaml
+++ b/test/data/base/09-include-with-var.yaml
@@ -1,0 +1,9 @@
+# Include a file using a path string that contains a variable
+otk.version: "1"
+
+otk.define.vars:
+  name: "example"
+
+otk.target.osbuild.name:
+  pipelines:
+    - otk.include: "02-include/${name}.yaml"

--- a/test/test_directive.py
+++ b/test/test_directive.py
@@ -2,7 +2,7 @@ import pytest
 
 from otk.context import CommonContext
 from otk.error import TransformDirectiveArgumentError, TransformDirectiveTypeError
-from otk.directive import desugar, include, op_join
+from otk.directive import substitute_vars, include, op_join
 
 
 def test_include_unhappy():
@@ -69,27 +69,27 @@ def test_op_map_join():
     assert op_join(ctx, d) == {"foo": "bar", "bar": "foo"}
 
 
-def test_desugar():
+def test_substitute_vars():
     ctx = CommonContext()
     ctx.define("str", "bar")
     ctx.define("int", 1)
     ctx.define("float", 1.1)
 
-    assert desugar(ctx, "") == ""
-    assert desugar(ctx, "${str}") == "bar"
-    assert desugar(ctx, "a${str}b") == "abarb"
-    assert desugar(ctx, "${int}") == 1
-    assert desugar(ctx, "a${int}b") == "a1b"
-    assert desugar(ctx, "${float}") == 1.1
-    assert desugar(ctx, "a${float}b") == "a1.1b"
+    assert substitute_vars(ctx, "") == ""
+    assert substitute_vars(ctx, "${str}") == "bar"
+    assert substitute_vars(ctx, "a${str}b") == "abarb"
+    assert substitute_vars(ctx, "${int}") == 1
+    assert substitute_vars(ctx, "a${int}b") == "a1b"
+    assert substitute_vars(ctx, "${float}") == 1.1
+    assert substitute_vars(ctx, "a${float}b") == "a1.1b"
 
 
-def test_desugar_unhappy():
+def test_substitute_vars_unhappy():
     ctx = CommonContext()
     ctx.define("dict", {})
 
     with pytest.raises(TransformDirectiveTypeError):
-        desugar(ctx, 1)
+        substitute_vars(ctx, 1)
 
     with pytest.raises(TransformDirectiveTypeError):
-        desugar(ctx, "a${dict}b")
+        substitute_vars(ctx, "a${dict}b")

--- a/test/test_substitute_vars.py
+++ b/test/test_substitute_vars.py
@@ -1,35 +1,38 @@
+import re
+
 import pytest
-
 from otk.context import CommonContext
-from otk.error import TransformDirectiveTypeError
 from otk.directive import substitute_vars
+from otk.error import TransformDirectiveTypeError
 
 
-def test_simple_sugar():
+def test_simple_sub_var():
     context = CommonContext()
     context.define("my_var", "foo")
 
     assert substitute_vars(context, "${my_var}") == "foo"
 
 
-def test_simple_sugar_nested():
+def test_simple_sub_var_nested():
     context = CommonContext()
     context.define("my_var", [1, 2])
 
     assert substitute_vars(context, "${my_var}") == [1, 2]
 
 
-def test_simple_sugar_nested_fail():
+def test_simple_sub_var_nested_fail():
     context = CommonContext()
     context.define("my_var", [1, 2])
+    data = "a${my_var}"
 
-    expected_error = "string sugar resolves to an incorrect type, expected int, float, or str but got %r"
+    expected_error = re.escape(f"string '{data}' resolves to an incorrect type, "
+                               "expected int, float, or str but got list")
 
     with pytest.raises(TransformDirectiveTypeError, match=expected_error):
-        substitute_vars(context, "a${my_var}")
+        substitute_vars(context, data)
 
 
-def test_sugar_multiple():
+def test_sub_var_multiple():
     context = CommonContext()
     context.define("a", "foo")
     context.define("b", "bar")
@@ -37,13 +40,27 @@ def test_sugar_multiple():
     assert substitute_vars(context, "${a}-${b}") == "foo-bar"
 
 
-def test_sugar_multiple_fail():
+def test_sub_var_multiple_fail():
     context = CommonContext()
     context.define("a", "foo")
     context.define("b", [1, 2])
+    context.define("c", {"one": 1})
+    data = "${a}-${b}"
 
-    expected_error = "string sugar resolves to an incorrect type, expected int, float, or str but got %r"
+    # the a will be replaced but the b will cause an error
+    expected_error = re.escape(r"string 'foo-${b}' resolves to an incorrect type, "
+                               "expected int, float, or str but got list")
 
     # Fails due to non-str type
     with pytest.raises(TransformDirectiveTypeError, match=expected_error):
-        substitute_vars(context, "${a}-${b}")
+        substitute_vars(context, data)
+
+    data = "${a}-${c}"
+
+    # the a will be replaced but the c will cause an error
+    expected_error = re.escape(r"string 'foo-${c}' resolves to an incorrect type, "
+                               "expected int, float, or str but got dict")
+
+    # Fails due to non-str type
+    with pytest.raises(TransformDirectiveTypeError, match=expected_error):
+        substitute_vars(context, data)

--- a/test/test_substitute_vars.py
+++ b/test/test_substitute_vars.py
@@ -2,21 +2,21 @@ import pytest
 
 from otk.context import CommonContext
 from otk.error import TransformDirectiveTypeError
-from otk.directive import desugar
+from otk.directive import substitute_vars
 
 
 def test_simple_sugar():
     context = CommonContext()
     context.define("my_var", "foo")
 
-    assert desugar(context, "${my_var}") == "foo"
+    assert substitute_vars(context, "${my_var}") == "foo"
 
 
 def test_simple_sugar_nested():
     context = CommonContext()
     context.define("my_var", [1, 2])
 
-    assert desugar(context, "${my_var}") == [1, 2]
+    assert substitute_vars(context, "${my_var}") == [1, 2]
 
 
 def test_simple_sugar_nested_fail():
@@ -26,7 +26,7 @@ def test_simple_sugar_nested_fail():
     expected_error = "string sugar resolves to an incorrect type, expected int, float, or str but got %r"
 
     with pytest.raises(TransformDirectiveTypeError, match=expected_error):
-        desugar(context, "a${my_var}")
+        substitute_vars(context, "a${my_var}")
 
 
 def test_sugar_multiple():
@@ -34,7 +34,7 @@ def test_sugar_multiple():
     context.define("a", "foo")
     context.define("b", "bar")
 
-    assert desugar(context, "${a}-${b}") == "foo-bar"
+    assert substitute_vars(context, "${a}-${b}") == "foo-bar"
 
 
 def test_sugar_multiple_fail():
@@ -46,4 +46,4 @@ def test_sugar_multiple_fail():
 
     # Fails due to non-str type
     with pytest.raises(TransformDirectiveTypeError, match=expected_error):
-        desugar(context, "${a}-${b}")
+        substitute_vars(context, "${a}-${b}")

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -2,14 +2,6 @@ from otk import transform
 from otk.context import CommonContext
 
 
-def test_dont_resolve():
-    assert transform.dont_resolve(CommonContext(), 1) == 1
-    assert transform.dont_resolve(CommonContext(), 1.0) == 1.0
-    assert transform.dont_resolve(CommonContext(), "foo") == "foo"
-    assert transform.dont_resolve(CommonContext(), True)
-    assert transform.dont_resolve(CommonContext(), None) is None
-
-
 def test_resolve_list():
     assert transform.resolve_list(
         CommonContext(),


### PR DESCRIPTION
This PR includes some small refactoring, code cleanups, and a new test.
I also included the first commit from #113 to avoid conflicts.  The second commit I'd like to add later with some changes (for example c6b0b6871b4928ed4b8b1df0b23728a0752821cc).

I renamed the `desugar()` function for clarity.  Quoting the commit message:

> The name `desugar()` was in reference to initial specifications that supported multiple ways of referring to variables and the `${name}` form was considered "syntactic sugar".  Now we only have one way of referring to variables and the concept of "desugaring" might be hard to understand.
>
> Rename it to `replace_vars()` to make its purpose clearer.