### PR TITLE
test: simplify naming of yaml/targets

### DIFF
--- a/test/data/base/00-empty.yaml
+++ b/test/data/base/00-empty.yaml
@@ -5,6 +5,6 @@
 # The results of compiling this omnifest are available in `00-empty.json`.
 otk.version: "1"
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     - a: "tree"

--- a/test/data/base/01-define.yaml
+++ b/test/data/base/01-define.yaml
@@ -3,10 +3,10 @@
 # The results of compiling this omnifest are available in `01-define.json`.
 otk.version: "1"
 
-otk.define.name:
+otk.define:
   a: "tree"
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     - a: "${a}"
     - a: "${a}/b"

--- a/test/data/base/02-include.yaml
+++ b/test/data/base/02-include.yaml
@@ -1,6 +1,6 @@
 # This example shows `otk.include` usage in an `otk` omnifest.
 otk.version: "1"
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     - otk.include: "02-include/example.yaml"

--- a/test/data/base/04-op-in-define.yaml
+++ b/test/data/base/04-op-in-define.yaml
@@ -1,12 +1,12 @@
 otk.version: "1"
 
-otk.define.name:
+otk.define:
   foo:
     otk.op.join:
       values:
         - - 1
         - - 2
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     - foo: ${foo}

--- a/test/data/base/05-target-in-include.yaml
+++ b/test/data/base/05-target-in-include.yaml
@@ -1,3 +1,3 @@
 otk.version: "1"
 
-otk.include.name: "05-target-in-include/example.yaml"
+otk.include: "05-target-in-include/example.yaml"

--- a/test/data/base/05-target-in-include/example.yaml
+++ b/test/data/base/05-target-in-include/example.yaml
@@ -1,4 +1,4 @@
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     - foo: bar
       bar: foo

--- a/test/data/base/06-duplicate-define.yaml
+++ b/test/data/base/06-duplicate-define.yaml
@@ -9,7 +9,7 @@ otk.define.b:
   foo:
     zoo: 3
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     - ${foo.bar}
     - ${foo.baz}

--- a/test/data/base/07-double-define.yaml
+++ b/test/data/base/07-double-define.yaml
@@ -7,7 +7,7 @@ otk.define.a:
 otk.define.b:
   zoo: 3
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     - ${bar}
     - ${baz}

--- a/test/data/base/08-type-define.yaml
+++ b/test/data/base/08-type-define.yaml
@@ -8,6 +8,6 @@ otk.define.a:
 otk.define.b:
   bar: "string"
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     - ${bar}

--- a/test/data/base/09-include-with-var.yaml
+++ b/test/data/base/09-include-with-var.yaml
@@ -1,9 +1,9 @@
 # Include a file using a path string that contains a variable
 otk.version: "1"
 
-otk.define.vars:
+otk.define:
   name: "example"
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     - otk.include: "02-include/${name}.yaml"

--- a/test/data/base/09-op.yaml
+++ b/test/data/base/09-op.yaml
@@ -1,6 +1,6 @@
 otk.version: "1"
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     foo:
       otk.op.join:

--- a/test/data/base/10-subdefines.yaml
+++ b/test/data/base/10-subdefines.yaml
@@ -1,6 +1,6 @@
 otk.version: "1"
 
-otk.define.x:
+otk.define:
   a: 1
   b:
     a: 2  # b.a
@@ -8,7 +8,7 @@ otk.define.x:
     inner: "${b.a}"  # 2
 
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   vars:
     - "${a}"
     - "${b}"

--- a/test/data/base/11-define-variants.yaml
+++ b/test/data/base/11-define-variants.yaml
@@ -62,7 +62,7 @@ otk.define.list_to_str_1:
 otk.define.list_to_str_2:
   list_to_str: "I was a list"
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     - name: "dict_to_list"
       stages:

--- a/test/data/base/12-op-join-type.yaml
+++ b/test/data/base/12-op-join-type.yaml
@@ -1,6 +1,6 @@
 otk.version: "1"
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     otk.op.join:
       values:

--- a/test/data/base/13-define-external.yaml
+++ b/test/data/base/13-define-external.yaml
@@ -1,13 +1,13 @@
 otk.version: "1"
 
