### PR TITLE
src: add `--libdir` to override buildin libdir

### DIFF
--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 import pathlib
 import sys
 from typing import List
@@ -66,7 +67,7 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
     # a full run so that resolving includes works correctly.
     warn_duplicated_defs = any(arg in getattr(arguments, "warn", [])
                                for arg in ["duplicate-definition", "all"])
-    doc = Omnifest(path, target=target_requested, warn_duplicated_defs=warn_duplicated_defs)
+    doc = Omnifest(path, target=target_requested, warn_duplicated_defs=warn_duplicated_defs, libdir=arguments.libdir)
 
     # and then output by writing to the output
     if not dry_run:
@@ -104,6 +105,12 @@ def parser_create() -> argparse.ArgumentParser:
         action='append',
         default=[],
         help="Enable warnings, use 'all' to get all or enable specific warnings. Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "-l",
+        "--libdir",
+        type=os.path.abspath,
+        help="Directory containing externals",
     )
 
     # get a subparser action

--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -46,21 +46,28 @@ class CommonContext(Context):
     _target_requested: str
     _version: Optional[int]
     _variables: dict[str, Any]
+    _libdir: str
 
     def __init__(
         self,
         *,
         target_requested: str = "",
         warn_duplicated_defs: bool = False,
+        libdir: str = "",
     ) -> None:
         self._version = None
         self._variables = {}
         self._target_requested = target_requested
         self.warn_duplicated_defs = warn_duplicated_defs
+        self._libdir = libdir
 
     @property
     def target_requested(self) -> str:
         return self._target_requested
+
+    @property
+    def libdir(self) -> str:
+        return self._libdir
 
     def version(self, v: int) -> None:
         # Set the context version, duplicate definitions with different

--- a/src/otk/document.py
+++ b/src/otk/document.py
@@ -18,9 +18,10 @@ class Omnifest:
     _ctx: CommonContext
     _osbuild_ctx: OSBuildContext
     _target: str
+    _libdir: None
 
-    def __init__(self, path: pathlib.Path, target: str = "", *, warn_duplicated_defs: bool = False) -> None:
-        self._ctx = CommonContext(target_requested=target, warn_duplicated_defs=warn_duplicated_defs)
+    def __init__(self, path: pathlib.Path, target: str = "", *, warn_duplicated_defs: bool = False, libdir: str = "") -> None:
+        self._ctx = CommonContext(target_requested=target, warn_duplicated_defs=warn_duplicated_defs, libdir=libdir)
         self._target = target
         # XXX: redo using a type-safe target registry
         if target:
@@ -66,6 +67,10 @@ class Omnifest:
     def targets(self) -> dict[str, Any]:
         """ Return a dict of target(s) and their subtree(s) """
         return _targets(self._tree)
+
+    @property
+    def libdir(self) -> str:
+        return self._libdir
 
     def as_target_string(self) -> str:
         # XXX: redo using type-safe target registry

--- a/src/otk/external.py
+++ b/src/otk/external.py
@@ -9,15 +9,16 @@ import subprocess
 import os
 from typing import Any
 
+from .context import CommonContext
 from .constant import PREFIX_EXTERNAL
 from .error import ExternalFailedError
 
 log = logging.getLogger(__name__)
 
 
-def call(directive: str, tree: Any) -> Any:
+def call(ctx: CommonContext, directive: str, tree: Any) -> Any:
     exe = exe_from_directive(directive)
