### PR TITLE
otk: consolidate target filtering into `Omnifest.targets`

### DIFF
--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -66,19 +66,8 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
     state = State(path=path, defines=ctx.defines)
     doc = Omnifest(process_include(ctx, state, path))
 
-    # let's peek at the tree to validate some things necessary for compilation
-    # we might want to move this into a separate place once this gets shared
-    # across multiple command
-    target_available = {
-        key.removeprefix(PREFIX_TARGET): val for key, val in doc.tree.items() if key.startswith(PREFIX_TARGET)
-    }
-
-    if not target_available:
-        log.fatal("INPUT does not contain any targets")
-        return 1
-
+    target_available = doc.targets
     target_requested = arguments.target
-
     if len(target_available) > 1 and not target_requested:
         log.fatal("INPUT contains multiple targets, `-t` is required")
         return 1

--- a/src/otk/document.py
+++ b/src/otk/document.py
@@ -27,12 +27,22 @@ class Omnifest:
         if NAME_VERSION not in deserialized_data:
             raise ParseVersionError("omnifest must contain a key by the name of %r" % (NAME_VERSION,))
 
-        target_available = {
-            key.removeprefix(PREFIX_TARGET): val for key, val in deserialized_data.items() if key.startswith(PREFIX_TARGET)
-        }
+        target_available = _targets(deserialized_data)
         if not target_available:
             raise NoTargetsError("input does not contain any targets")
 
     @property
     def tree(self) -> dict[str, Any]:
         return deepcopy(self._underlying_data)
+
+    @property
+    def targets(self) -> dict[str, Any]:
+        """ Return a dict of target(s) and their subtree(s) """
+        return _targets(self._underlying_data)
+
+
+def _targets(tree: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key.removeprefix(PREFIX_TARGET): val
+        for key, val in tree.items() if key.startswith(PREFIX_TARGET)
+    }


### PR DESCRIPTION
There are some places that check for targets, consolidate the target filtering into Omnifest and the error checking too.