### PR TITLE
[RFC] use process_include() for main entry point too

### DIFF
--- a/src/otk/document.py
+++ b/src/otk/document.py
@@ -2,8 +2,8 @@ import logging
 from copy import deepcopy
 from typing import Any
 
-from .constant import NAME_VERSION
-from .error import ParseVersionError
+from .constant import PREFIX_TARGET, NAME_VERSION
+from .error import NoTargetsError, ParseVersionError
 
 log = logging.getLogger(__name__)
 
@@ -26,6 +26,12 @@ class Omnifest:
         # being an Omnifest.
         if NAME_VERSION not in deserialized_data:
             raise ParseVersionError("omnifest must contain a key by the name of %r" % (NAME_VERSION,))
+
+        target_available = {
+            key.removeprefix(PREFIX_TARGET): val for key, val in deserialized_data.items() if key.startswith(PREFIX_TARGET)
+        }
+        if not target_available:
+            raise NoTargetsError("input does not contain any targets")
 
     @property
     def tree(self) -> dict[str, Any]:

--- a/src/otk/document.py
+++ b/src/otk/document.py
@@ -1,12 +1,9 @@
-import io
 import logging
 from copy import deepcopy
 from typing import Any
 
-import yaml
-
 from .constant import NAME_VERSION
-from .error import ParseTypeError, ParseVersionError
+from .error import ParseVersionError
 
 log = logging.getLogger(__name__)
 
@@ -17,36 +14,8 @@ class Omnifest:
     _underlying_data: dict[str, Any]
 
     def __init__(self, underlying_data: dict[str, Any]) -> None:
+        Omnifest.ensure(underlying_data)
         self._underlying_data = underlying_data
-
-    @classmethod
-    def from_yaml_bytes(cls, text: bytes) -> "Omnifest":
-        deserialized_data = cls.read(yaml.safe_load(text))
-        cls.ensure(deserialized_data)
-
-        return cls(deserialized_data)
-
-    @classmethod
-    def from_yaml_file(cls, file: io.IOBase) -> "Omnifest":
-        """Read a YAML file into an Omnifest instance."""
-        log.debug("reading yaml from path %r", file.name)
-        return cls.from_yaml_bytes(file.read())
-
-    @classmethod
-    def read(cls, deserialized_data: Any) -> dict[str, Any]:
-        """Take any type returned by a deserializer and ensure that it is
-        something that could represent an Omnifest."""
-
-        # The top level of the Omnifest needs to be a dictionary
-        if not isinstance(deserialized_data, dict):
-            log.error(
-                "data did not deserialize to a dictionary: type=%r,data=%r",
-                type(deserialized_data),
-                deserialized_data,
-            )
-            raise ParseTypeError("omnifest must deserialize to a dictionary")
-
-        return deserialized_data
 
     @classmethod
     def ensure(cls, deserialized_data: dict[str, Any]) -> None:

--- a/src/otk/error.py
+++ b/src/otk/error.py
@@ -104,3 +104,9 @@ class CircularIncludeError(ParseError):
     """Cirtcular include detected."""
 
     pass
+
+
+class NoTargetsError(ParseError):
+    """No targets in the otk file found."""
+
+    pass

--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -186,22 +186,6 @@ def process_include(ctx: Context, state: State, path: pathlib.Path) -> dict:
     return {}
 
 
-@tree.must_be(str)
-def include(ctx: Context, tree: Any) -> Any:
-    """Include a separate file."""
-
-    tree = substitute_vars(ctx, tree)
-
-    file = ctx._path / pathlib.Path(tree)
-
-    # TODO str'ed for json log, lets add a serializer for posixpath
-    # TODO instead
-    log.info("otk.include=%s", str(file))
-
-    # TODO
-    return yaml.safe_load(file.read_text())
-
-
 def op(ctx: Context, tree: Any, key: str) -> Any:
     """Dispatch the various `otk.op` directives while handling unknown
     operations."""

--- a/test/data/error/01-circular.yaml
+++ b/test/data/error/01-circular.yaml
@@ -1,4 +1,3 @@
 otk.version: 1
 
-otk.target.osbuild.name:
-  otk.include: 01-circular/a.yaml
+otk.include: 01-circular/a.yaml

--- a/test/test_directive.py
+++ b/test/test_directive.py
@@ -2,21 +2,7 @@ import pytest
 from otk.context import CommonContext
 from otk.error import (TransformDirectiveArgumentError,
                        TransformDirectiveTypeError)
-from otk.transform import include, op_join
-
-
-def test_include_unhappy():
-    ctx = CommonContext()
-
-    with pytest.raises(TransformDirectiveTypeError):
-        include(ctx, 1)
-
-
-def test_include_file_missing_errors(tmp_path):
-    ctx = CommonContext()
-
-    with pytest.raises(FileNotFoundError):
-        include(ctx, "non-existing.yml")
+from otk.transform import op_join
 
 
 def test_op_seq_join():

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -1,13 +1,18 @@
 import pytest
 
 from otk.document import Omnifest
