### PR TITLE
otk: remove unused "defines"  getter/setter from Context

### DIFF
--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -33,14 +33,6 @@ class Context(ABC):
     @abstractmethod
     def variable(self, name: str) -> Any: ...
 
-    @property
-    @abstractmethod
-    def defines(self) -> dict: ...
-
-    @defines.setter
-    @abstractmethod
-    def defines(self, val): ...
-
 
 class CommonContext(Context):
     duplicate_definitions_warning: bool
@@ -116,14 +108,6 @@ class CommonContext(Context):
 
         return value
 
-    @property
-    def defines(self) -> dict:
-        return self._variables
-
-    @defines.setter
-    def defines(self, val):
-        self._variables = val
-
 
 class OSBuildContext(Context):
     """Composes in a `GenericContext` while providing support for `osbuild`
@@ -143,11 +127,3 @@ class OSBuildContext(Context):
 
     def variable(self, name: str) -> Any:
         return self._context.variable(name)
-
-    @property
-    def defines(self) -> dict:
-        return self._context._variables
-
-    @defines.setter
-    def defines(self, val):
-        self._context._variables = val


### PR DESCRIPTION
It seems like nothing is currently using Context.defines plus there is already a `Context.define()` and a `Context.variable()` which provide similar functionality (and more as they can resolve dotted notation). Unless there is a use-case or a good reason let's remove these methods and bring them back if/when we need them.