### PR TITLE
otk: error when an invalid variable is used in a substitution

### DIFF
--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -17,7 +17,7 @@ from .error import (ParseError,
 log = logging.getLogger(__name__)
 
 
-def _validate_var_name(name):
+def validate_var_name(name):
     for part in name.split("."):
         if not re.fullmatch(VALID_VAR_NAME_RE, part):
             raise ParseError(f"invalid variable part '{part}' in '{name}', allowed {VALID_VAR_NAME_RE}")
@@ -76,7 +76,7 @@ class CommonContext(Context):
 
     def define(self, name: str, value: Any) -> None:
         log.debug("defining %r", name)
-        _validate_var_name(name)
+        validate_var_name(name)
 
         cur_var_scope = self._variables
         parts = name.split(".")


### PR DESCRIPTION
This commit adds detection for invalid variable usage in otk. This
means that:
```yaml
foo: ${a-b}
```
will now raise an error instead of being ignored.

It also means that nested var will error. The existing code has some
confusing behavior when nesting ${}, e.g.
```python
def test_sub_var_recursive():
    context = CommonContext()
    context.define("a", "foo")
    context.define("b", "bar")
    s = substitute_vars(context, "${a.${b}}")
    # s is now '${a.bar}' which is not quite right
```
This just no longer works because "$" is not a valid var name inside
a substitution.

[draft as it needs https://github.com/osbuild/otk/pull/143 and https://github.com/osbuild/otk/pull/147 (not strictly)]