### PR TITLE
otk: add support for `otk -w duplicate-definition`

### DIFF
--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -17,8 +17,10 @@ log = logging.getLogger(__name__)
 
 
 def root() -> int:
-    argv = sys.argv[1:]
+    return run(sys.argv[1:])
 
+
+def run(argv) -> int:
     parser = parser_create()
     arguments = parser.parse_args(argv)
 
@@ -58,7 +60,8 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
     else:
         path = pathlib.Path(arguments.input)
 
-    ctx = CommonContext()
+    ddw = "duplicate-definition" in getattr(arguments, "warn", [])
+    ctx = CommonContext(duplicate_definitions_warning=ddw)
     state = State()
     doc = Omnifest(process_include(ctx, state, path))
 
@@ -139,7 +142,8 @@ def parser_create() -> argparse.Namespace:
     parser.add_argument(
         "-w",
         "--warn",
-        default=None,
+        action='append',
+        default=[],
         help="Enable warnings, can be passed multiple times.",
     )
 

--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -71,7 +71,7 @@ class CommonContext(Context):
             return
         key = parts[-1]
         if cur_var_scope.get(key):
-            log.warning("redefinition of %r, previous values was %r and new value is %r",
+            log.warning("redefinition of %r, previous value was %r and new value is %r",
                         ".".join(parts), cur_var_scope[parts[-1]], value)
 
     def define(self, name: str, value: Any) -> None:

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -61,7 +61,7 @@ def test_context_warn_on_override_simple(caplog):
     ctx.define("key", "val")
     assert len(caplog.records) == 0
     ctx.define("key", "new-val")
-    expected_msg = "redefinition of 'key', previous values was 'val' and new value is 'new-val'"
+    expected_msg = "redefinition of 'key', previous value was 'val' and new value is 'new-val'"
     assert [expected_msg] == [r.message for r in caplog.records]
 
 
@@ -72,12 +72,12 @@ def test_context_warn_on_override_nested(caplog):
     assert len(caplog.records) == 0
     ctx.define("key.subkey", "newsubval")
     # from dict -> str
-    expected_msg1 = ("redefinition of 'key.subkey', previous values was "
+    expected_msg1 = ("redefinition of 'key.subkey', previous value was "
                      "{'subsubkey': 'subsubval'} and new value is 'newsubval'")
     assert [expected_msg1] == [r.message for r in caplog.records]
     ctx.define("key.subkey", {"sub": "dict"})
     # from str -> dict
-    expected_msg2 = ("redefinition of 'key.subkey', previous values was "
+    expected_msg2 = ("redefinition of 'key.subkey', previous value was "
                      "'newsubval' and new value is {'sub': 'dict'}")
     assert [expected_msg1, expected_msg2] == [r.message for r in caplog.records]
 
@@ -88,7 +88,7 @@ def test_context_warn_on_override_nested_from_val_to_dict(caplog):
     ctx.define("key.sub", "subval")
     assert len(caplog.records) == 0
     ctx.define("key.sub.subsub.subsubsub", {"subsubsub": "val2"})
-    expected_msg = ("redefinition of 'key.sub', previous values was "
+    expected_msg = ("redefinition of 'key.sub', previous value was "
                     "'subval' and new value is {'subsub.subsubsub': {'subsubsub': 'val2'}}")
 
     assert [expected_msg] == [r.message for r in caplog.records]

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,0 +1,40 @@
+import logging
+import os
+import textwrap
+
+import pytest
+
+from otk.command import run
+
+
+@pytest.mark.parametrize("cmd,with_dupe_warn", [
+    ("compile", False),
+    ("compile", True),
+    ("validate", False),
+    ("validate", True),
+])
+def test_warn(tmp_path, caplog, cmd, with_dupe_warn):
+    caplog.set_level(logging.WARNING)
+
+    test_otk = tmp_path / "foo.yaml"
+    test_otk.write_text(textwrap.dedent("""
+    otk.version: 1
+    otk.target.osbuild.foo:
+      x: y
+
+    otk.define.1:
+      a: 1
+    otk.define.2:
+      a: 2
+    """))
+
+    if with_dupe_warn:
+        prefix = ["-w", "duplicate-definition"]
+    else:
+        prefix = []
+    run(prefix + [cmd, os.fspath(test_otk)])
+    if with_dupe_warn:
+        expected_msg = "redefinition of 'a', previous value was 1 and new value is 2"
+        assert [expected_msg] == [rec.message for rec in caplog.records]
+    else:
+        assert [] == [rec.message for rec in caplog.records]


### PR DESCRIPTION
We describe in `01-directive.md` that we support warnings via `-w duplicate-definition` - this commit makes this real.

[edit: there is also a typo fix in the warning]