### PR TITLE
test: rename testcase

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,9 +1,9 @@
-from .test_against_images_refs import TestCase
+from .test_against_images_refs import _TestCase
 
 
 def pytest_make_parametrize_id(config, val):  # pylint: disable=W0613
     # see https://hackebrot.github.io/pytest-tricks/param_id_func/ and
     # https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.hookspec.pytest_make_parametrize_id
-    if isinstance(val, TestCase):
+    if isinstance(val, _TestCase):
         return f"{val}"
     return None

--- a/test/test_against_images_refs.py
+++ b/test/test_against_images_refs.py
@@ -10,7 +10,7 @@ from otk.command import run
 TEST_DATA_PATH = pathlib.Path(__file__).parent / "data"
 
 
-class TestCase:
+class _TestCase:
     def __init__(self, base, ref_yaml_path):
         self.ref_yaml_path = ref_yaml_path
         rel = self.ref_yaml_path.relative_to(base)
@@ -29,7 +29,7 @@ def reference_manifests():
     tc = []
     base = TEST_DATA_PATH / "images-ref"
     for path in base.glob("*/*/*/*/*.yaml"):
-        tc.append(TestCase(base, path))
+        tc.append(_TestCase(base, path))
     return tc
 
 


### PR DESCRIPTION
With the current naming of this class it gets collected by `pytest` and then warns about it:

```
==================================== warnings summary ====================================
test/test_against_images_refs.py:13
  /home/user/src/rh/otk/test/test_against_images_refs.py:13: PytestCollectionWarning: cannot collect test class 'TestCase' because it has a __init__ constructor (from: test/test_against_images_refs.py)
    class TestCase:
```