### PR TITLE
otk: make code `mypy` clean and run as part of the gh actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,3 +23,5 @@ jobs:
           pip install .[dev]
       - name: Run linters
         run: make lint
+      - name: Run type checker
+        run: make type

--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -4,12 +4,10 @@ import pathlib
 import sys
 
 from .constant import PREFIX_TARGET
-from .context import CommonContext
-from .context import registry as context_registry
+from .context import CommonContext, OSBuildContext
 from .document import Omnifest
 from .help.log import JSONSequenceHandler
-from .target import CommonTarget
-from .target import registry as target_registry
+from .target import OSBuildTarget
 from .transform import process_include, resolve
 from .traversal import State
 
@@ -89,13 +87,17 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
 
     # re-resolve the specific target with the specific context and target if
     # applicable
-    spec = context_registry.get(kind, CommonContext)(ctx)
+    # TODO: redo/readd {context,target}_registry in type safe way
+    if kind != "osbuild":
+        raise ValueError("only target osbuild supported right now")
+    spec = OSBuildContext(ctx)
+    target = OSBuildTarget()
     state = State(path=path)
     tree = resolve(spec, state, doc.tree[f"{PREFIX_TARGET}{kind}.{name}"])
 
     # and then output by writing to the output
     if not dry_run:
-        dst.write(target_registry.get(kind, CommonTarget)().as_string(spec, tree))
+        dst.write(target.as_string(spec, tree))
 
     return 0
 
@@ -108,7 +110,7 @@ def validate(arguments: argparse.Namespace) -> int:
     return _process(arguments, dry_run=True)
 
 
-def parser_create() -> argparse.Namespace:
+def parser_create() -> argparse.ArgumentParser:
     # set up the main parser arguments
     parser = argparse.ArgumentParser(
         prog="otk",

--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -131,7 +131,7 @@ class OSBuildContext(Context):
 
     sources: dict[str, list[Any]]
 
-    def __init__(self, context: Context) -> None:
+    def __init__(self, context: CommonContext) -> None:
         self.sources = {}
         self._context = context
 
@@ -151,8 +151,3 @@ class OSBuildContext(Context):
     @defines.setter
     def defines(self, val):
         self._context._variables = val
-
-
-registry = {
-    "osbuild": OSBuildContext,
-}

--- a/src/otk/external.py
+++ b/src/otk/external.py
@@ -34,7 +34,6 @@ def call(directive: str, tree: Any) -> Any:
         raise ExternalFailedError(msg)
 
     res = json.loads(process.stdout)
-
     return res["tree"]
 
 

--- a/src/otk/target.py
+++ b/src/otk/target.py
@@ -3,7 +3,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any
 
-from .context import Context, CommonContext, OSBuildContext
+from .context import CommonContext, OSBuildContext
 
 
 log = logging.getLogger(__name__)
@@ -14,7 +14,7 @@ class Target(ABC):
     def is_valid(self, tree: Any) -> bool: ...
 
     @abstractmethod
-    def as_string(self, context: Context, tree: Any, pretty: bool) -> str: ...
+    def as_string(self, context: Any, tree: Any, pretty: bool = True) -> str: ...
 
 
 # NOTE this common target is a bit weird, we probably shouldn't always assume JSON but
@@ -39,8 +39,3 @@ class OSBuildTarget(Target):
         tree["sources"] = context.sources
 
         return json.dumps(tree, indent=2 if pretty else None)
-
-
-registry = {
-    "osbuild": OSBuildTarget,
-}

--- a/src/otk/traversal.py
+++ b/src/otk/traversal.py
@@ -2,22 +2,23 @@ import copy
 import inspect
 import os
 import pathlib
+from typing import Union
 
 from .error import CircularIncludeError
 
 
 class State:
 
-    def __init__(self, path: pathlib.Path = None):
+    def __init__(self, path: Union[pathlib.Path, None] = None) -> None:
         if path is None:
             path = pathlib.Path()
         self.path = path
-        self._define_subkeys = []
+        self._define_subkeys: list[str] = []
         self._includes = []
         if path != pathlib.Path():
             self._includes.append(path)
 
-    def copy(self, *, path=None, subkey_add: str = None) -> "State":
+    def copy(self, *, path: Union[pathlib.Path, None] = None, subkey_add: Union[str, None] = None) -> "State":
         """
         Return a new State, optionally redefining the path and add a define
         subkey. Properties not defined in the args are (shallow) copied
@@ -35,7 +36,7 @@ class State:
             new_state._includes.append(path)
         return new_state
 
-    def define_subkey(self, key: str = None):
+    def define_subkey(self, key: Union[str, None] = None):
         """
         Return the current dotted path for a define, e.g. "key.subkey"
         """


### PR DESCRIPTION
There are many type hints but mypy was not happy so this commit makes it clean again and adds it as part of the GH workflow so that we keep it clean. The registries will have to be redone, they are currently not type safe but we only have a single target right now so it's probably okay for now to just use a very simple approach