-otk.define.name:
+otk.define:
   otk.external.mirror:
     a: "b"
     nested:
       sub: "key"
   c: "d"
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     - a: "${a}"
     - c: "${c}"

--- a/test/data/base/13-include-in-subdir/target.yaml
+++ b/test/data/base/13-include-in-subdir/target.yaml
@@ -1,3 +1,3 @@
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     - otk.include: "foo.yaml"

--- a/test/data/error/00-invalid.yaml
+++ b/test/data/error/00-invalid.yaml
@@ -1,5 +1,5 @@
 otk.version: "1"
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     - otk.include: "notexist"

--- a/test/data/error/02-include-in-define.yaml
+++ b/test/data/error/02-include-in-define.yaml
@@ -1,11 +1,11 @@
 otk.version: "1"
 
-otk.define.name:
+otk.define:
   otk.include: "02-include-in-define/example.yaml"
   subkey:
     otk.include: "02-include-in-define/example.yaml"
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     - foo: ${foo}
       bar: ${bar}

--- a/test/data/error/03-nonexistent-external.yaml
+++ b/test/data/error/03-nonexistent-external.yaml
@@ -1,4 +1,4 @@
 otk.version: "1"
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   otk.external.nonexistent: {}

--- a/test/data/error/03-target-should-not-be-list.yaml
+++ b/test/data/error/03-target-should-not-be-list.yaml
@@ -1,4 +1,4 @@
 otk.version: "1"
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   - test: 1

--- a/test/data/error/04-target-should-not-be-string.yaml
+++ b/test/data/error/04-target-should-not-be-string.yaml
@@ -1,3 +1,3 @@
 otk.version: "1"
 
-otk.target.osbuild.name: "test"
+otk.target.osbuild: "test"

--- a/test/data/error/05-target-should-not-contain-version.yaml
+++ b/test/data/error/05-target-should-not-contain-version.yaml
@@ -1,5 +1,5 @@
 otk.version: "1"
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines: "yes"
   version: 1

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -70,7 +70,7 @@ def test_parse_commands_failure(capsys, command, sys_exit_code, sys_exit_message
 
 TEST_ARGUMENT_T_INPUT = """otk.version: "1"
 
-otk.target.osbuild.name:
+otk.target.osbuild:
   pipelines:
     - "test"
 """
@@ -110,7 +110,7 @@ TEST_ARGUMENT_T_OUTPUT1 = """{
          },
 
         # Select the one available target
-        {"command": ["compile", "-t", "osbuild.name", "-o", "OUTPUTFILE", "INPUTFILE"],
+        {"command": ["compile", "-t", "osbuild", "-o", "OUTPUTFILE", "INPUTFILE"],
          "input_data": TEST_ARGUMENT_T_INPUT,
          "output_data": TEST_ARGUMENT_T_OUTPUT,
          "ret_expected": 0,

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -13,7 +13,7 @@ def test_command_compile_on_base_examples(tmp_path, src_yaml, _mirror):
     src_yaml = pathlib.Path(src_yaml)
     dst = tmp_path / "out.json"
 
-    ns = argparse.Namespace(input=src_yaml, output=dst, target="osbuild.name")
+    ns = argparse.Namespace(input=src_yaml, output=dst, target="osbuild")
 
     command.compile(ns)
 
@@ -28,7 +28,7 @@ def test_command_compile_on_base_examples(tmp_path, src_yaml, _mirror):
 def test_errors(src_yaml):
     src_yaml = pathlib.Path(src_yaml)
     expected = src_yaml.with_suffix(".err").read_text(encoding="utf8").strip()
-    ns = argparse.Namespace(input=src_yaml, output="/dev/null", target="osbuild.name")
+    ns = argparse.Namespace(input=src_yaml, output="/dev/null", target="osbuild")
     with pytest.raises(Exception) as exception:
         command.compile(ns)
     assert expected in str(exception.value)


### PR DESCRIPTION
We allow the use of `otk.define.foo` or `otk.target.osbuild.foo`
to ensure when multiple `otk.defines` are done in a single file
it is still valid yaml. However in a lot of our examples we only
have a single `otk.define` in the file or only a single target.
Here there is no need to append a postfix.

This commit simplifies these occurances and removes unneeded
postfixes. They are still valid and some tests needs them but
the are no longer there by default.

We should probably do the same for the `examples/**`.
