### PR TITLE
Fix precommit yamllint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 # Make sure only one action triggers the job, otherwise pushing to a
 # pull-request will run it twice.
-"on":
+on:  # yamllint disable-line rule:truthy
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 # Make sure only one action triggers the job, otherwise pushing to a
 # pull-request will run it twice.
-on:
+on:  # yamllint disable-line rule:truthy
   pull_request:
     branches:
       - "*"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,7 @@ repos:
     hooks:
       - id: pyspelling
         args: ["--config", ".spellcheck.yml"]
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.7
+  - repo: https://github.com/hhatto/autopep8
+    rev: v2.3.0
     hooks:
-      - id: ruff
-        args: [--fix]
-      - id: ruff-format
+      - id: autopep8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ otk_external_osbuild = "otk_external_osbuild.command:root"
 
 [project.optional-dependencies]
 dev = [
-    "ruff",
+    "autopep8",
     "pytest >= 8.0",
     "mypy >= 1.9",
     "types-PyYAML >= 6.0",
@@ -25,5 +25,5 @@ dev = [
 requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
-[tool.ruff]
-line-length = 120
+[tool.autopep8]
+max_line_length = 120


### PR DESCRIPTION
as `pre-commit` only runs on files you currently changed by default `lint.yml` and `test.yml` have been missing...

also suggesting to use autopep8 as it's not that aggressive as `ruff` is (see discussion in https://github.com/osbuild/images/pull/753 )