### PR TITLE
test: add test that has two includes and fix the resulting fallout

### DIFF
--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -41,14 +41,12 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
     else:
         path = pathlib.Path(arguments.input)
 
-    warn_duplicated_defs = any(arg in getattr(arguments, "warn", [])
-                               for arg in ["duplicate-definition", "all"])
     # First pass of resolving the otk file is "shallow", it will not run
     # externals and not resolve anything under otk.target.*
     #
     # It only exists as convenience for the user so that they do not need
     # to use "-t"
-    doc = Omnifest(path, warn_duplicated_defs=warn_duplicated_defs)
+    doc = Omnifest(path)
 
     target_available = doc.targets
     target_requested = arguments.target
@@ -66,6 +64,8 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
 
     # Now do the real resolve that takes the target into account. It needs
     # a full run so that resolving includes works correctly.
+    warn_duplicated_defs = any(arg in getattr(arguments, "warn", [])
+                               for arg in ["duplicate-definition", "all"])
     doc = Omnifest(path, target=target_requested, warn_duplicated_defs=warn_duplicated_defs)
 
     # and then output by writing to the output

--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -59,7 +59,7 @@ def resolve_dict(ctx: Context, state: State, tree: dict[str, Any]) -> Any:
     - Values under any other key are processed based on their type (see resolve()).
     """
 
-    for key, val in tree.items():
+    for key, val in tree.copy().items():
         # Replace any variables in a value immediately before doing anything
         # else, so that variables defined in strings are considered in the
         # processing of all directives.
@@ -86,7 +86,7 @@ def resolve_dict(ctx: Context, state: State, tree: dict[str, Any]) -> Any:
                         f"First level below a 'target' should be a dictionary (not a {type(target).__name__})")
 
                 tree.update(target)
-                return tree
+                continue
 
             if key.startswith(PREFIX_INCLUDE):
                 tree = tree.copy()  # copy the tree and drop the include directive
@@ -97,7 +97,7 @@ def resolve_dict(ctx: Context, state: State, tree: dict[str, Any]) -> Any:
                     return included
 
                 tree.update(included)
-                return tree
+                continue
 
             # Other directives do *not* allow siblings
             if len(tree) > 1:

--- a/test/data/base/14-include-regression.json
+++ b/test/data/base/14-include-regression.json
@@ -1,0 +1,9 @@
+{
+  "pipelines": [
+    {
+      "build-centos": 9
+    }
+  ],
+  "sources": {},
+  "version": "2"
+}

--- a/test/data/base/14-include-regression.yaml
+++ b/test/data/base/14-include-regression.yaml
@@ -1,0 +1,11 @@
+otk.version: "1"
+
+otk.define:
+  architecture: "x86_64"
+  version: "9"
+
+otk.include: "14-include-regression/centos-9.yaml"
+
+otk.target.osbuild:
+  pipelines:
+    - otk.include: "14-include-regression/build.yaml"

--- a/test/data/base/14-include-regression/build.yaml
+++ b/test/data/base/14-include-regression/build.yaml
@@ -1,0 +1,1 @@
+build-centos: ${centos_ver}

--- a/test/data/base/14-include-regression/centos-9.yaml
+++ b/test/data/base/14-include-regression/centos-9.yaml
@@ -1,0 +1,2 @@
+otk.define:
+  centos_ver: 9


### PR DESCRIPTION
This commit fixes the bug that the loop over a dict returns too early for `otk.target` and for `otk.include` - both need to continue iterating over the dict.

As fallout from this the command.py code also needs a tweak and "duplicated_defintion" warnings are now only printed in the final resolve run (not in the target-discovery phase).

A regression test is added based on the excellent example from Simon (thank you!).