### PR TITLE
otk: allow `otk.define={"a": {}}`

### DIFF
--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -153,6 +153,9 @@ def process_defines(ctx: Context, state: State, tree: Any) -> None:
     if tree is None:
         log.warning("empty otk.define in %s", state.path)
         return
+    if tree == {}:
+        ctx.define(state.define_subkey(), {})
+        return
 
     # Iterate over a copy of the tree so that we can modify it in-place.
     for key, value in tree.copy().items():

--- a/test/data/base/15-double-define-include.json
+++ b/test/data/base/15-double-define-include.json
@@ -1,0 +1,10 @@
+{
+  "pipelines": [
+      1,
+      2,
+      3,
+      {}
+  ],
+  "version": "2",
+  "sources": {}
+}

--- a/test/data/base/15-double-define-include.yaml
+++ b/test/data/base/15-double-define-include.yaml
@@ -1,0 +1,11 @@
+otk.version: "1"
+
+otk.include.a: "15-double-define-include/one.yaml"
+otk.include.b: "15-double-define-include/two.yaml"
+
+otk.target.osbuild:
+  pipelines:
+    - ${bar}
+    - ${baz}
+    - ${zoo}
+    - ${zam}

--- a/test/data/base/15-double-define-include/one.yaml
+++ b/test/data/base/15-double-define-include/one.yaml
@@ -1,0 +1,3 @@
+otk.define:
+  bar: 1
+  baz: 2

--- a/test/data/base/15-double-define-include/two.yaml
+++ b/test/data/base/15-double-define-include/two.yaml
@@ -1,0 +1,3 @@
+otk.define:
+  zoo: 3
+  zam: {}

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -32,6 +32,11 @@ from otk.traversal import State
             {"a": "alpha", "b": {"a": "subalpha", "c": "${b.a}"}},
             {"a": "alpha", "b": {"a": "subalpha", "c": "subalpha"}},
         ),
+        (
+            # special
+            {"a": {}},
+            {"a": {}},
+        ),
     ]
 )
 def test_transform_process_defines(data, defines):


### PR DESCRIPTION
This commit fixes the special case that an define can be an empty
dict.


Base on https://github.com/osbuild/otk/pull/173