### PR TITLE
Fix duplicate defines when original value is not a dictionary

### DIFF
--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -149,7 +149,12 @@ def process_defines(ctx: Context, state: State, tree: Any):
 
         if isinstance(value, dict):
             # the value is a dict: process it recursively under a new subblock
-            new_subblock = subblock.get(key, {})
+            new_subblock = {}
+            if isinstance(subblock.get(key), dict):
+                # If the new subblock already exists and is a dictionary, use it so they get merged
+                # Any other type will be replaced completely.
+                new_subblock = subblock[key]
+
             # set the new subblock on the parent so that both context and subblock are available immediately
             subblock[key] = new_subblock
             new_state = state.copy(defines=new_subblock)

--- a/test/data/base/11-define-variants.json
+++ b/test/data/base/11-define-variants.json
@@ -1,0 +1,56 @@
+{
+  "pipelines": [
+    {
+      "name": "dict_to_list",
+      "stages": [
+        [
+          3,
+          4,
+          5
+        ]
+      ]
+    },
+    {
+      "name": "dict_to_str",
+      "stages": [
+        "I'm a string now"
+      ]
+    },
+    {
+      "name": "list_to_dict",
+      "stages": [
+        {
+          "eleven": 11,
+          "twelve": 12
+        }
+      ]
+    },
+    {
+      "name": "str_to_dict",
+      "stages": [
+        {
+          "thirteen": 13,
+          "fourteen": 14
+        }
+      ]
+    },
+    {
+      "name": "str_to_list",
+      "stages": [
+        [
+          "yay",
+          "I'm a",
+          "list"
+        ]
+      ]
+    },
+    {
+      "name": "list_to_str",
+      "stages": [
+        "I was a list"
+      ]
+    }
+  ],
+  "version": "2",
+  "sources": {}
+}

--- a/test/data/base/11-define-variants.yaml
+++ b/test/data/base/11-define-variants.yaml
@@ -1,0 +1,84 @@
+otk.version: "1"
+
+# dictionary -> List replacement test
+otk.define.dict_to_list_1:
+  dict_to_list:
+    one: 1
+    two: 2
+
+otk.define.dict_to_list_2:
+  dict_to_list:
+    - 3
+    - 4
+    - 5
+
+# dictionary -> string replacement test
+otk.define.dict_to_str_1:
+  dict_to_str:
+    one: 1
+    two: 2
+
+otk.define.dict_to_str_2:
+  dict_to_str: "I'm a string now"
+
+
+# list -> dictionary replacement test
+otk.define.list_to_dict_1:
+  list_to_dict:
+    - 11
+    - 12
+
+otk.define.list_to_dict_2:
+  list_to_dict:
+    eleven: 11
+    twelve: 12
+
+
+# string -> dictionary replacment test
+otk.define.str_to_dict_1:
+  str_to_dict: "thirteen and fourteen"
+
+otk.define.str_to_dict_2:
+  str_to_dict:
+    thirteen: 13
+    fourteen: 14
+
+# string -> list replacement test
+otk.define.str_to_list_1:
+  str_to_list: "I want to be a list"
+
+otk.define.str_to_list_2:
+  str_to_list:
+    - "yay"
+    - "I'm a"
+    - "list"
+
+# list -> str replacement test
+otk.define.list_to_str_1:
+  list_to_str:
+    - "Replace"
+    - "me!"
+
+otk.define.list_to_str_2:
+  list_to_str: "I was a list"
+
+otk.target.osbuild.name:
+  pipelines:
+    - name: "dict_to_list"
+      stages:
+        - ${dict_to_list}
+    - name: "dict_to_str"
+      stages:
+        - ${dict_to_str}
+    - name: "list_to_dict"
+      stages:
+        - ${list_to_dict}
+    - name: "str_to_dict"
+      stages:
+        - ${str_to_dict}
+    - name: "str_to_list"
+      stages:
+        - ${str_to_list}
+    - name: "list_to_str"
+      stages:
+        - ${list_to_str}


### PR DESCRIPTION
**otk: only try to merge dict with dict in defines**

If a key was previously defined in the context's defines but was not a
dict and was instead a list or primitive type, we would try to merge
them, which would break when trying to index the existing value as a
dictionary.

Make sure a subblock is reused only when it's actually a dictionary.  In
all other cases, the new value replaces the old.

---

**test: expand duplicate-define to include replacement cases**

The test now also checks if:
- a dictionary/object definition is replaced when the new value is a
  list or a string.
- a list or string definition is replaced when the new value is a
  dictionary/object.
- a list or string definition is replaced when the new value is a string
  or list (respectively).

---
