### PR TITLE
otk: error for top-level keys without targets

### DIFF
--- a/src/otk/document.py
+++ b/src/otk/document.py
@@ -2,8 +2,8 @@ import logging
 from copy import deepcopy
 from typing import Any
 
-from .constant import PREFIX_TARGET, NAME_VERSION
-from .error import NoTargetsError, ParseVersionError
+from .constant import PREFIX, PREFIX_TARGET, NAME_VERSION
+from .error import NoTargetsError, ParseError, ParseVersionError
 
 log = logging.getLogger(__name__)
 
@@ -26,6 +26,12 @@ class Omnifest:
         # being an Omnifest.
         if NAME_VERSION not in deserialized_data:
             raise ParseVersionError(f"omnifest must contain a key by the name of {NAME_VERSION!r}")
+
+        # no toplevel keys without a target or an otk directive
+        targetless_keys = [key for key in deserialized_data
+                           if not key.startswith(PREFIX)]
+        if len(targetless_keys):
+            raise ParseError(f"otk file contains top-level keys {targetless_keys} without a target")
 
         target_available = _targets(deserialized_data)
         if not target_available:

--- a/test/data/error/03-lonely-keys.err
+++ b/test/data/error/03-lonely-keys.err
@@ -1,0 +1,1 @@
+otk file contains top-level keys ['targetless'] without a target

--- a/test/data/error/03-lonely-keys.yaml
+++ b/test/data/error/03-lonely-keys.yaml
@@ -1,0 +1,7 @@
+otk.version: 1
+
+otk.target.osbuild.foo:
+  a: 1
+
+targetless:
+  key: value


### PR DESCRIPTION
This commit disallows top level keys that have no targets and are not `otk.` specific. I.e. it disallows something like:
```yaml
otk.version: 1
otk.target.osbuild:

random:
 key: value
```

The rational is that a construct like this may confuse users as the `random:` subtree will not appear in any output or have any other effect.