### PR TITLE
otk: add support for `-Wall`

### DIFF
--- a/doc/03-omnifest/01-directive.md
+++ b/doc/03-omnifest/01-directive.md
@@ -44,7 +44,7 @@ Variable scope is global, an `otk.define` directive anywhere in the omnifest
 tree will result in the defined names being hoisted to the global scope.
 
 Redefinitions of variables are allowed. This allows for setting up default
-values. If `-w duplicate-definition` is passed as an argument to `otk` then
+values. If `-W duplicate-definition` is passed as an argument to `otk` then
 `otk` will warn on all duplicate definitions.
 
 Expects a `map` for its value.

--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -117,11 +117,11 @@ def parser_create() -> argparse.ArgumentParser:
         help="Sets verbosity. Can be passed multiple times to be more verbose.",
     )
     parser.add_argument(
-        "-w",
+        "-W",
         "--warn",
         action='append',
         default=[],
-        help="Enable warnings, use 'all' to get all warnings or enable specific warnings. Can be passed multiple times.",
+        help="Enable warnings, use 'all' to get all or enable specific warnings. Can be passed multiple times.",
     )
 
     # get a subparser action

--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -45,7 +45,8 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
     else:
         path = pathlib.Path(arguments.input)
 
-    ddw = "duplicate-definition" in getattr(arguments, "warn", [])
+    ddw = any(arg in getattr(arguments, "warn", [])
+              for arg in ["duplicate-definition", "all"])
     ctx = CommonContext(duplicate_definitions_warning=ddw)
     state = State()
     doc = Omnifest(process_include(ctx, state, path))
@@ -120,7 +121,7 @@ def parser_create() -> argparse.ArgumentParser:
         "--warn",
         action='append',
         default=[],
-        help="Enable warnings, can be passed multiple times.",
+        help="Enable warnings, use 'all' to get all warnings or enable specific warnings. Can be passed multiple times.",
     )
 
     # get a subparser action

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -7,13 +7,15 @@ import pytest
 from otk.command import run
 
 
-@pytest.mark.parametrize("cmd,with_dupe_warn", [
-    ("compile", False),
-    ("compile", True),
-    ("validate", False),
-    ("validate", True),
+@pytest.mark.parametrize("cmd,warn_arg,expect_warning", [
+    ("compile", "", False),
+    ("compile", "duplicate-definition", True),
+    ("compile", "all", True),
+    ("validate", "", False),
+    ("validate", "duplicate-definition", True),
+    ("validate", "all", True),
 ])
-def test_warn(tmp_path, caplog, cmd, with_dupe_warn):
+def test_warn(tmp_path, caplog, cmd, warn_arg, expect_warning):
     caplog.set_level(logging.WARNING)
 
     test_otk = tmp_path / "foo.yaml"
@@ -28,12 +30,12 @@ def test_warn(tmp_path, caplog, cmd, with_dupe_warn):
       a: 2
     """))
 
-    if with_dupe_warn:
-        prefix = ["-w", "duplicate-definition"]
+    if warn_arg:
+        prefix = ["-w", warn_arg]
     else:
         prefix = []
     run(prefix + [cmd, os.fspath(test_otk)])
-    if with_dupe_warn:
+    if expect_warning:
         expected_msg = "redefinition of 'a', previous value was 1 and new value is 2"
         assert [expected_msg] == [rec.message for rec in caplog.records]
     else:

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -31,7 +31,7 @@ def test_warn(tmp_path, caplog, cmd, warn_arg, expect_warning):
     """))
 
     if warn_arg:
-        prefix = ["-w", warn_arg]
+        prefix = ["-W", warn_arg]
     else:
         prefix = []
     run(prefix + [cmd, os.fspath(test_otk)])


### PR DESCRIPTION
otk: add support for `-w all`

Tiny commit to allow to shortcut warning passing by allowing to
do a `-w all` style that just enables all warnings.

---

otk: rename `-w` -> `-W` for warning control

Both gcc and python use `-W` to enable warnings so let's just follow
the same pattern.
