### PR TITLE
otk: add more mypy strictness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,16 @@ max_line_length = 120
 [tool.pylint.main]
 max-line-length = 120
 disable = ["C0114", "C0115", "C0116", "fixme", "protected-access", "redefined-outer-name"]
+
+[tool.mypy]
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+strict_equality = true
+extra_checks = true
+disallow_incomplete_defs = true
+# TODO: follow
+# https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options
+# and get to "--strict" eventually
+#check_untyped_defs = true
+#disallow_untyped_calls = true

--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import pathlib
 import sys
+from typing import List
 
 from .constant import PREFIX_TARGET
 from .context import CommonContext, OSBuildContext
@@ -17,7 +18,7 @@ def root() -> int:
     return run(sys.argv[1:])
 
 
-def run(argv) -> int:
+def run(argv: List[str]) -> int:
     parser = parser_create()
     arguments = parser.parse_args(argv)
 

--- a/src/otk/external.py
+++ b/src/otk/external.py
@@ -54,8 +54,8 @@ def path_for(exe):
     if env is not None:
         paths = [env] + paths
 
-    for path in paths:
-        path = pathlib.Path(path) / exe
+    for pathname in paths:
+        path = pathlib.Path(pathname) / exe
 
         if path.exists() and os.access(path, os.X_OK):
             return path

--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -103,7 +103,7 @@ def resolve_dict(ctx: Context, state: State, tree: dict[str, Any]) -> Any:
     return tree
 
 
-def resolve_list(ctx, state: State, tree: list[Any]) -> list[Any]:
+def resolve_list(ctx: Context, state: State, tree: list[Any]) -> list[Any]:
     """Resolving a list means applying the resolve function to each element in
     the list."""
 
@@ -112,7 +112,7 @@ def resolve_list(ctx, state: State, tree: list[Any]) -> list[Any]:
     return [resolve(ctx, state, val) for val in tree]
 
 
-def resolve_str(ctx, _: State, tree: str) -> Any:
+def resolve_str(ctx: Context, _: State, tree: str) -> Any:
     """Resolving strings means they are parsed for any variable
     interpolation."""
 
@@ -126,7 +126,7 @@ def is_directive(needle: Any) -> bool:
     return isinstance(needle, str) and needle.startswith(PREFIX)
 
 
-def process_defines(ctx: Context, state: State, tree: Any):
+def process_defines(ctx: Context, state: State, tree: Any) -> None:
     """
     Processes tree for new defines, resolving any references to other variables,
     and update the global context. The State holds a reference to the nested

--- a/src/otk/traversal.py
+++ b/src/otk/traversal.py
@@ -2,7 +2,7 @@ import copy
 import inspect
 import os
 import pathlib
-from typing import Optional
+from typing import Any, Optional
 
 from .error import CircularIncludeError
 
@@ -36,7 +36,7 @@ class State:
             new_state._includes.append(path)
         return new_state
 
-    def define_subkey(self, key: Optional[str] = None):
+    def define_subkey(self, key: Optional[str] = None) -> str:
         """
         Return the current dotted path for a define, e.g. "key.subkey"
         """
@@ -44,7 +44,7 @@ class State:
             return ".".join(self._define_subkeys)
         return ".".join(self._define_subkeys + [key])
 
-    def __setattr__(self, name, val):
+    def __setattr__(self, name: str, val: Any) -> None:
         caller = inspect.stack()[1][3]
         # ideally we would check that the caller is State.copy() here
         if hasattr(self, name) and caller != "copy":

--- a/src/otk/tree.py
+++ b/src/otk/tree.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 
 
 import functools
-from typing import Type
+from typing import Callable, Type
 
 from .error import TransformDirectiveArgumentError, TransformDirectiveTypeError
 
 
-def must_be(kind: Type):
+def must_be(kind: Type) -> Callable:
     """Handles the tree having to be of a specific type at runtime."""
 
     def decorator(function):


### PR DESCRIPTION
Add more `mypy` strictness, especially `disallow_incomplete_defs`
is useful. This follows roughly the suggestions from
https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options

The next steps would probably be:
```
check_untyped_defs = true
disallow_untyped_calls = True
disallow_untyped_defs = True
```
but `disallow_untyped_defs` would require to be able to exclude
all the file in `test/` for this specific check as it seems a
bit overkill.

[based on https://github.com/osbuild/otk/pull/154 to avoid conflicts]