-    exe = path_for(exe)
+    exe = path_for(ctx.libdir, exe)
 
     data = json.dumps(
         {
@@ -39,7 +40,7 @@ def exe_from_directive(directive):
     return directive.removeprefix(PREFIX_EXTERNAL)
 
 
-def path_for(exe):
+def path_for(libdir, exe):
     paths = [
         "/usr/local/libexec/otk/external",
         "/usr/libexec/otk/external",
@@ -48,9 +49,11 @@ def path_for(exe):
     ]
 
     env = os.getenv("OTK_EXTERNAL_PATH", None)
-
     if env is not None:
         paths = [env] + paths
+
+    if libdir:
+        paths = [pathlib.Path(libdir) / "external" ] + paths
 
     for pathname in paths:
         path = pathlib.Path(pathname) / exe

--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -115,7 +115,7 @@ def resolve_dict(ctx: Context, state: State, tree: dict[str, Any]) -> Any:
                 if not ctx.target_requested:
                     continue
                 # return is fine, no siblings allowed
-                return resolve(ctx, state, call(key, resolve(ctx, state, val)))
+                return resolve(ctx, state, call(ctx, key, resolve(ctx, state, val)))
 
         tree[key] = resolve(ctx, state, val)
     return tree
@@ -175,7 +175,7 @@ def process_defines(ctx: Context, state: State, tree: Any) -> None:
             continue
 
         if key.startswith("otk.external."):
-            new_vars = resolve(ctx, state, call(key, resolve(ctx, state, value)))
+            new_vars = resolve(ctx, state, call(ctx, key, resolve(ctx, state, value)))
             ctx.merge_defines(state.define_subkey(), new_vars)
             continue
 

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -23,7 +23,7 @@ def test_compile_integration_file(tmp_path):
     input_path.write_text(FAKE_OTK_YAML)
     output_path = tmp_path / "output.txt"
 
-    arguments = argparse.Namespace(input=input_path, output=output_path, target="osbuild.qcow2")
+    arguments = argparse.Namespace(input=input_path, output=output_path, target="osbuild.qcow2", libdir="")
     ret = compile(arguments)
     assert ret == 0
 
@@ -37,7 +37,7 @@ def test_compile_integration_stdin(capsys, monkeypatch):
     os.lseek(mocked_stdin, 0, 0)
     monkeypatch.setattr("sys.stdin", os.fdopen(mocked_stdin))
 
-    arguments = argparse.Namespace(input=None, output=None, target="osbuild.qcow2")
+    arguments = argparse.Namespace(input=None, output=None, target="osbuild.qcow2", libdir="")
     ret = compile(arguments)
     assert ret == 0
 

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -13,7 +13,7 @@ def test_command_compile_on_base_examples(tmp_path, src_yaml, _mirror):
     src_yaml = pathlib.Path(src_yaml)
     dst = tmp_path / "out.json"
 
-    ns = argparse.Namespace(input=src_yaml, output=dst, target="osbuild")
+    ns = argparse.Namespace(input=src_yaml, output=dst, target="osbuild", libdir="")
 
     command.compile(ns)
 
@@ -28,7 +28,7 @@ def test_command_compile_on_base_examples(tmp_path, src_yaml, _mirror):
 def test_errors(src_yaml, _mirror):
     src_yaml = pathlib.Path(src_yaml)
     expected = src_yaml.with_suffix(".err").read_text(encoding="utf8").strip()
-    ns = argparse.Namespace(input=src_yaml, output="/dev/null", target="osbuild")
+    ns = argparse.Namespace(input=src_yaml, output="/dev/null", target="osbuild", libdir="")
     with pytest.raises(Exception) as exception:
         command.compile(ns)
     assert expected in str(exception.value)

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -5,6 +5,7 @@ import textwrap
 import pytest
 
 import otk.external
+from otk.context import CommonContext
 from otk.external import exe_from_directive
 
 
@@ -21,16 +22,19 @@ def test_exe_from_directive(text, exe):
 
 
 def test_external_not_found():
+    ctx = CommonContext()
     fake_directive = "otk.external.not_available"
     fake_tree = {}
     with pytest.raises(RuntimeError) as exc:
-        otk.external.call(fake_directive, fake_tree)
+        otk.external.call(ctx, fake_directive, fake_tree)
     assert "could not find 'not_available' in any search path" in str(exc.value)
 
 
-def test_integration_happy(tmp_path):
-    os.environ["OTK_EXTERNAL_PATH"] = os.fspath(tmp_path)
-    fake_external_path = tmp_path / "test"
+@pytest.fixture(name="test_external")
+def test_external_fixture(tmp_path):
+    """Create a test external with the name "test" that just prints a result"""
+    fake_external_path = tmp_path / "external" / "test"
+    fake_external_path.parent.mkdir(parents=True, exist_ok=True)
     fake_external_path.write_text(
         textwrap.dedent("""\
     #!/bin/sh
@@ -39,17 +43,27 @@ def test_integration_happy(tmp_path):
     """)
     )
     os.chmod(fake_external_path, 0o755)
+    return fake_external_path
 
+
+def test_integration_happy_libdir(test_external):
+    ctx = CommonContext(libdir=test_external.parent.parent)
     fake_directive = "otk.external.test"
-    fake_tree = {
-        "foo": "bar",
-        "sub": {
-            "baz": "foobar",
-        },
-    }
+    fake_tree = {"foo": "bar"}
 
-    res = otk.external.call(fake_directive, fake_tree)
+    res = otk.external.call(ctx, fake_directive, fake_tree)
     assert res == {"some": "result"}
+    inp = test_external.with_suffix(".stdin").read_text()
+    assert json.loads(inp) == {"tree": fake_tree}
 
-    inp = fake_external_path.with_suffix(".stdin").read_text()
+
+def test_integration_happy_env(monkeypatch, test_external):
+    ctx = CommonContext()
+    fake_directive = "otk.external.test"
+    fake_tree = {"foo": "bar"}
+    monkeypatch.setenv("OTK_EXTERNAL_PATH", os.fspath(test_external.parent))
+
+    res = otk.external.call(ctx, fake_directive, fake_tree)
+    assert res == {"some": "result"}
+    inp = test_external.with_suffix(".stdin").read_text()
     assert json.loads(inp) == {"tree": fake_tree}

--- a/test/test_validate.py
+++ b/test/test_validate.py
@@ -10,7 +10,7 @@ from otk.command import validate
     [
         # "GENERATE" is a placeholder to append "tmp_path" from pytest
         (
-            argparse.Namespace(input="GENERATE", output="GENERATE", target=None),
+            argparse.Namespace(input="GENERATE", output="GENERATE", target=None, libdir=""),
             """otk.version: 1
 otk.target.osbuild.qcow2: { test: 1 }
 """,
@@ -18,7 +18,7 @@ otk.target.osbuild.qcow2: { test: 1 }
             None,
         ),
         (
-            argparse.Namespace(input="GENERATE", output=None, target=None),
+            argparse.Namespace(input="GENERATE", output=None, target=None, libdir=""),
             """otk.version: 1
 otk.target.osbuild.qcow2: { test: 1 }
 """,
@@ -26,7 +26,7 @@ otk.target.osbuild.qcow2: { test: 1 }
             None,
         ),
         (
-            argparse.Namespace(input="GENERATE", output="GENERATE", target=None),
+            argparse.Namespace(input="GENERATE", output="GENERATE", target=None, libdir=""),
             """otk.version: 1
 otk.target.osbuild.qcow2: { test: 1 }
 otk.target.osbuild.ami: { test: 2 }


### PR DESCRIPTION
src: add `--libdir` to override buildin libdir

This allows the local developer to easily run local externals. Similar
to the experience with osbuild and given that otk developers will
most likely also run osbuild having the two similar is probably
a good thing.

[draft as the this is only very lightly tested (and not lint happy)]