### PR TITLE
otk: remove `_path` from CommonContext()

### DIFF
--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -49,20 +49,15 @@ def root() -> int:
 
 
 def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
-    src = sys.stdin if arguments.input is None else open(arguments.input)
     if not dry_run:
         dst = sys.stdout if arguments.output is None else open(arguments.output, "w")
-
-    # the working directory is either the current directory for stdin or the
-    # directory the omnifest is located in
-    cwd = pathlib.Path.cwd() if arguments.input is None else pathlib.Path(src.name).parent
 
     if arguments.input is None:
         path = pathlib.Path(f"/proc/self/fd/{sys.stdin.fileno()}")
     else:
         path = pathlib.Path(arguments.input)
 
-    ctx = CommonContext(cwd)
+    ctx = CommonContext()
     state = State(path=path, defines=ctx.defines)
     doc = Omnifest(process_include(ctx, state, path))
 

--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import logging
-import pathlib
 from abc import ABC, abstractmethod
 from typing import Any, Optional
 
@@ -36,15 +35,12 @@ class Context(ABC):
 
 class CommonContext(Context):
     _version: Optional[int]
-    _path: pathlib.Path
     _variables: dict[str, Any]
 
     def __init__(
         self,
-        path: Optional[pathlib.Path] = None,
     ) -> None:
         self._version = None
-        self._path = path if path else pathlib.Path(".")
         self._variables = {}
 
     def version(self, v: int) -> None:
@@ -122,13 +118,8 @@ class OSBuildContext(Context):
     def variable(self, name: str) -> Any:
         return self._context.variable(name)
 
-    @property
-    def _path(self):
-        return self._context._path
-
     def for_external(self):
         return {
-            "path": str(self._context._path),
             "variables": self._context._variables,
             "sources": self.sources,
         }


### PR DESCRIPTION
The path of the project is now tracked in `traversal.State.path` so it can be safely removed from CommonContext().