### PR TITLE
Implement error for invalid target

### DIFF
--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -87,6 +87,9 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
     state = State(path=path)
     tree = resolve(spec, state, doc.tree[f"{PREFIX_TARGET}{kind}.{name}"])
 
+    if not target.is_valid(tree):
+        return 1
+
     # and then output by writing to the output
     if not dry_run:
         dst.write(target.as_string(spec, tree))

--- a/src/otk/target.py
+++ b/src/otk/target.py
@@ -29,6 +29,15 @@ class CommonTarget(Target):
 
 class OSBuildTarget(Target):
     def is_valid(self, tree: Any) -> bool:
+        if not isinstance(tree, dict):
+            log.fatal("First level below a 'target' should be a dictionary (not a %s)", type(tree).__name__)
+            return False
+
+        if "version" in tree:
+            log.fatal("First level below a 'target' must not contain 'version'.")
+            log.fatal("The key 'version' is added by otk internally.")
+            return False
+
         return True
 
     def as_string(self, context: OSBuildContext, tree: Any, pretty: bool = True) -> str:

--- a/test/data/log_fatal/00-target-should-not-be-list.err
+++ b/test/data/log_fatal/00-target-should-not-be-list.err
@@ -1,0 +1,1 @@
+First level below a 'target' should be a dictionary (not a list)

--- a/test/data/log_fatal/00-target-should-not-be-list.yaml
+++ b/test/data/log_fatal/00-target-should-not-be-list.yaml
@@ -1,0 +1,4 @@
+otk.version: "1"
+
+otk.target.osbuild.name:
+  - test: 1

--- a/test/data/log_fatal/01-target-should-not-be-string.err
+++ b/test/data/log_fatal/01-target-should-not-be-string.err
@@ -1,0 +1,1 @@
+First level below a 'target' should be a dictionary (not a str)

--- a/test/data/log_fatal/01-target-should-not-be-string.yaml
+++ b/test/data/log_fatal/01-target-should-not-be-string.yaml
@@ -1,0 +1,3 @@
+otk.version: "1"
+
+otk.target.osbuild.name: "test"

--- a/test/data/log_fatal/02-target-should-not-contain-version.err
+++ b/test/data/log_fatal/02-target-should-not-contain-version.err
@@ -1,0 +1,1 @@
+First level below a 'target' must not contain 'version'

--- a/test/data/log_fatal/02-target-should-not-contain-version.yaml
+++ b/test/data/log_fatal/02-target-should-not-contain-version.yaml
@@ -1,0 +1,5 @@
+otk.version: "1"
+
+otk.target.osbuild.name:
+  pipelines: "yes"
+  version: 1

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -31,3 +31,16 @@ def test_errors(src_yaml):
     with pytest.raises(Exception) as exception:
         command.compile(ns)
     assert expected in str(exception.value)
+
+
+@pytest.mark.parametrize("src_yaml",
+                         [str(path) for path in (pathlib.Path(__file__).parent / "data/log_fatal").glob("*.yaml")])
+def test_log_fatal(caplog, src_yaml):
+    src_yaml = pathlib.Path(src_yaml)
+    expected = src_yaml.with_suffix(".err").read_text(encoding="utf8").strip()
+    ns = argparse.Namespace(input=src_yaml, output="/dev/null", target="osbuild.name")
+    ret = command.compile(ns)
+
+    assert ret != 0
+    log_text = caplog.text
+    assert expected in log_text


### PR DESCRIPTION
checking that target
- is a dict
- contains 'pipelines'
- does not contain 'version'

checking source is unclear to me - so it's a comment for now