### PR TITLE
targets: toml and json

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,6 +4,7 @@ RUN \
     microdnf install -y \
         python3-pip \
         python3-pyyaml \
+        python3-toml \
         && microdnf clean all
 
 WORKDIR /src

--- a/doc/03-omnifest/01-directive.md
+++ b/doc/03-omnifest/01-directive.md
@@ -23,6 +23,8 @@ A target is necessary for `otk` to generate any outputs. The target is namespace
 The following values are valid for the `<consumer>` part of the key, this list can grow as other image build tooling is supported:
 
 - `osbuild`
+- `toml`
+- `json`
 
 The `<name>` part of the key is free form and allows you to use a descriptive name for the export. Note that there MUST be no duplication of the `<consumer>.<name>` tuple.
 
@@ -177,27 +179,6 @@ otk.define:
   c:
    a: 1
    b: 2
-```
-
-## `otk.meta.<name>`
-
-Under the `otk.meta` namespace any data can be stored that other applications
-need to use from an omnifest.
-
-Expects a `map` for its value.
-
-```yaml
-otk.meta.osbuild-composer:
-  boot_mode: uefi
-  export: image
-  pipelines:
-    build:
-      - root
-    system:
-      - tree
-
-otk.meta.kiwi:
-  label: "A Label"
 ```
 
 ## `otk.external`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dev = [
     "pytest >= 8.0",
     "mypy >= 1.9",
     "types-PyYAML >= 6.0",
+    "types-toml",
     "pre-commit",
     "toml",
     "pylint"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dev = [
     "mypy >= 1.9",
     "types-PyYAML >= 6.0",
     "pre-commit",
+    "toml",
     "pylint"
 ]
 

--- a/src/otk/document.py
+++ b/src/otk/document.py
@@ -8,7 +8,7 @@ from .context import CommonContext, OSBuildContext
 from .error import NoTargetsError, ParseError, ParseVersionError, OTKError
 from .transform import process_include
 from .traversal import State
-from .target import OSBuildTarget
+from .target import OSBuildTarget, JSONTarget
 
 log = logging.getLogger(__name__)
 
@@ -69,9 +69,14 @@ class Omnifest:
 
     def as_target_string(self) -> str:
         # XXX: redo using type-safe target registry
-        if not self._target.startswith("osbuild"):
+        if self._target.startswith("osbuild"):
+            target = OSBuildTarget()
+        elif self._target.startswith("json"):
+            target = JSONTarget()
+        else:
             raise OTKError("only osbuild targets supported right now")
-        target = OSBuildTarget()
+
+        target.ensure_valid(self._tree)
         target.ensure_valid(self._tree)
         return target.as_string(self._osbuild_ctx, self._tree)
 

--- a/src/otk/document.py
+++ b/src/otk/document.py
@@ -8,7 +8,7 @@ from .context import CommonContext, OSBuildContext
 from .error import NoTargetsError, ParseError, ParseVersionError, OTKError
 from .transform import process_include
 from .traversal import State
-from .target import OSBuildTarget, JSONTarget
+from .target import Target, OSBuildTarget, JSONTarget
 
 log = logging.getLogger(__name__)
 
@@ -68,16 +68,15 @@ class Omnifest:
         return _targets(self._tree)
 
     def as_target_string(self) -> str:
+        # By default we use the JSON target
+        target: Target = JSONTarget()
+
         # XXX: redo using type-safe target registry
         if self._target.startswith("osbuild"):
             target = OSBuildTarget()
-        elif self._target.startswith("json"):
-            target = JSONTarget()
-        else:
-            raise OTKError("only osbuild targets supported right now")
 
         target.ensure_valid(self._tree)
-        target.ensure_valid(self._tree)
+
         return target.as_string(self._osbuild_ctx, self._tree)
 
 

--- a/src/otk/target.py
+++ b/src/otk/target.py
@@ -3,6 +3,8 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any
 
+import toml
+
 from .context import CommonContext, OSBuildContext
 from .constant import PREFIX_TARGET
 from .error import ParseError
@@ -41,3 +43,11 @@ class JSONTarget(Target):
 
     def as_string(self, context: CommonContext, tree: Any, pretty: bool = True) -> str:
         return json.dumps(tree, indent=2 if pretty else None)
+
+
+class TOMLTarget(Target):
+    def ensure_valid(self, tree: Any) -> None:
+        return None
+
+    def as_string(self, context: CommonContext, tree: Any, _pretty: bool = True) -> str:
+        return toml.dumps(tree)

--- a/src/otk/target.py
+++ b/src/otk/target.py
@@ -33,3 +33,11 @@ class OSBuildTarget(Target):
         osbuild_tree["sources"] = context.sources
 
         return json.dumps(osbuild_tree, indent=2 if pretty else None)
+
+
+class JSONTarget(Target):
+    def ensure_valid(self, tree: Any) -> None:
+        return None
+
+    def as_string(self, context: CommonContext, tree: Any, pretty: bool = True) -> str:
+        return json.dumps(tree, indent=2 if pretty else None)

--- a/src/otk/target.py
+++ b/src/otk/target.py
@@ -18,16 +18,6 @@ class Target(ABC):
     def as_string(self, context: Any, tree: Any, pretty: bool = True) -> str: ...
 
 
-# NOTE this common target is a bit weird, we probably shouldn't always assume JSON but
-# NOTE it makes development a tad easier until we figure out all our targets
-class CommonTarget(Target):
-    def ensure_valid(self, _tree: Any) -> None:
-        pass
-
-    def as_string(self, context: CommonContext, tree: Any, pretty: bool = True) -> str:
-        return json.dumps(tree, indent=2 if pretty else None)
-
-
 class OSBuildTarget(Target):
     def ensure_valid(self, tree: Any) -> None:
         if "version" in tree:


### PR DESCRIPTION
Provide targets to format data as either JSON or TOML without validation. Replaces the meta keys.