### PR TITLE
otk: use typing.Optional instead of Union[,None]

### DIFF
--- a/src/otk/traversal.py
+++ b/src/otk/traversal.py
@@ -2,14 +2,14 @@ import copy
 import inspect
 import os
 import pathlib
-from typing import Union
+from typing import Optional
 
 from .error import CircularIncludeError
 
 
 class State:
 
-    def __init__(self, path: Union[pathlib.Path, None] = None) -> None:
+    def __init__(self, path: Optional[pathlib.Path] = None) -> None:
         if path is None:
             path = pathlib.Path()
         self.path = path
@@ -18,7 +18,7 @@ class State:
         if path != pathlib.Path():
             self._includes.append(path)
 
-    def copy(self, *, path: Union[pathlib.Path, None] = None, subkey_add: Union[str, None] = None) -> "State":
+    def copy(self, *, path: Optional[pathlib.Path] = None, subkey_add: Optional[str] = None) -> "State":
         """
         Return a new State, optionally redefining the path and add a define
         subkey. Properties not defined in the args are (shallow) copied
@@ -36,7 +36,7 @@ class State:
             new_state._includes.append(path)
         return new_state
 
-    def define_subkey(self, key: Union[str, None] = None):
+    def define_subkey(self, key: Optional[str] = None):
         """
         Return the current dotted path for a define, e.g. "key.subkey"
         """


### PR DESCRIPTION
This commit switches the the shorter and easier (IMHO) to read typing.Optional[] type and uses that instead of typing.Union[]. The are equivalent otherwise.

