### PR TITLE
test: deal gracefully with empty `otk.defines`

### DIFF
--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -150,6 +150,9 @@ def process_defines(ctx: Context, state: State, tree: Any) -> None:
     defines block the function is working in. New defines are added to the
     nested block but references are resolved from the global ctx.defines.
     """
+    if tree is None:
+        log.warning("empty otk.define in %s", state.path)
+        return
 
     # Iterate over a copy of the tree so that we can modify it in-place.
     for key, value in tree.copy().items():

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -40,3 +40,17 @@ def test_warn(tmp_path, caplog, cmd, warn_arg, expect_warning):
         assert [expected_msg] == [rec.message for rec in caplog.records]
     else:
         assert [] == [rec.message for rec in caplog.records]
+
+
+def test_otk_define_empty(tmp_path, caplog):
+    test_otk = tmp_path / "foo.yaml"
+    test_otk.write_text(textwrap.dedent("""
+    otk.version: 1
+    otk.target.osbuild:
+      otk.define:
+    """))
+    run(["validate", os.fspath(test_otk)])
+    # note that this will appear twice because we resolve the otk file
+    # twice
+    expected_msg = f"empty otk.define in {test_otk}"
+    assert expected_msg in [rec.message for rec in caplog.records]


### PR DESCRIPTION
Deal with an empty `otk.define` in a graceful way. Currently the code will just crash, this commit fixes it by ignoring (and warning) about empty `otk.define`s.