### PR TITLE
many: add `pylint` to linters and fix warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,6 @@ jobs:
       - name: "Clone Repository"
         uses: actions/checkout@v4
       - name: Install
-        run: pip install pre-commit autopep8
+        run: pip install pre-commit autopep8 pylint
       - name: Run linters
         run: make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,11 @@ jobs:
         run: sudo apt-get install -y yamllint aspell
       - name: "Clone Repository"
         uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
       - name: Install
-        run: pip install pre-commit autopep8 pylint
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
       - name: Run linters
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: lint
 lint:
 	pre-commit run --all-files
+	pylint src/ test/*.py
 
 .PHONY: type
 type:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.autopep8]
 max_line_length = 120
+
+[tool.pylint.main]
+max-line-length = 120
+disable = ["C0114", "C0115", "C0116", "fixme", "protected-access", "redefined-outer-name"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dev = [
     "pytest >= 8.0",
     "mypy >= 1.9",
     "types-PyYAML >= 6.0",
-    "pre-commit"
+    "pre-commit",
+    "pylint"
 ]
 
 

--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -42,7 +42,7 @@ def root() -> int:
 
     if arguments.command == "compile":
         return compile(arguments)
-    elif arguments.command == "validate":
+    if arguments.command == "validate":
         return validate(arguments)
 
     raise RuntimeError("Unknown subcommand")
@@ -50,7 +50,8 @@ def root() -> int:
 
 def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
     if not dry_run:
-        dst = sys.stdout if arguments.output is None else open(arguments.output, "w")
+        # pylint: disable=R1732
+        dst = sys.stdout if arguments.output is None else open(arguments.output, "w", encoding="utf-8")
 
     if arguments.input is None:
         path = pathlib.Path(f"/proc/self/fd/{sys.stdin.fileno()}")
@@ -99,7 +100,7 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
     return 0
 
 
-def compile(arguments: argparse.Namespace) -> int:
+def compile(arguments: argparse.Namespace) -> int:  # pylint: disable=redefined-builtin
     return _process(arguments, dry_run=False)
 
 
@@ -111,7 +112,9 @@ def parser_create() -> argparse.Namespace:
     # set up the main parser arguments
     parser = argparse.ArgumentParser(
         prog="otk",
-        description="`otk` is the omnifest toolkit. A program to work with omnifest inputs and translate them into the native formats for image build tooling.",
+        description="`otk` is the omnifest toolkit. A program to work with "
+        "omnifest inputs and translate them into the native formats for image "
+        "build tooling.",
     )
     parser.add_argument(
         "-j",

--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -57,7 +57,7 @@ class CommonContext(Context):
         log.debug("context setting version to %r", v)
         self._version = v
 
-    def _maybe_log_var_override(self, cur_var_scope, parts, name, value):
+    def _maybe_log_var_override(self, cur_var_scope, parts, value):
         if not self.duplicate_definitions_warning:
             return
         key = parts[-1]
@@ -72,10 +72,10 @@ class CommonContext(Context):
         parts = name.split(".")
         for i, part in enumerate(parts[:-1]):
             if not isinstance(cur_var_scope.get(part), dict):
-                self._maybe_log_var_override(cur_var_scope, parts[:i+1], name, {".".join(parts[i+1:]): value})
+                self._maybe_log_var_override(cur_var_scope, parts[:i+1], {".".join(parts[i+1:]): value})
                 cur_var_scope[part] = {}
             cur_var_scope = cur_var_scope[part]
-        self._maybe_log_var_override(cur_var_scope, parts, name, value)
+        self._maybe_log_var_override(cur_var_scope, parts, value)
         cur_var_scope[parts[-1]] = value
 
     def variable(self, name: str) -> Any:
@@ -86,7 +86,7 @@ class CommonContext(Context):
         for part in parts:
             if isinstance(value, dict):
                 if part not in value:
-                    raise TransformVariableLookupError("Could not find %r" % parts)
+                    raise TransformVariableLookupError(f"Could not find {parts!r}")
 
                 # TODO how should we deal with integer keys, convert them
                 # TODO on KeyError? Check for existence of both?
@@ -97,8 +97,8 @@ class CommonContext(Context):
 
                 try:
                     value = value[int(part)]
-                except IndexError:
-                    raise TransformVariableIndexRangeError()
+                except IndexError as exc:
+                    raise TransformVariableIndexRangeError() from exc
             else:
                 raise TransformVariableTypeError("tried to look up %r.%r but %r isn't a dictionary")
 
@@ -131,16 +131,6 @@ class OSBuildContext(Context):
 
     def variable(self, name: str) -> Any:
         return self._context.variable(name)
-
-    def for_external(self):
-        return {
-            "variables": self._context._variables,
-            "sources": self.sources,
-        }
-
-    def from_external(self, data: str):
-        self._context._variables = data["variables"]
-        self.sources = data.get("sources", {})
 
     @property
     def defines(self) -> dict:

--- a/src/otk/document.py
+++ b/src/otk/document.py
@@ -25,7 +25,7 @@ class Omnifest:
         # And that dictionary needs to contain certain keys to indicate this
         # being an Omnifest.
         if NAME_VERSION not in deserialized_data:
-            raise ParseVersionError("omnifest must contain a key by the name of %r" % (NAME_VERSION,))
+            raise ParseVersionError(f"omnifest must contain a key by the name of {NAME_VERSION!r}")
 
         target_available = _targets(deserialized_data)
         if not target_available:

--- a/src/otk/error.py
+++ b/src/otk/error.py
@@ -4,109 +4,77 @@
 class OTKError(Exception):
     """Any application raised by `otk` inherits from this."""
 
-    pass
-
 
 class ParseError(OTKError):
     """General base exception for any errors related to parsing omnifests."""
-
-    pass
 
 
 class ParseTypeError(ParseError):
     """A wrong type was encountered for a position in the omnifest."""
 
-    pass
-
 
 class ParseKeyError(ParseTypeError):
     """A required key was missing for a position in the omnifest."""
-
-    pass
 
 
 class ParseVersionError(ParseKeyError):
     """The `otk.version` key is missing from an omnifest."""
 
-    pass
-
 
 class ParseTargetError(ParseError):
     """An unknown target or no targets were encountered in the omnifest."""
 
-    pass
-
 
 class ParseValueError(ParseTypeError):
     """A required value was missing for a position in the omnifest."""
-
-    pass
 
 
 class TransformError(OTKError):
     """General base exception for any errors related to transforming
     omnifests."""
 
-    pass
-
 
 class TransformVariableLookupError(TransformError):
     """Failed to look up a variable."""
 
-    pass
-
 
 class TransformVariableTypeError(TransformError):
     """Failed to look up a variable due to a parent variable type."""
-
-    pass
 
 
 class TransformVariableIndexTypeError(TransformError):
     """Failed to look up an index into a variable due to the index contents
     not being a number."""
 
-    pass
-
 
 class TransformVariableIndexRangeError(TransformError):
     """Failed to look up an index into a variable due to it being out of
     bounds."""
 
-    pass
-
 
 class TransformDefineDuplicateError(TransformError):
     """Tried to redefine a variable."""
-
-    pass
 
 
 class TransformDirectiveTypeError(TransformError):
     """A directive received the wrong types."""
 
-    pass
-
 
 class TransformDirectiveArgumentError(TransformError):
     """A directive received the wrong argument(s)."""
-
-    pass
 
 
 class TransformDirectiveUnknownError(TransformError):
     """Unknown directive."""
 
-    pass
-
 
 class CircularIncludeError(ParseError):
     """Cirtcular include detected."""
-
-    pass
 
 
 class NoTargetsError(ParseError):
     """No targets in the otk file found."""
 
-    pass
+
+class ExternalFailedError(OTKError):
+    """ Call to external failed """

--- a/src/otk/tree.py
+++ b/src/otk/tree.py
@@ -19,8 +19,7 @@ def must_be(kind: Type):
         def wrapper(*args, **kwargs):
             if not isinstance(args[1], kind):
                 raise TransformDirectiveTypeError(
-                    "otk.define expects a %r as its argument but received a `%s`: `%r`" % (kind, type(args[1]), args[1])
-                )
+                    f"otk.define expects a {kind!r} as its argument but received a `{type(args[1])}`: `{args[1]!r}`")
             return function(*args, **kwargs)
 
         return wrapper
@@ -47,6 +46,6 @@ def has_keys(keys):
     def inner(tree):
         for key in keys:
             if key not in tree:
-                raise TransformDirectiveArgumentError("Expected key %r", key)
+                raise TransformDirectiveArgumentError(f"Expected key {key!r}")
 
     return inner

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -34,7 +34,7 @@ def test_parse_no_command(capsys):
         (["validate", "foo.yaml"], {"command": "validate", "input": "foo.yaml"}),
     ],
 )
-def test_parse_commands_success(capsys, command, results):
+def test_parse_commands_success(command, results):
     p = parser_create()
     r = p.parse_args(command)
     for k in results.keys():

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -2,16 +2,16 @@ import argparse
 import os
 
 
-from otk.command import compile
+from otk.command import compile  # pylint: disable=W0622
 
 
-fake_otk_yaml = """
+FAKE_OTK_YAML = """
 otk.version: 1
 otk.target.osbuild.qcow2:
  test: 1
 """
 
-expected_otk_tree = """\
+EXPECTED_OTK_TREE = """\
 {
   "test": 1,
   "version": "2",
@@ -21,7 +21,7 @@ expected_otk_tree = """\
 
 def test_compile_integration_file(tmp_path):
     input_path = tmp_path / "input.txt"
-    input_path.write_text(fake_otk_yaml)
+    input_path.write_text(FAKE_OTK_YAML)
     output_path = tmp_path / "output.txt"
 
     arguments = argparse.Namespace(input=input_path, output=output_path, target="osbuild")
@@ -29,12 +29,12 @@ def test_compile_integration_file(tmp_path):
     assert ret == 0
 
     assert output_path.exists()
-    assert output_path.read_text() == expected_otk_tree
+    assert output_path.read_text() == EXPECTED_OTK_TREE
 
 
 def test_compile_integration_stdin(capsys, monkeypatch):
     mocked_stdin = os.memfd_create("<fake-stdin>")
-    os.write(mocked_stdin, fake_otk_yaml.encode("utf8"))
+    os.write(mocked_stdin, FAKE_OTK_YAML.encode("utf8"))
     os.lseek(mocked_stdin, 0, 0)
     monkeypatch.setattr("sys.stdin", os.fdopen(mocked_stdin))
 
@@ -42,4 +42,4 @@ def test_compile_integration_stdin(capsys, monkeypatch):
     ret = compile(arguments)
     assert ret == 0
 
-    assert capsys.readouterr().out == expected_otk_tree
+    assert capsys.readouterr().out == EXPECTED_OTK_TREE

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -71,11 +71,13 @@ def test_context_warn_on_override_nested(caplog):
     assert len(caplog.records) == 0
     ctx.define("key.subkey", "newsubval")
     # from dict -> str
-    expected_msg1 = "redefinition of 'key.subkey', previous values was {'subsubkey': 'subsubval'} and new value is 'newsubval'"
+    expected_msg1 = ("redefinition of 'key.subkey', previous values was "
+                     "{'subsubkey': 'subsubval'} and new value is 'newsubval'")
     assert [expected_msg1] == [r.message for r in caplog.records]
     ctx.define("key.subkey", {"sub": "dict"})
     # from str -> dict
-    expected_msg2 = "redefinition of 'key.subkey', previous values was 'newsubval' and new value is {'sub': 'dict'}"
+    expected_msg2 = ("redefinition of 'key.subkey', previous values was "
+                     "'newsubval' and new value is {'sub': 'dict'}")
     assert [expected_msg1, expected_msg2] == [r.message for r in caplog.records]
 
 
@@ -85,7 +87,8 @@ def test_context_warn_on_override_nested_from_val_to_dict(caplog):
     ctx.define("key.sub", "subval")
     assert len(caplog.records) == 0
     ctx.define("key.sub.subsub.subsubsub", {"subsubsub": "val2"})
-    expected_msg = "redefinition of 'key.sub', previous values was 'subval' and new value is {'subsub.subsubsub': {'subsubsub': 'val2'}}"
+    expected_msg = ("redefinition of 'key.sub', previous values was "
+                    "'subval' and new value is {'subsub.subsubsub': {'subsubsub': 'val2'}}")
 
     assert [expected_msg] == [r.message for r in caplog.records]
 

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -16,8 +16,9 @@ def test_command_compile_on_base_examples(tmp_path, src_yaml):
 
     command.compile(ns)
 
-    expected = json.load(src_yaml.with_suffix(".json").open())
-    actual = json.load(dst.open())
+    # pylint: disable=consider-using-with
+    expected = json.load(src_yaml.with_suffix(".json").open(encoding="utf8"))
+    actual = json.load(dst.open(encoding="utf8"))
     assert expected == actual
 
 
@@ -25,7 +26,7 @@ def test_command_compile_on_base_examples(tmp_path, src_yaml):
                          [str(path) for path in (pathlib.Path(__file__).parent / "data/error").glob("*.yaml")])
 def test_errors(src_yaml):
     src_yaml = pathlib.Path(src_yaml)
-    expected = src_yaml.with_suffix(".err").read_text().strip()
+    expected = src_yaml.with_suffix(".err").read_text(encoding="utf8").strip()
     ns = argparse.Namespace(input=src_yaml, output="/dev/null", target="osbuild")
     with pytest.raises(Exception) as exception:
         command.compile(ns)

--- a/test/test_substitute_vars.py
+++ b/test/test_substitute_vars.py
@@ -50,7 +50,7 @@ def test_sub_var_multiple_fail():
 
     # the a will be replaced but the b will cause an error
     expected_error = re.escape(
-        r"string 'foo-${b}' resolves to an incorrect type, " "expected int, float, or str but got list"
+        r"string 'foo-${b}' resolves to an incorrect type, expected int, float, or str but got list"
     )
 
     # Fails due to non-str type
@@ -61,7 +61,7 @@ def test_sub_var_multiple_fail():
 
     # the a will be replaced but the c will cause an error
     expected_error = re.escape(
-        r"string 'foo-${c}' resolves to an incorrect type, " "expected int, float, or str but got dict"
+        r"string 'foo-${c}' resolves to an incorrect type, expected int, float, or str but got dict"
     )
 
     # Fails due to non-str type

--- a/test/test_traversal.py
+++ b/test/test_traversal.py
@@ -57,4 +57,4 @@ def test_state_detect_circular_2():
 
 def test_state_empty_includes():
     state = State()
-    assert state._includes == []
+    assert len(state._includes) == 0

--- a/test/test_validate.py
+++ b/test/test_validate.py
@@ -36,20 +36,11 @@ otk.target.osbuild.ami: { test: 2 }
         ),
     ],
 )
-def test_validate(
-    tmp_path,
-    caplog,
-    capsys,
-    monkeypatch,
-    arguments,
-    input_data,
-    sys_exit_code,
-    log_message,
-):
+def test_validate(tmp_path, caplog, arguments, input_data, sys_exit_code, log_message):  # pylint: disable=too-many-arguments
     if arguments.input == "GENERATE":
         input_filename = "input.yaml"
         arguments.input = os.path.join(tmp_path, input_filename)
-        with open(arguments.input, "w") as f:
+        with open(arguments.input, "w", encoding="utf8") as f:
             f.write(input_data)
 
     if arguments.output == "GENERATE":


### PR DESCRIPTION
This commit adds pylint and fixes the various warnings that it triggers. There are still some disabled ones left but this captures many of the low-hanging fruits.