### PR TITLE
test: add tests for directives that do not allow siblings

### DIFF
--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -105,13 +105,14 @@ def resolve_dict(ctx: Context, state: State, tree: dict[str, Any]) -> Any:
                 raise KeyError(f"directive {key} should not have siblings: {keys!r}")
 
             if key.startswith(PREFIX_OP):
+                # return is fine, no siblings allowed
                 return resolve(ctx, state, op(ctx, resolve(ctx, state, val), key))
 
             if key.startswith("otk.external."):
                 # no target, "dry" run
                 if not ctx.target_requested:
                     continue
-
+                # return is fine, no siblings allowed
                 return resolve(ctx, state, call(key, resolve(ctx, state, val)))
 
         tree[key] = resolve(ctx, state, val)

--- a/test/data/error/06-no-two-externals.err
+++ b/test/data/error/06-no-two-externals.err
@@ -1,0 +1,1 @@
+directive otk.external.mirror should not have siblings: ['otk.external.mirror', 'otk.external.other']

--- a/test/data/error/06-no-two-externals.yaml
+++ b/test/data/error/06-no-two-externals.yaml
@@ -1,0 +1,8 @@
+otk.version: 1
+
+otk.target.osbuild:
+  a:
+    otk.external.mirror:
+      a: b
+    otk.external.other:
+      c: d

--- a/test/data/error/07-no-two-op-joins.err
+++ b/test/data/error/07-no-two-op-joins.err
@@ -1,0 +1,1 @@
+directive otk.op.join should not have siblings: ['otk.op.join', 'otk.op.noop']

--- a/test/data/error/07-no-two-op-joins.yaml
+++ b/test/data/error/07-no-two-op-joins.yaml
@@ -1,0 +1,8 @@
+otk.version: 1
+
+otk.target.osbuild:
+  otk.op.join:
+    - 1
+    - 2
+  otk.op.noop:
+    - 3

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -25,7 +25,7 @@ def test_command_compile_on_base_examples(tmp_path, src_yaml, _mirror):
 
 @pytest.mark.parametrize("src_yaml",
                          [str(path) for path in (pathlib.Path(__file__).parent / "data/error").glob("*.yaml")])
-def test_errors(src_yaml):
+def test_errors(src_yaml, _mirror):
     src_yaml = pathlib.Path(src_yaml)
     expected = src_yaml.with_suffix(".err").read_text(encoding="utf8").strip()
     ns = argparse.Namespace(input=src_yaml, output="/dev/null", target="osbuild")


### PR DESCRIPTION
It is not allowed to have multiple `otk.op` or `otk.external` in the same dict today, add a test that makes this explicit.

Fwiw, it's not clear to me why we disallow this but given that it seems a concious decision let's ensure we not change it by accident.