### PR TITLE
pre-commit: add pylint to be checked

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,8 @@ repos:
     rev: v2.3.0
     hooks:
       - id: autopep8
+  - repo: https://github.com/pycqa/pylint
+    rev: v3.2.6
+    hooks:
+      - id: pylint
+        additional_dependencies: ["PyYAML", "types-PyYAML", "pytest"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 .PHONY: lint
 lint:
 	pre-commit run --all-files
-	pylint src/ test/*.py
 
 .PHONY: type
 type:


### PR DESCRIPTION
`pylint` is part of github actions, so it should be checked locally to avoid problems
