### PR TITLE
otk,test: support otk.external inside otk.define

### DIFF
--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -31,6 +31,9 @@ class Context(ABC):
     def define(self, name: str, value: Any) -> None: ...
 
     @abstractmethod
+    def merge_defines(self, defines: dict[str, Any]) -> None: ...
+
+    @abstractmethod
     def variable(self, name: str) -> Any: ...
 
 
@@ -108,6 +111,9 @@ class CommonContext(Context):
 
         return value
 
+    def merge_defines(self, defines: dict[str, Any]) -> None:
+        self._variables.update(defines)
+
 
 class OSBuildContext(Context):
     """Composes in a `GenericContext` while providing support for `osbuild`
@@ -127,3 +133,6 @@ class OSBuildContext(Context):
 
     def variable(self, name: str) -> Any:
         return self._context.variable(name)
+
+    def merge_defines(self, defines: dict[str, Any]) -> None:
+        self._context.merge_defines(defines)

--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -150,6 +150,11 @@ def process_defines(ctx: Context, state: State, tree: Any) -> None:
             ctx.define(state.define_subkey(), value)
             continue
 
+        if key.startswith("otk.external."):
+            new_vars = resolve(ctx, state, call(key, resolve(ctx, state, value)))
+            ctx._variables.update(new_vars)
+            continue
+
         if isinstance(value, dict):
             new_state = state.copy(subkey_add=key)
             process_defines(ctx, new_state, value)

--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -152,7 +152,7 @@ def process_defines(ctx: Context, state: State, tree: Any) -> None:
 
         if key.startswith("otk.external."):
             new_vars = resolve(ctx, state, call(key, resolve(ctx, state, value)))
-            ctx._variables.update(new_vars)
+            ctx.merge_defines(new_vars)
             continue
 
         if isinstance(value, dict):

--- a/test/data/base/13-define-external.json
+++ b/test/data/base/13-define-external.json
@@ -2,6 +2,14 @@
   "pipelines": [
     {
       "a": "b"
+    },
+    {
+      "c": "d"
+    },
+    {
+      "nested": {
+	"sub": "key"
+      }
     }
   ],
   "version": "2",

--- a/test/data/base/13-define-external.json
+++ b/test/data/base/13-define-external.json
@@ -1,0 +1,9 @@
+{
+  "pipelines": [
+    {
+      "a": "b"
+    }
+  ],
+  "version": "2",
+  "sources": {}
+}

--- a/test/data/base/13-define-external.yaml
+++ b/test/data/base/13-define-external.yaml
@@ -3,7 +3,12 @@ otk.version: "1"
 otk.define.name:
   otk.external.mirror:
     a: "b"
+    nested:
+      sub: "key"
+  c: "d"
 
 otk.target.osbuild.name:
   pipelines:
     - a: "${a}"
+    - c: "${c}"
+    - nested: "${nested}"

--- a/test/data/base/13-define-external.yaml
+++ b/test/data/base/13-define-external.yaml
@@ -1,0 +1,9 @@
+otk.version: "1"
+
+otk.define.name:
+  otk.external.mirror:
+    a: "b"
+
+otk.target.osbuild.name:
+  pipelines:
+    - a: "${a}"

--- a/test/data/error/03-nonexistent-external.err
+++ b/test/data/error/03-nonexistent-external.err
@@ -1,0 +1,1 @@
+could not find 'nonexistent' in any search path

--- a/test/data/error/03-nonexistent-external.yaml
+++ b/test/data/error/03-nonexistent-external.yaml
@@ -1,0 +1,4 @@
+otk.version: "1"
+
+otk.target.osbuild.name:
+  otk.external.nonexistent: {}

--- a/test/fake_externals.py
+++ b/test/fake_externals.py
@@ -1,0 +1,23 @@
+import os
+import textwrap
+
+import pytest
+
+
+@pytest.fixture()
+def mirror(tmp_path):
+    os.environ["OTK_EXTERNAL_PATH"] = os.fspath(tmp_path)
+    fake_external_path = tmp_path / "mirror"
+    fake_external_path.write_text(
+        textwrap.dedent("""\
+    #!/usr/bin/python3
+    import json,sys
+    tree=json.loads(sys.stdin.read())
+    print(json.dumps({"tree": tree["tree"]["otk.external.mirror"]}))
+    """)
+    )
+    os.chmod(fake_external_path, 0o755)
+
+    yield tmp_path
+
+    del os.environ["OTK_EXTERNAL_PATH"]

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -1,34 +1,15 @@
 import argparse
 import json
 import pathlib
-import os
-import textwrap
 
 import pytest
 from otk import command
-
-
-@pytest.fixture()
-def mirror(tmp_path):
-    os.environ["OTK_EXTERNAL_PATH"] = os.fspath(tmp_path)
-    fake_external_path = tmp_path / "mirror"
-    fake_external_path.write_text(
-        textwrap.dedent("""\
-    #!/bin/sh
-    cat - > "$0".stdin
-    echo '{"tree": {"some": "result"}}'
-    """)
-    )
-    os.chmod(fake_external_path, 0o755)
-
-    yield tmp_path
-
-    del os.environ["OTK_EXTERNAL_PATH"]
+from .fake_externals import mirror as _mirror
 
 
 @pytest.mark.parametrize("src_yaml",
                          [str(path) for path in (pathlib.Path(__file__).parent / "data/base").glob("*.yaml")])
-def test_command_compile_on_base_examples(tmp_path, src_yaml, mirror):
+def test_command_compile_on_base_examples(tmp_path, src_yaml, _mirror):
     src_yaml = pathlib.Path(src_yaml)
     dst = tmp_path / "out.json"
 


### PR DESCRIPTION
Adds a test that uses a mocked mirror external that returns the subtree directly inside an `otk.define` block. The variable is not available while it should be.