### PR TITLE
external: drop external name from schema

### DIFF
--- a/doc/03-omnifest/02-external.md
+++ b/doc/03-omnifest/02-external.md
@@ -23,10 +23,8 @@ The external gets called with the following JSON:
 ```json
 {
   "tree": {
-    "otk.external.name": {
-      "child": [1],
-      "options": "are here"
-    }
+    "child": [1],
+    "options": "are here"
   }
 }
 ```
@@ -77,7 +75,7 @@ Given the following script called `concat` in `/usr/local/libexec/otk/concat`:
 ```bash
 #!/usr/bin/env bash
 
-output="$(jq -jr '.tree."otk.external.concat".parts[]' <<< "${1}")"
+output="$(jq -jr '.tree.parts[]' <<< "${1}")"
 echo "{\"tree\":{\"output\":\"$output\"}}"
 ```
 
@@ -97,13 +95,11 @@ the script is called with the following data on stdin:
 ```json
 {
   "tree": {
-    "otk.external.concat": {
-      "parts": [
-        "list",
-        "of",
-        "strings"
-      ]
-    }
+    "parts": [
+      "list",
+      "of",
+      "strings"
+    ]
   }
 }
 ```

--- a/src/otk/external.py
+++ b/src/otk/external.py
@@ -21,9 +21,7 @@ def call(directive: str, tree: Any) -> Any:
 
     data = json.dumps(
         {
-            "tree": {
-                directive: tree,
-            },
+            "tree": tree,
         }
     )
 

--- a/test/fake_externals.py
+++ b/test/fake_externals.py
@@ -13,7 +13,7 @@ def mirror(tmp_path):
     #!/usr/bin/python3
     import json,sys
     tree=json.loads(sys.stdin.read())
-    print(json.dumps({"tree": tree["tree"]["otk.external.mirror"]}))
+    print(json.dumps({"tree": tree["tree"]}))
     """)
     )
     os.chmod(fake_external_path, 0o755)

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -52,4 +52,4 @@ def test_integration_happy(tmp_path):
     assert res == {"some": "result"}
 
     inp = fake_external_path.with_suffix(".stdin").read_text()
-    assert json.loads(inp) == {"tree": {fake_directive: fake_tree}}
+    assert json.loads(inp) == {"tree": fake_tree}


### PR DESCRIPTION
The external name in the schema serves no good purpose.