### PR TITLE
context: remove {for,from}_externals() as they are unused

### DIFF
--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -132,16 +132,6 @@ class OSBuildContext(Context):
     def variable(self, name: str) -> Any:
         return self._context.variable(name)
 
-    def for_external(self):
-        return {
-            "variables": self._context._variables,
-            "sources": self.sources,
-        }
-
-    def from_external(self, data: str):
-        self._context._variables = data["variables"]
-        self.sources = data.get("sources", {})
-
     @property
     def defines(self) -> dict:
         return self._context._variables


### PR DESCRIPTION
These helpers are currently unused and it's not clear (to me) what they do. Let's remove them until we have a use case. But equally happy to add a comment or test if we know how they will be used.