### PR TITLE
test: parametrize base examples test with filenames

### DIFF
--- a/test/test_example.py
+++ b/test/test_example.py
@@ -3,12 +3,13 @@ import json
 import pathlib
 
 import pytest
-
 from otk import command
 
 
-@pytest.mark.parametrize("src_yaml", (pathlib.Path(__file__).parent / "data/base").glob("*.yaml"))
+@pytest.mark.parametrize("src_yaml",
+                         [str(path) for path in (pathlib.Path(__file__).parent / "data/base").glob("*.yaml")])
 def test_command_compile_on_base_examples(tmp_path, src_yaml):
+    src_yaml = pathlib.Path(src_yaml)
     dst = tmp_path / "out.json"
 
     ns = argparse.Namespace(input=src_yaml, output=dst, target="osbuild")


### PR DESCRIPTION
While pathlib.Path is much nicer to work with than doing glob.glob() and getting a bunch of strings, when the list of parameters for pytest is a list of strings, you get much nicer test output with the filename in the name of the test and, more importantly, the ability to filter tests based on the name of the yaml file parameter.

Closes #121 