### PR TITLE
otk: detect circular imports

### DIFF
--- a/src/otk/error.py
+++ b/src/otk/error.py
@@ -98,3 +98,9 @@ class TransformDirectiveUnknownError(TransformError):
     """Unknown directive."""
 
     pass
+
+
+class CircularIncludeError(ParseError):
+    """Cirtcular include detected."""
+
+    pass

--- a/src/otk/traversal.py
+++ b/src/otk/traversal.py
@@ -1,9 +1,12 @@
 class State:
-    def __init__(self, path, defines):
+    def __init__(self, path, defines, includes=None):
         self.path = path
         self.defines = defines
+        if includes is None:
+            includes = []
+        self.includes = includes
 
-    def copy(self, *, path=None, defines=None) -> "State":
+    def copy(self, *, path=None, defines=None, includes=None) -> "State":
         """
         Return a new State, optionally redefining the path and defines
         properties. Properties not defined in the args are (shallow) copied
@@ -16,5 +19,7 @@ class State:
             path = self.path
         if defines is None:
             defines = self.defines
+        if includes is None:
+            includes = self.includes.copy()
 
-        return State(path, defines)
+        return State(path, defines, includes)

--- a/test/data/error/01-circular.err
+++ b/test/data/error/01-circular.err
@@ -1,0 +1,1 @@
+circular include from

--- a/test/data/error/01-circular.yaml
+++ b/test/data/error/01-circular.yaml
@@ -1,0 +1,4 @@
+otk.version: 1
+
+otk.target.osbuild.name:
+  otk.include: 01-circular/a.yaml

--- a/test/data/error/01-circular/a.yaml
+++ b/test/data/error/01-circular/a.yaml
@@ -1,0 +1,1 @@
+otk.include: b.yaml

--- a/test/data/error/01-circular/b.yaml
+++ b/test/data/error/01-circular/b.yaml
@@ -1,0 +1,1 @@
+otk.include: subdir/c.yaml

--- a/test/data/error/01-circular/subdir/c.yaml
+++ b/test/data/error/01-circular/subdir/c.yaml
@@ -1,0 +1,1 @@
+otk.include: ../a.yaml


### PR DESCRIPTION
Now that we have state during the recursion we can detect circular imports. This commit adds it and a matching test.

