### PR TITLE
pre-commit: allow EOL whitespaces in markdown

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,9 +2,11 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
+        args:
+          - --markdown-linebreak-ext=md
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files


### PR DESCRIPTION
in markdown a double whitespace at the end of a line is concidered a newline and nothing bad...

I think this should be the default in all repos