-from otk.error import ParseVersionError
+from otk.error import NoTargetsError, ParseVersionError
 
 
 def test_omnifest_ensure():
-    Omnifest.ensure({"otk.version": 1})
+    Omnifest.ensure({"otk.version": 1, "otk.target.osbuild": {}})
 
 
 def test_omnifest_ensure_no_keys():
     with pytest.raises(ParseVersionError):
         assert Omnifest.ensure({})
+
+
+def test_omnifest_ensure_no_targets():
+    with pytest.raises(NoTargetsError):
+        Omnifest.ensure({"otk.version": 1})

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -1,23 +1,7 @@
-import textwrap
-
 import pytest
 
 from otk.document import Omnifest
-from otk.error import ParseTypeError, ParseVersionError
-
-
-def test_omnifest_read_dict():
-    assert Omnifest.read({}) == {}
-
-
-def test_omnifest_read_list():
-    with pytest.raises(ParseTypeError):
-        Omnifest.read([])
-
-
-def test_omnifest_read_string():
-    with pytest.raises(ParseTypeError):
-        Omnifest.read("")
+from otk.error import ParseVersionError
 
 
 def test_omnifest_ensure():
@@ -27,70 +11,3 @@ def test_omnifest_ensure():
 def test_omnifest_ensure_no_keys():
     with pytest.raises(ParseVersionError):
         assert Omnifest.ensure({})
-
-
-def test_omnifest_from_yaml_bytes_sad():
-    # A bunch of YAMLs that don't contain a top level map
-    with pytest.raises(ParseTypeError):
-        Omnifest.from_yaml_bytes(
-            """
-"""
-        )
-
-    with pytest.raises(ParseTypeError):
-        Omnifest.from_yaml_bytes(
-            """
-1
-"""
-        )
-
-    with pytest.raises(ParseTypeError):
-        Omnifest.from_yaml_bytes(
-            """
-- 1
-- 2
-"""
-        )
-
-    with pytest.raises(ParseTypeError):
-        Omnifest.from_yaml_bytes(
-            """
-"1"
-"""
-        )
-
-    # And a YAML that does have a top level map, but no `otk.version` key
-    with pytest.raises(ParseVersionError):
-        Omnifest.from_yaml_bytes(
-            """
-otk.not-version: 1
-"""
-        )
-
-
-TEST_CASES = [
-    (
-        textwrap.dedent("""
-        otk.version: 1
-        otk.target.osbuild:
-          some: key
-        """),
-        {"otk.target.osbuild": {"some": "key"}, "otk.version": 1},
-    )
-]
-
-
-@pytest.mark.parametrize("fake_input,expected_tree", TEST_CASES)
-def test_omnifest_from_yaml_bytes_happy(fake_input, expected_tree):
-    omi = Omnifest.from_yaml_bytes(fake_input)
-    assert omi.tree == expected_tree
-
-
-@pytest.mark.parametrize("fake_input,expected_tree", TEST_CASES)
-def test_omnifest_from_yaml_file_happy(tmp_path, fake_input, expected_tree):
-    fake_yaml_path = tmp_path / "test.otk"
-    fake_yaml_path.write_text(fake_input)
-
-    with fake_yaml_path.open() as fp:
-        omi = Omnifest.from_yaml_file(fp)
-    assert omi.tree == expected_tree


### PR DESCRIPTION
A quick draft with some ideas about consolidating some things now that we have a the new recursive core.

---

otk: remove no longer used `include()` and tests

The `transform.include()` helper got superseeded by the new
`process_includes()`.

----

otk: simplify Omnifest and use `process_include` in
 entrypoint

With the recent change to require a fully processed tree before
creating the omnifest [0] it seems we can simplify the Omnifest
a bit more now that it essentially is just a container for an
externally resolved tree.

This commit does that by removing some of the entrypoints
like `from_yaml_{file,data}` as those are not that useful
without resolving the tree first.

One nice effect of this change is that the circular import
detection now includes the top-level entrypoint in the error
and it is also more symetrical (a single way to open/read/parse
an otk file).

The handling of data from <stdin> is not super nice right now
and it actually makes me wonder if we should maybe stop supporting
omnifests from stdin. It seems that most omnifests will contain
includes so the notion of creating an omnifest from <stdin> is
a bit fuzzy.

[0] https://github.com/osbuild/otk/pull/128

---

otk: move validations that targets exist into
 Omnifest.ensure()

This commit moves all the validation for a well-formed omnifest
into the `Omnifest.ensure()` helper.
