### PR TITLE
target: don't write `sources` by default

### DIFF
--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -129,12 +129,9 @@ class CommonContext(Context):
 
 class OSBuildContext(Context):
     """Composes in a `GenericContext` while providing support for `osbuild`
-    concepts such as sources."""
-
-    sources: dict[str, list[Any]]
+    concepts."""
 
     def __init__(self, context: CommonContext) -> None:
-        self.sources = {}
         self._context = context
 
     def version(self, v: int) -> None:

--- a/src/otk/target.py
+++ b/src/otk/target.py
@@ -36,10 +36,7 @@ class OSBuildTarget(Target):
                 "The key 'version' is added by otk internally.")
 
     def as_string(self, context: OSBuildContext, tree: Any, pretty: bool = True) -> str:
-        log.debug("as string %r!", context.sources)
-
         osbuild_tree = tree[PREFIX_TARGET + context.target_requested]
         osbuild_tree["version"] = "2"
-        osbuild_tree["sources"] = context.sources
 
         return json.dumps(osbuild_tree, indent=2 if pretty else None)

--- a/test/data/base/00-empty.json
+++ b/test/data/base/00-empty.json
@@ -4,6 +4,5 @@
       "a": "tree"
     }
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }

--- a/test/data/base/01-define.json
+++ b/test/data/base/01-define.json
@@ -7,6 +7,5 @@
       "a": "tree/b"
     }
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }

--- a/test/data/base/02-include.json
+++ b/test/data/base/02-include.json
@@ -5,6 +5,5 @@
       "bar": "foo"
     }
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }

--- a/test/data/base/04-op-in-define.json
+++ b/test/data/base/04-op-in-define.json
@@ -4,6 +4,5 @@
       "foo": [1, 2]
     }
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }

--- a/test/data/base/05-target-in-include.json
+++ b/test/data/base/05-target-in-include.json
@@ -5,6 +5,5 @@
       "bar": "foo"
     }
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }

--- a/test/data/base/06-duplicate-define.json
+++ b/test/data/base/06-duplicate-define.json
@@ -4,6 +4,5 @@
       2,
       3
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }

--- a/test/data/base/07-double-define.json
+++ b/test/data/base/07-double-define.json
@@ -4,6 +4,5 @@
       2,
       3
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }

--- a/test/data/base/08-type-define.json
+++ b/test/data/base/08-type-define.json
@@ -2,6 +2,5 @@
   "pipelines": [
       "string"
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }

--- a/test/data/base/09-include-with-var.json
+++ b/test/data/base/09-include-with-var.json
@@ -5,6 +5,5 @@
       "bar": "foo"
     }
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }

--- a/test/data/base/09-op.json
+++ b/test/data/base/09-op.json
@@ -17,6 +17,5 @@
       6
     ]
   },
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }

--- a/test/data/base/10-subdefines.json
+++ b/test/data/base/10-subdefines.json
@@ -10,6 +10,5 @@
     1,
     2
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }

--- a/test/data/base/11-define-variants.json
+++ b/test/data/base/11-define-variants.json
@@ -51,6 +51,5 @@
       ]
     }
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }

--- a/test/data/base/12-op-join-type.json
+++ b/test/data/base/12-op-join-type.json
@@ -2,6 +2,5 @@
     "pipelines": [
         1, 2, 3, 4, 5, 3.13, "+0.1", true, 6
     ],
-    "version": "2",
-    "sources": {}
+    "version": "2"
 }

--- a/test/data/base/13-define-external.json
+++ b/test/data/base/13-define-external.json
@@ -17,6 +17,5 @@
       }
     }
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }

--- a/test/data/base/13-include-in-subdir.json
+++ b/test/data/base/13-include-in-subdir.json
@@ -4,6 +4,5 @@
       "a": 1
     }
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }

--- a/test/data/base/14-include-regression.json
+++ b/test/data/base/14-include-regression.json
@@ -4,6 +4,5 @@
       "build-centos": 9
     }
   ],
-  "sources": {},
   "version": "2"
 }

--- a/test/data/base/15-double-define-include.json
+++ b/test/data/base/15-double-define-include.json
@@ -5,6 +5,5 @@
       3,
       {}
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }

--- a/test/data/base/16-include-copy.json
+++ b/test/data/base/16-include-copy.json
@@ -1,5 +1,4 @@
 {
-  "sources": {},
   "version": "2",
   "id": "centos"
 }

--- a/test/data/base/17-include-define.json
+++ b/test/data/base/17-include-define.json
@@ -1,5 +1,4 @@
 {
-  "sources": {},
   "version": "2",
   "answer": "is 42"
 }

--- a/test/data/base/18-define-in-target.json
+++ b/test/data/base/18-define-in-target.json
@@ -1,5 +1,4 @@
 {
-  "sources": {},
   "version": "2",
   "a": "b"
 }

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -85,16 +85,14 @@ TEST_ARGUMENT_T_OUTPUT = """{
   "pipelines": [
     "test"
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }"""
 
 TEST_ARGUMENT_T_OUTPUT1 = """{
   "pipelines": [
     "test1"
   ],
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }"""
 
 

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -14,8 +14,7 @@ otk.target.osbuild.qcow2:
 EXPECTED_OTK_TREE = """\
 {
   "test": 1,
-  "version": "2",
-  "sources": {}
+  "version": "2"
 }"""
 
 


### PR DESCRIPTION
Sources are no longer implicit to the osbuild context but will instead be generated explicitly by externals. Remove them from the target, context, and test cases.

I'm splitting out the work of fixing up CentOS started in #169 in separate PRs so #186 can build upon them without it being an unreviewable mess.