### PR TITLE
otk: limit var naming

### DIFF
--- a/doc/03-omnifest/01-directive.md
+++ b/doc/03-omnifest/01-directive.md
@@ -60,6 +60,10 @@ otk.define:
   boot_mode: uefi
 ```
 
+Valid variable names must start with `[a-zA-Z]` and after that initial
+char can also contain `[a-zA-Z0-9_]`. E.g. `foo` is valid but `f?` is
+not.
+
 ## Usage of `${}`
 
 Use a previously defined variable. String values can be used inside other

--- a/src/otk/constant.py
+++ b/src/otk/constant.py
@@ -9,3 +9,6 @@ PREFIX_DEFINE = f"{PREFIX}define"
 PREFIX_EXTERNAL = f"{PREFIX}external."
 
 NAME_VERSION = f"{PREFIX}version"
+
+# only allow "simple" variable names to avoid confusion
+VALID_VAR_NAME_RE = r"[a-zA-Z][a-zA-Z0-9_]*"

--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -4,14 +4,23 @@
 from __future__ import annotations
 
 import logging
+import re
 from abc import ABC, abstractmethod
 from typing import Any, Optional
 
-from .error import (TransformVariableIndexRangeError,
+from .constant import VALID_VAR_NAME_RE
+from .error import (ParseError,
+                    TransformVariableIndexRangeError,
                     TransformVariableIndexTypeError,
                     TransformVariableLookupError, TransformVariableTypeError)
 
 log = logging.getLogger(__name__)
+
+
+def _validate_var_name(name):
+    for part in name.split("."):
+        if not re.fullmatch(VALID_VAR_NAME_RE, part):
+            raise ParseError(f"invalid variable part '{part}' in '{name}', allowed {VALID_VAR_NAME_RE}")
 
 
 class Context(ABC):
@@ -55,6 +64,7 @@ class CommonContext(Context):
 
     def define(self, name: str, value: Any) -> None:
         log.debug("defining %r", name)
+        _validate_var_name(name)
 
         cur_var_scope = self._variables
         parts = name.split(".")

--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -20,7 +20,7 @@ from typing import Any, List
 import yaml
 
 from . import tree
-from .constant import NAME_VERSION, PREFIX, PREFIX_DEFINE, PREFIX_INCLUDE, PREFIX_OP, PREFIX_TARGET
+from .constant import NAME_VERSION, PREFIX, PREFIX_DEFINE, PREFIX_INCLUDE, PREFIX_OP, PREFIX_TARGET, VALID_VAR_NAME_RE
 from .context import Context, OSBuildContext
 from .error import ParseError, TransformDirectiveTypeError, TransformDirectiveUnknownError
 from .external import call
@@ -250,7 +250,8 @@ def substitute_vars(ctx: Context, data: str) -> Any:
     float."""
 
     bracket = r"\$\{%s\}"
-    pattern = bracket % r"(?P<name>[a-zA-Z0-9-_\.]+)"
+    pattern = bracket % r"(?P<name>%(VALID_VAR_NAME_RE)s(?:\.%(VALID_VAR_NAME_RE)s)*)" % {
+        "VALID_VAR_NAME_RE": VALID_VAR_NAME_RE}
 
     # If there is a single match and its span is the entire haystack then we
     # return its value directly.


### PR DESCRIPTION
This commit adds rules how variables can be named. This is
mostly a defensive measure to avoid ambiguity to disallow
cases that are valid yaml but will may confuse users:
```yaml
otk.define:
 a-b: "foo"

key: ${a-b}
```
which is no longer possible with this commit.
