### PR TITLE
otk: fix incorrect tree copy in `otk.include`

### DIFF
--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -89,8 +89,7 @@ def resolve_dict(ctx: Context, state: State, tree: dict[str, Any]) -> Any:
                 continue
 
             if key.startswith(PREFIX_INCLUDE):
-                tree = tree.copy()  # copy the tree and drop the include directive
-                del tree[key]
+                del tree[key]  # replace "otk.include" with resolved included data
 
                 included = process_include(ctx, state, pathlib.Path(val))
                 if not isinstance(included, dict):
@@ -116,7 +115,6 @@ def resolve_dict(ctx: Context, state: State, tree: dict[str, Any]) -> Any:
                 return resolve(ctx, state, call(key, resolve(ctx, state, val)))
 
         tree[key] = resolve(ctx, state, val)
-
     return tree
 
 

--- a/test/data/base/16-include-copy.json
+++ b/test/data/base/16-include-copy.json
@@ -1,0 +1,5 @@
+{
+  "sources": {},
+  "version": "2",
+  "id": "centos"
+}

--- a/test/data/base/16-include-copy.yaml
+++ b/test/data/base/16-include-copy.yaml
@@ -1,0 +1,7 @@
+otk.version: 1
+
+otk.define:
+  version: 9
+
+otk.target.osbuild:
+  otk.include: "16-include-copy/repository-${version}.yaml"

--- a/test/data/base/16-include-copy/repository-9.yaml
+++ b/test/data/base/16-include-copy/repository-9.yaml
@@ -1,0 +1,1 @@
+id: "centos"


### PR DESCRIPTION
When trying to compile the example in PR#167 I noticed slightly strange behavior. Currently when doing:
```yaml
otk.target.osbuild:
  otk.include: "16-include-copy/repository-${version}.yaml"
```
the output is
```json
{
     'otk.include': '16-include-copy/repository-${version}.yaml',
     'sources': {},
     'version': '2',
}
```
The reason is that we have an extra `tree.copy()` when we process includes. However in other parts of the code (including accross recursions) we use "tree.update()" so that the tree we worked on and the tree that the other parts of the recursion go out of sync. The easiest fix is to simply drop the copy.