### PR TITLE
ci: use pre-commit in actions as well

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install yamllint
-        run: sudo apt-get install -y yamllint
+        run: sudo apt-get install -y yamllint aspell
       - name: "Clone Repository"
         uses: actions/checkout@v4
       - name: Install
-        run: pip install ruff
+        run: pip install pre-commit autopep8
       - name: Run linters
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 .PHONY: lint
 lint:
-	@find . -name '*.yaml' | xargs yamllint
-	@ruff check
+	pre-commit run --all-files
 
 .PHONY: type
 type:
@@ -13,9 +12,8 @@ format:
 	@find test -name '*.py' | xargs autopep8 --in-place
 
 .PHONY: test
-test:
+test: lint
 	@pytest
-	pre-commit run --all-files
 
 .PHONY: git-diff-check
 git-diff-check:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ type:
 
 .PHONY: format
 format:
-	@ruff format src/ test/
+	@find src -name '*.py' | xargs autopep8 --in-place
+	@find test -name '*.py' | xargs autopep8 --in-place
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ type:
 
 .PHONY: format
 format:
-	@find src -name '*.py' | xargs autopep8 --in-place
-	@find test -name '*.py' | xargs autopep8 --in-place
+	@find src test -name '*.py' | xargs autopep8 --in-place
 
 .PHONY: test
 test: lint


### PR DESCRIPTION
We dropped `ruff` for formatting in #125, lets drop `ruff` from `make lint`; let's use `pre-commit` in CI for the linter to make everything the same everywhere.