### PR TITLE
[RFC] otk: rename `traverse.State.defines` to `define_subtree_ref`

### DIFF
--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -63,7 +63,7 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
         path = pathlib.Path(arguments.input)
 
     ctx = CommonContext(cwd)
-    state = State(path=path, defines=ctx.defines)
+    state = State(path=path, define_subtree_ref=ctx.defines)
     doc = Omnifest(process_include(ctx, state, path))
 
     # let's peek at the tree to validate some things necessary for compilation
@@ -105,7 +105,7 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
     # re-resolve the specific target with the specific context and target if
     # applicable
     spec = context_registry.get(kind, CommonContext)(ctx)
-    state = State(path=path, defines=ctx.defines)
+    state = State(path=path, define_subtree_ref=ctx.defines)
     tree = resolve(spec, state, doc.tree[f"{PREFIX_TARGET}{kind}.{name}"])
 
     # and then output by writing to the output

--- a/src/otk/traversal.py
+++ b/src/otk/traversal.py
@@ -1,25 +1,25 @@
 class State:
-    def __init__(self, path, defines, includes=None):
+    def __init__(self, path, define_subtree_ref, includes=None):
         self.path = path
-        self.defines = defines
+        self.define_subtree_ref = define_subtree_ref
         if includes is None:
             includes = []
         self.includes = includes
 
-    def copy(self, *, path=None, defines=None, includes=None) -> "State":
+    def copy(self, *, path=None, define_subtree_ref=None, includes=None) -> "State":
         """
         Return a new State, optionally redefining the path and defines
         properties. Properties not defined in the args are (shallow) copied
         from the existing instance.
-        A shallow copy of the 'defines' allows us to keep modifying the global
+        A reference the 'define_subtree_ref' allows us to keep modifying the global
         context variables through the reference on this State object, which can
-        refer to a sub-object of the global context when necessary.
+        refer to the current (sub)tree of the defines in the global context.
         """
         if path is None:
             path = self.path
-        if defines is None:
-            defines = self.defines
+        if define_subtree_ref is None:
+            define_subtree_ref = self.define_subtree_ref
         if includes is None:
             includes = self.includes.copy()
 
-        return State(path, defines, includes)
+        return State(path, define_subtree_ref, includes)

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -39,4 +39,4 @@ def test_transform_process_defines(data, defines):
     state = State("", ctx.defines)
 
     transform.process_defines(ctx, state, data)
-    assert state.defines == defines
+    assert ctx._variables == defines


### PR DESCRIPTION
To make clearer what the var is about name it more explicitely.

Small followup for https://github.com/osbuild/otk/pull/129#discussion_r1651263922 - names are a bit strawman(ish) but I feel this would makes it a little bit clearer. 

We could also remove Context.define() as it is no longer used (outside of test code) or we change the code so that the Context.define() is used again but then we will need to support "nested.defines.with.subkeys" :) (but it may make the recursive defines also nicer but is a slightly bigger change)