### PR TITLE
test: move all `substitute_vars` tests into `test_substitute_vars.py`

### DIFF
--- a/test/test_directive.py
+++ b/test/test_directive.py
@@ -2,7 +2,7 @@ import pytest
 
 from otk.context import CommonContext
 from otk.error import TransformDirectiveArgumentError, TransformDirectiveTypeError
-from otk.directive import substitute_vars, include, op_join
+from otk.directive import include, op_join
 
 
 def test_include_unhappy():
@@ -67,29 +67,3 @@ def test_op_map_join():
     d = {"values": [d1, d2]}
 
     assert op_join(ctx, d) == {"foo": "bar", "bar": "foo"}
-
-
-def test_substitute_vars():
-    ctx = CommonContext()
-    ctx.define("str", "bar")
-    ctx.define("int", 1)
-    ctx.define("float", 1.1)
-
-    assert substitute_vars(ctx, "") == ""
-    assert substitute_vars(ctx, "${str}") == "bar"
-    assert substitute_vars(ctx, "a${str}b") == "abarb"
-    assert substitute_vars(ctx, "${int}") == 1
-    assert substitute_vars(ctx, "a${int}b") == "a1b"
-    assert substitute_vars(ctx, "${float}") == 1.1
-    assert substitute_vars(ctx, "a${float}b") == "a1.1b"
-
-
-def test_substitute_vars_unhappy():
-    ctx = CommonContext()
-    ctx.define("dict", {})
-
-    with pytest.raises(TransformDirectiveTypeError):
-        substitute_vars(ctx, 1)
-
-    with pytest.raises(TransformDirectiveTypeError):
-        substitute_vars(ctx, "a${dict}b")

--- a/test/test_substitute_vars.py
+++ b/test/test_substitute_vars.py
@@ -25,8 +25,9 @@ def test_simple_sub_var_nested_fail():
     context.define("my_var", [1, 2])
     data = "a${my_var}"
 
-    expected_error = re.escape(f"string '{data}' resolves to an incorrect type, "
-                               "expected int, float, or str but got list")
+    expected_error = re.escape(
+        f"string '{data}' resolves to an incorrect type, " "expected int, float, or str but got list"
+    )
 
     with pytest.raises(TransformDirectiveTypeError, match=expected_error):
         substitute_vars(context, data)
@@ -48,8 +49,9 @@ def test_sub_var_multiple_fail():
     data = "${a}-${b}"
 
     # the a will be replaced but the b will cause an error
-    expected_error = re.escape(r"string 'foo-${b}' resolves to an incorrect type, "
-                               "expected int, float, or str but got list")
+    expected_error = re.escape(
+        r"string 'foo-${b}' resolves to an incorrect type, " "expected int, float, or str but got list"
+    )
 
     # Fails due to non-str type
     with pytest.raises(TransformDirectiveTypeError, match=expected_error):
@@ -58,9 +60,36 @@ def test_sub_var_multiple_fail():
     data = "${a}-${c}"
 
     # the a will be replaced but the c will cause an error
-    expected_error = re.escape(r"string 'foo-${c}' resolves to an incorrect type, "
-                               "expected int, float, or str but got dict")
+    expected_error = re.escape(
+        r"string 'foo-${c}' resolves to an incorrect type, " "expected int, float, or str but got dict"
+    )
 
     # Fails due to non-str type
     with pytest.raises(TransformDirectiveTypeError, match=expected_error):
         substitute_vars(context, data)
+
+
+def test_substitute_vars():
+    ctx = CommonContext()
+    ctx.define("str", "bar")
+    ctx.define("int", 1)
+    ctx.define("float", 1.1)
+
+    assert substitute_vars(ctx, "") == ""
+    assert substitute_vars(ctx, "${str}") == "bar"
+    assert substitute_vars(ctx, "a${str}b") == "abarb"
+    assert substitute_vars(ctx, "${int}") == 1
+    assert substitute_vars(ctx, "a${int}b") == "a1b"
+    assert substitute_vars(ctx, "${float}") == 1.1
+    assert substitute_vars(ctx, "a${float}b") == "a1.1b"
+
+
+def test_substitute_vars_unhappy():
+    ctx = CommonContext()
+    ctx.define("dict", {})
+
+    with pytest.raises(TransformDirectiveTypeError):
+        substitute_vars(ctx, 1)
+
+    with pytest.raises(TransformDirectiveTypeError):
+        substitute_vars(ctx, "a${dict}b")


### PR DESCRIPTION
Right now there are some tests defined in `test_substitute_vars.py` and some in `test_directive.py`. Move them all into a single file.

[Sorry for the whitespace changes, this is `pre-commit` doing stuff :( Not overly happy about this]