### PR TITLE
test: use `sort_keys=False` in the `gen-image-def` helper

### DIFF
--- a/test/data/images-ref/centos/9/x86_64/ami/centos_9-x86_64-ami-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/ami/centos_9-x86_64-ami-empty.yaml
@@ -1,9 +1,12 @@
+version: '2'
 pipelines:
   - name: build
     runner: org.osbuild.centos9
     stages:
-      - inputs:
+      - type: org.osbuild.rpm
+        inputs:
           packages:
+            type: org.osbuild.files
             origin: org.osbuild.source
             references:
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
@@ -27,7 +30,6 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b
-            type: org.osbuild.files
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -86,21 +88,22 @@ pipelines:
               =kkH7
 
               -----END PGP PUBLIC KEY BLOCK-----'
-        type: org.osbuild.rpm
-      - options:
+      - type: org.osbuild.selinux
+        options:
           file_contexts: etc/selinux/targeted/contexts/files/file_contexts
           labels:
             /usr/bin/cp: system_u:object_r:install_exec_t:s0
-        type: org.osbuild.selinux
-  - build: name:build
-    name: os
+  - name: os
+    build: name:build
     stages:
-      - options:
-          kernel_opts: console=tty0 console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295
+      - type: org.osbuild.kernel-cmdline
+        options:
           root_fs_uuid: 1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1
-        type: org.osbuild.kernel-cmdline
-      - inputs:
+          kernel_opts: console=tty0 console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295
+      - type: org.osbuild.rpm
+        inputs:
           packages:
+            type: org.osbuild.files
             origin: org.osbuild.source
             references:
               - id: sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00
@@ -131,7 +134,6 @@ pipelines:
               - id: sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7
               - id: sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
-            type: org.osbuild.files
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -190,35 +192,35 @@ pipelines:
               =kkH7
 
               -----END PGP PUBLIC KEY BLOCK-----'
-        type: org.osbuild.rpm
-      - options:
+      - type: org.osbuild.fix-bls
+        options:
           prefix: ''
-        type: org.osbuild.fix-bls
-      - options:
+      - type: org.osbuild.locale
+        options:
           language: en_US.UTF-8
-        type: org.osbuild.locale
-      - options:
+      - type: org.osbuild.keymap
+        options:
           keymap: us
           x11-keymap:
             layouts:
               - us
-        type: org.osbuild.keymap
-      - options:
+      - type: org.osbuild.timezone
+        options:
           zone: UTC
-        type: org.osbuild.timezone
-      - options:
-          leapsectz: ''
+      - type: org.osbuild.chrony
+        options:
           servers:
             - hostname: 169.254.169.123
-              iburst: true
-              maxpoll: 4
               minpoll: 4
+              maxpoll: 4
+              iburst: true
               prefer: true
-        type: org.osbuild.chrony
-      - options:
+          leapsectz: ''
+      - type: org.osbuild.sysconfig
+        options:
           kernel:
-            default_kernel: kernel
             update_default: true
+            default_kernel: kernel
           network:
             networking: true
             no_zero_conf: true
@@ -232,92 +234,91 @@ pipelines:
                 peerdns: true
                 type: Ethernet
                 userctl: true
-        type: org.osbuild.sysconfig
-      - options:
+      - type: org.osbuild.systemd-logind
+        options:
+          filename: 00-getty-fixes.conf
           config:
             Login:
               NAutoVTs: 0
-          filename: 00-getty-fixes.conf
-        type: org.osbuild.systemd-logind
-      - options:
+      - type: org.osbuild.cloud-init
+        options:
+          filename: 00-rhel-default-user.cfg
           config:
             system_info:
               default_user:
                 name: ec2-user
-          filename: 00-rhel-default-user.cfg
-        type: org.osbuild.cloud-init
-      - options:
+      - type: org.osbuild.modprobe
+        options:
+          filename: blacklist-nouveau.conf
           commands:
             - command: blacklist
               modulename: nouveau
-          filename: blacklist-nouveau.conf
-        type: org.osbuild.modprobe
-      - options:
+      - type: org.osbuild.modprobe
+        options:
+          filename: blacklist-amdgpu.conf
           commands:
             - command: blacklist
               modulename: amdgpu
-          filename: blacklist-amdgpu.conf
-        type: org.osbuild.modprobe
-      - options:
+      - type: org.osbuild.dracut.conf
+        options:
+          filename: sgdisk.conf
           config:
             install_items:
               - sgdisk
-          filename: sgdisk.conf
-        type: org.osbuild.dracut.conf
-      - options:
+      - type: org.osbuild.dracut.conf
+        options:
+          filename: ec2.conf
           config:
             add_drivers:
               - nvme
               - xen-blkfront
-          filename: ec2.conf
-        type: org.osbuild.dracut.conf
-      - options:
+      - type: org.osbuild.systemd.unit
+        options:
+          unit: nm-cloud-setup.service
+          dropin: 10-rh-enable-for-ec2.conf
           config:
             Service:
               Environment:
                 - key: NM_CLOUD_SETUP_EC2
                   value: 'yes'
-          dropin: 10-rh-enable-for-ec2.conf
-          unit: nm-cloud-setup.service
-        type: org.osbuild.systemd.unit
-      - options:
+      - type: org.osbuild.authselect
+        options:
           profile: sssd
-        type: org.osbuild.authselect
-      - options:
+      - type: org.osbuild.sshd.config
+        options:
           config:
             PasswordAuthentication: false
-        type: org.osbuild.sshd.config
-      - options:
+      - type: org.osbuild.fstab
+        options:
           filesystems:
-            - options: defaults
+            - uuid: 1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1
+              vfs_type: xfs
               path: /
-              uuid: 1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1
+              options: defaults
+            - uuid: 44019259-d936-49a3-a807-063467c4551a
               vfs_type: xfs
-            - options: defaults
               path: /boot
-              uuid: 44019259-d936-49a3-a807-063467c4551a
-              vfs_type: xfs
-            - options: defaults,uid=0,gid=0,umask=077,shortname=winnt
-              passno: 2
-              path: /boot/efi
-              uuid: 7B77-95E7
+              options: defaults
+            - uuid: 7B77-95E7
               vfs_type: vfat
-        type: org.osbuild.fstab
-      - options:
+              path: /boot/efi
+              options: defaults,uid=0,gid=0,umask=077,shortname=winnt
+              passno: 2
+      - type: org.osbuild.grub2
+        options:
+          root_fs_uuid: 1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1
           boot_fs_uuid: 44019259-d936-49a3-a807-063467c4551a
-          config:
-            default: saved
           kernel_opts: console=tty0 console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295
           legacy: i386-pc
-          root_fs_uuid: 1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1
-          saved_entry: ffffffffffffffffffffffffffffffff-0-0.noarch
           uefi:
-            unified: true
             vendor: centos
+            unified: true
+          saved_entry: ffffffffffffffffffffffffffffffff-0-0.noarch
           write_cmdline: false
-        type: org.osbuild.grub2
-      - options:
-          default_target: multi-user.target
+          config:
+            default: saved
+      - type: org.osbuild.systemd
+        options:
           enabled_services:
             - sshd
             - NetworkManager
@@ -329,25 +330,21 @@ pipelines:
             - cloud-final
             - reboot.target
             - tuned
-        type: org.osbuild.systemd
-      - options:
+          default_target: multi-user.target
+      - type: org.osbuild.selinux
+        options:
           file_contexts: etc/selinux/targeted/contexts/files/file_contexts
-        type: org.osbuild.selinux
-  - build: name:build
-    name: image
+  - name: image
+    build: name:build
     stages:
-      - options:
+      - type: org.osbuild.truncate
+        options:
           filename: image.raw
           size: '10737418240'
-        type: org.osbuild.truncate
-      - devices:
-          device:
-            options:
-              filename: image.raw
-              lock: true
-            type: org.osbuild.loopback
+      - type: org.osbuild.sfdisk
         options:
           label: gpt
+          uuid: D209C89E-EA5E-4FBD-B161-B461CCE297E0
           partitions:
             - bootable: true
               size: 2048
@@ -366,100 +363,104 @@ pipelines:
               start: 2510848
               type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
               uuid: 6264D520-3FB9-423F-8AB8-7A0A8E3D3562
-          uuid: D209C89E-EA5E-4FBD-B161-B461CCE297E0
-        type: org.osbuild.sfdisk
-      - devices:
+        devices:
           device:
+            type: org.osbuild.loopback
             options:
               filename: image.raw
               lock: true
-              size: 409600
-              start: 4096
-            type: org.osbuild.loopback
+      - type: org.osbuild.mkfs.fat
         options:
           volid: 7B7795E7
-        type: org.osbuild.mkfs.fat
-      - devices:
+        devices:
           device:
-            options:
-              filename: image.raw
-              lock: true
-              size: 2097152
-              start: 413696
             type: org.osbuild.loopback
-        options:
-          label: boot
-          uuid: 44019259-d936-49a3-a807-063467c4551a
-        type: org.osbuild.mkfs.xfs
-      - devices:
-          device:
             options:
               filename: image.raw
-              lock: true
-              size: 18460639
-              start: 2510848
-            type: org.osbuild.loopback
-        options:
-          label: root
-          uuid: 1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1
-        type: org.osbuild.mkfs.xfs
-      - devices:
-          '-':
-            options:
-              filename: image.raw
-              size: 18460639
-              start: 2510848
-            type: org.osbuild.loopback
-          boot:
-            options:
-              filename: image.raw
-              size: 2097152
-              start: 413696
-            type: org.osbuild.loopback
-          boot-efi:
-            options:
-              filename: image.raw
-              size: 409600
               start: 4096
+              size: 409600
+              lock: true
+      - type: org.osbuild.mkfs.xfs
+        options:
+          uuid: 44019259-d936-49a3-a807-063467c4551a
+          label: boot
+        devices:
+          device:
             type: org.osbuild.loopback
+            options:
+              filename: image.raw
+              start: 413696
+              size: 2097152
+              lock: true
+      - type: org.osbuild.mkfs.xfs
+        options:
+          uuid: 1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1
+          label: root
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: image.raw
+              start: 2510848
+              size: 18460639
+              lock: true
+      - type: org.osbuild.copy
         inputs:
           root-tree:
+            type: org.osbuild.tree
             origin: org.osbuild.pipeline
             references:
               - name:os
-            type: org.osbuild.tree
-        mounts:
-          - name: '-'
-            source: '-'
-            target: /
-            type: org.osbuild.xfs
-          - name: boot
-            source: boot
-            target: /boot
-            type: org.osbuild.xfs
-          - name: boot-efi
-            source: boot-efi
-            target: /boot/efi
-            type: org.osbuild.fat
         options:
           paths:
             - from: input://root-tree/
               to: mount://-/
-        type: org.osbuild.copy
-      - options:
-          core:
-            filesystem: xfs
-            partlabel: gpt
-            type: mkimage
+        devices:
+          '-':
+            type: org.osbuild.loopback
+            options:
+              filename: image.raw
+              start: 2510848
+              size: 18460639
+          boot:
+            type: org.osbuild.loopback
+            options:
+              filename: image.raw
+              start: 413696
+              size: 2097152
+          boot-efi:
+            type: org.osbuild.loopback
+            options:
+              filename: image.raw
+              start: 4096
+              size: 409600
+        mounts:
+          - name: '-'
+            type: org.osbuild.xfs
+            source: '-'
+            target: /
+          - name: boot
+            type: org.osbuild.xfs
+            source: boot
+            target: /boot
+          - name: boot-efi
+            type: org.osbuild.fat
+            source: boot-efi
+            target: /boot/efi
+      - type: org.osbuild.grub2.inst
+        options:
           filename: image.raw
-          location: 2048
           platform: i386-pc
-          prefix:
-            number: 2
+          location: 2048
+          core:
+            type: mkimage
             partlabel: gpt
-            path: /grub2
+            filesystem: xfs
+          prefix:
             type: partition
-        type: org.osbuild.grub2.inst
+            partlabel: gpt
+            number: 2
+            path: /grub2
 sources:
   org.osbuild.curl:
     items:
@@ -531,4 +532,3 @@ sources:
         url: https://example.com/repo/packages/yum-utils
       sha256:fed83cba0a72e3b9f6af32c0dbc2c45a0bde5ebcc0a8e4ca27678844d9b82c84:
         url: https://example.com/repo/packages/dhcp-client
-version: '2'

--- a/test/data/images-ref/centos/9/x86_64/qcow2/centos_9-x86_64-qcow2-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/qcow2/centos_9-x86_64-qcow2-empty.yaml
@@ -1,9 +1,12 @@
+version: '2'
 pipelines:
   - name: build
     runner: org.osbuild.centos9
     stages:
-      - inputs:
+      - type: org.osbuild.rpm
+        inputs:
           packages:
+            type: org.osbuild.files
             origin: org.osbuild.source
             references:
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
@@ -26,7 +29,6 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c
-            type: org.osbuild.files
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -85,21 +87,22 @@ pipelines:
               =kkH7
 
               -----END PGP PUBLIC KEY BLOCK-----'
-        type: org.osbuild.rpm
-      - options:
+      - type: org.osbuild.selinux
+        options:
           file_contexts: etc/selinux/targeted/contexts/files/file_contexts
           labels:
             /usr/bin/cp: system_u:object_r:install_exec_t:s0
-        type: org.osbuild.selinux
-  - build: name:build
-    name: os
+  - name: os
+    build: name:build
     stages:
-      - options:
-          kernel_opts: console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0
+      - type: org.osbuild.kernel-cmdline
+        options:
           root_fs_uuid: dde1466f-f75b-4f05-bcf6-8386564c6f79
-        type: org.osbuild.kernel-cmdline
-      - inputs:
+          kernel_opts: console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0
+      - type: org.osbuild.rpm
+        inputs:
           packages:
+            type: org.osbuild.files
             origin: org.osbuild.source
             references:
               - id: sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00
@@ -133,7 +136,6 @@ pipelines:
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
               - id: sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb
               - id: sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff
-            type: org.osbuild.files
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -192,74 +194,69 @@ pipelines:
               =kkH7
 
               -----END PGP PUBLIC KEY BLOCK-----'
-        type: org.osbuild.rpm
-      - options:
+      - type: org.osbuild.fix-bls
+        options:
           prefix: ''
-        type: org.osbuild.fix-bls
-      - options:
+      - type: org.osbuild.locale
+        options:
           language: C.UTF-8
-        type: org.osbuild.locale
-      - options:
+      - type: org.osbuild.timezone
+        options:
           zone: America/New_York
-        type: org.osbuild.timezone
-      - options:
+      - type: org.osbuild.sysconfig
+        options:
           kernel:
-            default_kernel: kernel
             update_default: true
+            default_kernel: kernel
           network:
             networking: true
             no_zero_conf: true
-        type: org.osbuild.sysconfig
-      - options:
+      - type: org.osbuild.fstab
+        options:
           filesystems:
-            - options: defaults
+            - uuid: dde1466f-f75b-4f05-bcf6-8386564c6f79
+              vfs_type: xfs
               path: /
-              uuid: dde1466f-f75b-4f05-bcf6-8386564c6f79
+              options: defaults
+            - uuid: e4520b54-3a3f-4ed3-b8a6-e326beec8e93
               vfs_type: xfs
-            - options: defaults
               path: /boot
-              uuid: e4520b54-3a3f-4ed3-b8a6-e326beec8e93
-              vfs_type: xfs
-            - options: defaults,uid=0,gid=0,umask=077,shortname=winnt
-              passno: 2
-              path: /boot/efi
-              uuid: 7B77-95E7
+              options: defaults
+            - uuid: 7B77-95E7
               vfs_type: vfat
-        type: org.osbuild.fstab
-      - options:
+              path: /boot/efi
+              options: defaults,uid=0,gid=0,umask=077,shortname=winnt
+              passno: 2
+      - type: org.osbuild.grub2
+        options:
+          root_fs_uuid: dde1466f-f75b-4f05-bcf6-8386564c6f79
           boot_fs_uuid: e4520b54-3a3f-4ed3-b8a6-e326beec8e93
-          config:
-            default: saved
           kernel_opts: console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0
           legacy: i386-pc
-          root_fs_uuid: dde1466f-f75b-4f05-bcf6-8386564c6f79
-          saved_entry: ffffffffffffffffffffffffffffffff-0-0.noarch
           uefi:
-            unified: true
             vendor: centos
+            unified: true
+          saved_entry: ffffffffffffffffffffffffffffffff-0-0.noarch
           write_cmdline: false
-        type: org.osbuild.grub2
-      - options:
+          config:
+            default: saved
+      - type: org.osbuild.systemd
+        options:
           default_target: multi-user.target
-        type: org.osbuild.systemd
-      - options:
+      - type: org.osbuild.selinux
+        options:
           file_contexts: etc/selinux/targeted/contexts/files/file_contexts
-        type: org.osbuild.selinux
-  - build: name:build
-    name: image
+  - name: image
+    build: name:build
     stages:
-      - options:
+      - type: org.osbuild.truncate
+        options:
           filename: disk.img
           size: '10737418240'
-        type: org.osbuild.truncate
-      - devices:
-          device:
-            options:
-              filename: disk.img
-              lock: true
-            type: org.osbuild.loopback
+      - type: org.osbuild.sfdisk
         options:
           label: gpt
+          uuid: D209C89E-EA5E-4FBD-B161-B461CCE297E0
           partitions:
             - bootable: true
               size: 2048
@@ -278,116 +275,120 @@ pipelines:
               start: 2510848
               type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
               uuid: 6264D520-3FB9-423F-8AB8-7A0A8E3D3562
-          uuid: D209C89E-EA5E-4FBD-B161-B461CCE297E0
-        type: org.osbuild.sfdisk
-      - devices:
+        devices:
           device:
+            type: org.osbuild.loopback
             options:
               filename: disk.img
               lock: true
-              size: 409600
-              start: 4096
-            type: org.osbuild.loopback
+      - type: org.osbuild.mkfs.fat
         options:
           volid: 7B7795E7
-        type: org.osbuild.mkfs.fat
-      - devices:
+        devices:
           device:
-            options:
-              filename: disk.img
-              lock: true
-              size: 2097152
-              start: 413696
             type: org.osbuild.loopback
-        options:
-          label: boot
-          uuid: e4520b54-3a3f-4ed3-b8a6-e326beec8e93
-        type: org.osbuild.mkfs.xfs
-      - devices:
-          device:
             options:
               filename: disk.img
-              lock: true
-              size: 18460639
-              start: 2510848
-            type: org.osbuild.loopback
-        options:
-          label: root
-          uuid: dde1466f-f75b-4f05-bcf6-8386564c6f79
-        type: org.osbuild.mkfs.xfs
-      - devices:
-          '-':
-            options:
-              filename: disk.img
-              size: 18460639
-              start: 2510848
-            type: org.osbuild.loopback
-          boot:
-            options:
-              filename: disk.img
-              size: 2097152
-              start: 413696
-            type: org.osbuild.loopback
-          boot-efi:
-            options:
-              filename: disk.img
-              size: 409600
               start: 4096
+              size: 409600
+              lock: true
+      - type: org.osbuild.mkfs.xfs
+        options:
+          uuid: e4520b54-3a3f-4ed3-b8a6-e326beec8e93
+          label: boot
+        devices:
+          device:
             type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 413696
+              size: 2097152
+              lock: true
+      - type: org.osbuild.mkfs.xfs
+        options:
+          uuid: dde1466f-f75b-4f05-bcf6-8386564c6f79
+          label: root
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 2510848
+              size: 18460639
+              lock: true
+      - type: org.osbuild.copy
         inputs:
           root-tree:
+            type: org.osbuild.tree
             origin: org.osbuild.pipeline
             references:
               - name:os
-            type: org.osbuild.tree
-        mounts:
-          - name: '-'
-            source: '-'
-            target: /
-            type: org.osbuild.xfs
-          - name: boot
-            source: boot
-            target: /boot
-            type: org.osbuild.xfs
-          - name: boot-efi
-            source: boot-efi
-            target: /boot/efi
-            type: org.osbuild.fat
         options:
           paths:
             - from: input://root-tree/
               to: mount://-/
-        type: org.osbuild.copy
-      - options:
-          core:
-            filesystem: xfs
-            partlabel: gpt
-            type: mkimage
+        devices:
+          '-':
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 2510848
+              size: 18460639
+          boot:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 413696
+              size: 2097152
+          boot-efi:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 4096
+              size: 409600
+        mounts:
+          - name: '-'
+            type: org.osbuild.xfs
+            source: '-'
+            target: /
+          - name: boot
+            type: org.osbuild.xfs
+            source: boot
+            target: /boot
+          - name: boot-efi
+            type: org.osbuild.fat
+            source: boot-efi
+            target: /boot/efi
+      - type: org.osbuild.grub2.inst
+        options:
           filename: disk.img
-          location: 2048
           platform: i386-pc
-          prefix:
-            number: 2
+          location: 2048
+          core:
+            type: mkimage
             partlabel: gpt
-            path: /grub2
+            filesystem: xfs
+          prefix:
             type: partition
-        type: org.osbuild.grub2.inst
-  - build: name:build
-    name: qcow2
+            partlabel: gpt
+            number: 2
+            path: /grub2
+  - name: qcow2
+    build: name:build
     stages:
-      - inputs:
+      - type: org.osbuild.qemu
+        inputs:
           image:
+            type: org.osbuild.files
             origin: org.osbuild.pipeline
             references:
               name:image:
                 file: disk.img
-            type: org.osbuild.files
         options:
           filename: disk.qcow2
           format:
-            compat: '1.1'
             type: qcow2
-        type: org.osbuild.qemu
+            compat: '1.1'
 sources:
   org.osbuild.curl:
     items:
@@ -467,4 +468,3 @@ sources:
         url: https://example.com/repo/packages/systemd
       sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d:
         url: https://example.com/repo/packages/efibootmgr
-version: '2'

--- a/test/data/images-ref/fedora/40/aarch64/minimal-raw/fedora_40-aarch64-minimal_raw-empty.yaml
+++ b/test/data/images-ref/fedora/40/aarch64/minimal-raw/fedora_40-aarch64-minimal_raw-empty.yaml
@@ -1,9 +1,12 @@
+version: '2'
 pipelines:
   - name: build
     runner: org.osbuild.fedora40
     stages:
-      - inputs:
+      - type: org.osbuild.rpm
+        inputs:
           packages:
+            type: org.osbuild.files
             origin: org.osbuild.source
             references:
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
@@ -23,7 +26,6 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a
-            type: org.osbuild.files
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -82,21 +84,22 @@ pipelines:
               =wOl2
 
               -----END PGP PUBLIC KEY BLOCK-----'
-        type: org.osbuild.rpm
-      - options:
+      - type: org.osbuild.selinux
+        options:
           file_contexts: etc/selinux/targeted/contexts/files/file_contexts
           labels:
             /usr/bin/cp: system_u:object_r:install_exec_t:s0
-        type: org.osbuild.selinux
-  - build: name:build
-    name: os
+  - name: os
+    build: name:build
     stages:
-      - options:
-          kernel_opts: ro
+      - type: org.osbuild.kernel-cmdline
+        options:
           root_fs_uuid: b1a2302c-2db6-49d4-bd83-ffcfaf27ba37
-        type: org.osbuild.kernel-cmdline
-      - inputs:
+          kernel_opts: ro
+      - type: org.osbuild.rpm
+        inputs:
           packages:
+            type: org.osbuild.files
             origin: org.osbuild.source
             references:
               - id: sha256:a9b1404916c3972c2d1085be3f747210fa1cd300e84ded13ef370a3041748fff
@@ -118,7 +121,6 @@ pipelines:
               - id: sha256:cc6a02963fb4d1a2974e58cb463b61430aa28e3ddfe44564ef7524db95c0324d
               - id: sha256:c6901c753d002dc687294351488f7f32d417c7d7620dcd985087188654ebf5f0
               - id: sha256:2d7ad6dafb3919522d425e546ac189f12e7a5096bc570cec344a32dbd17bd526
-            type: org.osbuild.files
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -177,91 +179,86 @@ pipelines:
               =wOl2
 
               -----END PGP PUBLIC KEY BLOCK-----'
-        type: org.osbuild.rpm
-      - options:
+      - type: org.osbuild.fix-bls
+        options:
           prefix: ''
-        type: org.osbuild.fix-bls
-      - options:
+      - type: org.osbuild.locale
+        options:
           language: en_US
-        type: org.osbuild.locale
-      - options:
+      - type: org.osbuild.hostname
+        options:
           hostname: localhost.localdomain
-        type: org.osbuild.hostname
-      - options:
+      - type: org.osbuild.timezone
+        options:
           zone: UTC
-        type: org.osbuild.timezone
-      - options:
+      - type: org.osbuild.fstab
+        options:
           filesystems:
-            - options: defaults
+            - uuid: b1a2302c-2db6-49d4-bd83-ffcfaf27ba37
+              vfs_type: ext4
               path: /
-              uuid: b1a2302c-2db6-49d4-bd83-ffcfaf27ba37
+              options: defaults
+            - uuid: 95f06a9d-54e3-4b4e-a9a4-18fccbe0b448
               vfs_type: ext4
-            - options: defaults
               path: /boot
-              uuid: 95f06a9d-54e3-4b4e-a9a4-18fccbe0b448
-              vfs_type: ext4
-            - options: defaults,uid=0,gid=0,umask=077,shortname=winnt
-              passno: 2
-              path: /boot/efi
-              uuid: 7B77-95E7
+              options: defaults
+            - uuid: 7B77-95E7
               vfs_type: vfat
-        type: org.osbuild.fstab
-      - options:
+              path: /boot/efi
+              options: defaults,uid=0,gid=0,umask=077,shortname=winnt
+              passno: 2
+      - type: org.osbuild.grub2
+        options:
+          root_fs_uuid: b1a2302c-2db6-49d4-bd83-ffcfaf27ba37
           boot_fs_uuid: 95f06a9d-54e3-4b4e-a9a4-18fccbe0b448
+          kernel_opts: ro
+          uefi:
+            vendor: fedora
+            unified: true
+          saved_entry: ffffffffffffffffffffffffffffffff-0-0.noarch
+          write_cmdline: false
           config:
             default: saved
             timeout: 5
-          kernel_opts: ro
-          root_fs_uuid: b1a2302c-2db6-49d4-bd83-ffcfaf27ba37
-          saved_entry: ffffffffffffffffffffffffffffffff-0-0.noarch
-          uefi:
-            unified: true
-            vendor: fedora
-          write_cmdline: false
-        type: org.osbuild.grub2
-      - inputs:
+      - type: org.osbuild.copy
+        inputs:
           file-5ef477a297674dc16b6d212f37875f579a51370d9794a36e57cf0ad91562774e:
+            type: org.osbuild.files
             origin: org.osbuild.source
             references:
               - id: sha256:5ef477a297674dc16b6d212f37875f579a51370d9794a36e57cf0ad91562774e
-            type: org.osbuild.files
         options:
           paths:
             - from: input://file-5ef477a297674dc16b6d212f37875f579a51370d9794a36e57cf0ad91562774e/sha256:5ef477a297674dc16b6d212f37875f579a51370d9794a36e57cf0ad91562774e
-              remove_destination: true
               to: tree:///root/anaconda-ks.cfg
-        type: org.osbuild.copy
-      - options:
+              remove_destination: true
+      - type: org.osbuild.chown
+        options:
           items:
             /root/anaconda-ks.cfg:
-              group: root
               user: root
-        type: org.osbuild.chown
-      - options:
+              group: root
+      - type: org.osbuild.systemd
+        options:
           enabled_services:
             - NetworkManager.service
             - firewalld.service
             - initial-setup.service
             - sshd.service
-        type: org.osbuild.systemd
-      - options:
+      - type: org.osbuild.selinux
+        options:
           file_contexts: etc/selinux/targeted/contexts/files/file_contexts
-        type: org.osbuild.selinux
-  - build: name:build
-    name: image
+  - name: image
+    build: name:build
     stages:
-      - options:
+      - type: org.osbuild.truncate
+        options:
           filename: disk.img
           size: '4514119680'
-        type: org.osbuild.truncate
-      - devices:
-          device:
-            options:
-              filename: disk.img
-              lock: true
-            type: org.osbuild.loopback
+      - type: org.osbuild.sfdisk
         options:
           label: dos
+          uuid: '0xc1748067'
           partitions:
             - bootable: true
               size: 409600
@@ -273,142 +270,146 @@ pipelines:
             - size: 6291456
               start: 2525184
               type: '83'
-          uuid: '0xc1748067'
-        type: org.osbuild.sfdisk
-      - devices:
+        devices:
           device:
+            type: org.osbuild.loopback
             options:
               filename: disk.img
               lock: true
-              size: 409600
-              start: 18432
-            type: org.osbuild.loopback
+      - type: org.osbuild.mkfs.fat
         options:
           volid: 7B7795E7
-        type: org.osbuild.mkfs.fat
-      - devices:
+        devices:
           device:
-            options:
-              filename: disk.img
-              lock: true
-              size: 2097152
-              start: 428032
             type: org.osbuild.loopback
-        options:
-          label: boot
-          uuid: 95f06a9d-54e3-4b4e-a9a4-18fccbe0b448
-        type: org.osbuild.mkfs.ext4
-      - devices:
-          device:
             options:
               filename: disk.img
-              lock: true
-              size: 6291456
-              start: 2525184
-            type: org.osbuild.loopback
-        options:
-          label: root
-          uuid: b1a2302c-2db6-49d4-bd83-ffcfaf27ba37
-        type: org.osbuild.mkfs.ext4
-      - devices:
-          '-':
-            options:
-              filename: disk.img
-              size: 6291456
-              start: 2525184
-            type: org.osbuild.loopback
-          boot:
-            options:
-              filename: disk.img
-              size: 2097152
-              start: 428032
-            type: org.osbuild.loopback
-          boot-efi:
-            options:
-              filename: disk.img
-              size: 409600
               start: 18432
+              size: 409600
+              lock: true
+      - type: org.osbuild.mkfs.ext4
+        options:
+          uuid: 95f06a9d-54e3-4b4e-a9a4-18fccbe0b448
+          label: boot
+        devices:
+          device:
             type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 428032
+              size: 2097152
+              lock: true
+      - type: org.osbuild.mkfs.ext4
+        options:
+          uuid: b1a2302c-2db6-49d4-bd83-ffcfaf27ba37
+          label: root
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 2525184
+              size: 6291456
+              lock: true
+      - type: org.osbuild.copy
         inputs:
           root-tree:
+            type: org.osbuild.tree
             origin: org.osbuild.pipeline
             references:
               - name:os
-            type: org.osbuild.tree
-        mounts:
-          - name: '-'
-            source: '-'
-            target: /
-            type: org.osbuild.ext4
-          - name: boot
-            source: boot
-            target: /boot
-            type: org.osbuild.ext4
-          - name: boot-efi
-            source: boot-efi
-            target: /boot/efi
-            type: org.osbuild.fat
         options:
           paths:
             - from: input://root-tree/
               to: mount://-/
-        type: org.osbuild.copy
-      - devices:
+        devices:
           '-':
+            type: org.osbuild.loopback
             options:
               filename: disk.img
-              size: 6291456
               start: 2525184
-            type: org.osbuild.loopback
+              size: 6291456
           boot:
+            type: org.osbuild.loopback
             options:
               filename: disk.img
-              size: 2097152
               start: 428032
-            type: org.osbuild.loopback
+              size: 2097152
           boot-efi:
+            type: org.osbuild.loopback
             options:
               filename: disk.img
-              size: 409600
               start: 18432
-            type: org.osbuild.loopback
+              size: 409600
+        mounts:
+          - name: '-'
+            type: org.osbuild.ext4
+            source: '-'
+            target: /
+          - name: boot
+            type: org.osbuild.ext4
+            source: boot
+            target: /boot
+          - name: boot-efi
+            type: org.osbuild.fat
+            source: boot-efi
+            target: /boot/efi
+      - type: org.osbuild.copy
         inputs:
           root-tree:
+            type: org.osbuild.tree
             origin: org.osbuild.pipeline
             references:
               - name:os
-            type: org.osbuild.tree
-        mounts:
-          - name: '-'
-            source: '-'
-            target: /
-            type: org.osbuild.ext4
-          - name: boot
-            source: boot
-            target: /boot
-            type: org.osbuild.ext4
-          - name: boot-efi
-            source: boot-efi
-            target: /boot/efi
-            type: org.osbuild.fat
         options:
           paths:
             - from: input://root-tree/usr/share/uboot/rpi_arm64/u-boot.bin
               to: mount://-/boot/efi/rpi-u-boot.bin
-        type: org.osbuild.copy
-  - build: name:build
-    name: xz
+        devices:
+          '-':
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 2525184
+              size: 6291456
+          boot:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 428032
+              size: 2097152
+          boot-efi:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 18432
+              size: 409600
+        mounts:
+          - name: '-'
+            type: org.osbuild.ext4
+            source: '-'
+            target: /
+          - name: boot
+            type: org.osbuild.ext4
+            source: boot
+            target: /boot
+          - name: boot-efi
+            type: org.osbuild.fat
+            source: boot-efi
+            target: /boot/efi
+  - name: xz
+    build: name:build
     stages:
-      - inputs:
+      - type: org.osbuild.xz
+        inputs:
           file:
+            type: org.osbuild.files
             origin: org.osbuild.pipeline
             references:
               name:image:
                 file: disk.img
-            type: org.osbuild.files
         options:
           filename: disk.raw.xz
-        type: org.osbuild.xz
 sources:
   org.osbuild.curl:
     items:
@@ -467,6 +468,5 @@ sources:
   org.osbuild.inline:
     items:
       sha256:5ef477a297674dc16b6d212f37875f579a51370d9794a36e57cf0ad91562774e:
-        data: IyBSdW4gaW5pdGlhbC1zZXR1cCBvbiBmaXJzdCBib290CiMgQ3JlYXRlZCBieSBvc2J1aWxkCmZpcnN0Ym9vdCAtLXJlY29uZmlnCg==
         encoding: base64
-version: '2'
+        data: IyBSdW4gaW5pdGlhbC1zZXR1cCBvbiBmaXJzdCBib290CiMgQ3JlYXRlZCBieSBvc2J1aWxkCmZpcnN0Ym9vdCAtLXJlY29uZmlnCg==

--- a/test/data/images-ref/fedora/40/x86_64/minimal-raw/fedora_40-x86_64-minimal_raw-empty.yaml
+++ b/test/data/images-ref/fedora/40/x86_64/minimal-raw/fedora_40-x86_64-minimal_raw-empty.yaml
@@ -1,9 +1,12 @@
+version: '2'
 pipelines:
   - name: build
     runner: org.osbuild.fedora40
     stages:
-      - inputs:
+      - type: org.osbuild.rpm
+        inputs:
           packages:
+            type: org.osbuild.files
             origin: org.osbuild.source
             references:
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
@@ -23,7 +26,6 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a
-            type: org.osbuild.files
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -82,21 +84,22 @@ pipelines:
               =wOl2
 
               -----END PGP PUBLIC KEY BLOCK-----'
-        type: org.osbuild.rpm
-      - options:
+      - type: org.osbuild.selinux
+        options:
           file_contexts: etc/selinux/targeted/contexts/files/file_contexts
           labels:
             /usr/bin/cp: system_u:object_r:install_exec_t:s0
-        type: org.osbuild.selinux
-  - build: name:build
-    name: os
+  - name: os
+    build: name:build
     stages:
-      - options:
-          kernel_opts: ro
+      - type: org.osbuild.kernel-cmdline
+        options:
           root_fs_uuid: bf59b5df-279f-44e3-9320-77de18d2c4f7
-        type: org.osbuild.kernel-cmdline
-      - inputs:
+          kernel_opts: ro
+      - type: org.osbuild.rpm
+        inputs:
           packages:
+            type: org.osbuild.files
             origin: org.osbuild.source
             references:
               - id: sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00
@@ -114,7 +117,6 @@ pipelines:
               - id: sha256:cc6a02963fb4d1a2974e58cb463b61430aa28e3ddfe44564ef7524db95c0324d
               - id: sha256:c6901c753d002dc687294351488f7f32d417c7d7620dcd985087188654ebf5f0
               - id: sha256:2d7ad6dafb3919522d425e546ac189f12e7a5096bc570cec344a32dbd17bd526
-            type: org.osbuild.files
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -173,91 +175,86 @@ pipelines:
               =wOl2
 
               -----END PGP PUBLIC KEY BLOCK-----'
-        type: org.osbuild.rpm
-      - options:
+      - type: org.osbuild.fix-bls
+        options:
           prefix: ''
-        type: org.osbuild.fix-bls
-      - options:
+      - type: org.osbuild.locale
+        options:
           language: en_US
-        type: org.osbuild.locale
-      - options:
+      - type: org.osbuild.hostname
+        options:
           hostname: localhost.localdomain
-        type: org.osbuild.hostname
-      - options:
+      - type: org.osbuild.timezone
+        options:
           zone: UTC
-        type: org.osbuild.timezone
-      - options:
+      - type: org.osbuild.fstab
+        options:
           filesystems:
-            - options: defaults
+            - uuid: bf59b5df-279f-44e3-9320-77de18d2c4f7
+              vfs_type: ext4
               path: /
-              uuid: bf59b5df-279f-44e3-9320-77de18d2c4f7
+              options: defaults
+            - uuid: 183791e1-f506-4579-973c-1af91a080f19
               vfs_type: ext4
-            - options: defaults
               path: /boot
-              uuid: 183791e1-f506-4579-973c-1af91a080f19
-              vfs_type: ext4
-            - options: defaults,uid=0,gid=0,umask=077,shortname=winnt
-              passno: 2
-              path: /boot/efi
-              uuid: 7B77-95E7
+              options: defaults
+            - uuid: 7B77-95E7
               vfs_type: vfat
-        type: org.osbuild.fstab
-      - options:
+              path: /boot/efi
+              options: defaults,uid=0,gid=0,umask=077,shortname=winnt
+              passno: 2
+      - type: org.osbuild.grub2
+        options:
+          root_fs_uuid: bf59b5df-279f-44e3-9320-77de18d2c4f7
           boot_fs_uuid: 183791e1-f506-4579-973c-1af91a080f19
+          kernel_opts: ro
+          uefi:
+            vendor: fedora
+            unified: true
+          saved_entry: ffffffffffffffffffffffffffffffff-0-0.noarch
+          write_cmdline: false
           config:
             default: saved
             timeout: 5
-          kernel_opts: ro
-          root_fs_uuid: bf59b5df-279f-44e3-9320-77de18d2c4f7
-          saved_entry: ffffffffffffffffffffffffffffffff-0-0.noarch
-          uefi:
-            unified: true
-            vendor: fedora
-          write_cmdline: false
-        type: org.osbuild.grub2
-      - inputs:
+      - type: org.osbuild.copy
+        inputs:
           file-5ef477a297674dc16b6d212f37875f579a51370d9794a36e57cf0ad91562774e:
+            type: org.osbuild.files
             origin: org.osbuild.source
             references:
               - id: sha256:5ef477a297674dc16b6d212f37875f579a51370d9794a36e57cf0ad91562774e
-            type: org.osbuild.files
         options:
           paths:
             - from: input://file-5ef477a297674dc16b6d212f37875f579a51370d9794a36e57cf0ad91562774e/sha256:5ef477a297674dc16b6d212f37875f579a51370d9794a36e57cf0ad91562774e
-              remove_destination: true
               to: tree:///root/anaconda-ks.cfg
-        type: org.osbuild.copy
-      - options:
+              remove_destination: true
+      - type: org.osbuild.chown
+        options:
           items:
             /root/anaconda-ks.cfg:
-              group: root
               user: root
-        type: org.osbuild.chown
-      - options:
+              group: root
+      - type: org.osbuild.systemd
+        options:
           enabled_services:
             - NetworkManager.service
             - firewalld.service
             - initial-setup.service
             - sshd.service
-        type: org.osbuild.systemd
-      - options:
+      - type: org.osbuild.selinux
+        options:
           file_contexts: etc/selinux/targeted/contexts/files/file_contexts
-        type: org.osbuild.selinux
-  - build: name:build
-    name: image
+  - name: image
+    build: name:build
     stages:
-      - options:
+      - type: org.osbuild.truncate
+        options:
           filename: disk.img
           size: '4515168256'
-        type: org.osbuild.truncate
-      - devices:
-          device:
-            options:
-              filename: disk.img
-              lock: true
-            type: org.osbuild.loopback
+      - type: org.osbuild.sfdisk
         options:
           label: gpt
+          uuid: D209C89E-EA5E-4FBD-B161-B461CCE297E0
           partitions:
             - size: 409600
               start: 18432
@@ -271,99 +268,103 @@ pipelines:
               start: 2525184
               type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
               uuid: 6264D520-3FB9-423F-8AB8-7A0A8E3D3562
-          uuid: D209C89E-EA5E-4FBD-B161-B461CCE297E0
-        type: org.osbuild.sfdisk
-      - devices:
+        devices:
           device:
+            type: org.osbuild.loopback
             options:
               filename: disk.img
               lock: true
-              size: 409600
-              start: 18432
-            type: org.osbuild.loopback
+      - type: org.osbuild.mkfs.fat
         options:
           volid: 7B7795E7
-        type: org.osbuild.mkfs.fat
-      - devices:
+        devices:
           device:
-            options:
-              filename: disk.img
-              lock: true
-              size: 2097152
-              start: 428032
             type: org.osbuild.loopback
-        options:
-          label: boot
-          uuid: 183791e1-f506-4579-973c-1af91a080f19
-        type: org.osbuild.mkfs.ext4
-      - devices:
-          device:
             options:
               filename: disk.img
-              lock: true
-              size: 6293471
-              start: 2525184
-            type: org.osbuild.loopback
-        options:
-          label: root
-          uuid: bf59b5df-279f-44e3-9320-77de18d2c4f7
-        type: org.osbuild.mkfs.ext4
-      - devices:
-          '-':
-            options:
-              filename: disk.img
-              size: 6293471
-              start: 2525184
-            type: org.osbuild.loopback
-          boot:
-            options:
-              filename: disk.img
-              size: 2097152
-              start: 428032
-            type: org.osbuild.loopback
-          boot-efi:
-            options:
-              filename: disk.img
-              size: 409600
               start: 18432
+              size: 409600
+              lock: true
+      - type: org.osbuild.mkfs.ext4
+        options:
+          uuid: 183791e1-f506-4579-973c-1af91a080f19
+          label: boot
+        devices:
+          device:
             type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 428032
+              size: 2097152
+              lock: true
+      - type: org.osbuild.mkfs.ext4
+        options:
+          uuid: bf59b5df-279f-44e3-9320-77de18d2c4f7
+          label: root
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 2525184
+              size: 6293471
+              lock: true
+      - type: org.osbuild.copy
         inputs:
           root-tree:
+            type: org.osbuild.tree
             origin: org.osbuild.pipeline
             references:
               - name:os
-            type: org.osbuild.tree
-        mounts:
-          - name: '-'
-            source: '-'
-            target: /
-            type: org.osbuild.ext4
-          - name: boot
-            source: boot
-            target: /boot
-            type: org.osbuild.ext4
-          - name: boot-efi
-            source: boot-efi
-            target: /boot/efi
-            type: org.osbuild.fat
         options:
           paths:
             - from: input://root-tree/
               to: mount://-/
-        type: org.osbuild.copy
-  - build: name:build
-    name: xz
+        devices:
+          '-':
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 2525184
+              size: 6293471
+          boot:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 428032
+              size: 2097152
+          boot-efi:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 18432
+              size: 409600
+        mounts:
+          - name: '-'
+            type: org.osbuild.ext4
+            source: '-'
+            target: /
+          - name: boot
+            type: org.osbuild.ext4
+            source: boot
+            target: /boot
+          - name: boot-efi
+            type: org.osbuild.fat
+            source: boot-efi
+            target: /boot/efi
+  - name: xz
+    build: name:build
     stages:
-      - inputs:
+      - type: org.osbuild.xz
+        inputs:
           file:
+            type: org.osbuild.files
             origin: org.osbuild.pipeline
             references:
               name:image:
                 file: disk.img
-            type: org.osbuild.files
         options:
           filename: disk.raw.xz
-        type: org.osbuild.xz
 sources:
   org.osbuild.curl:
     items:
@@ -414,6 +415,5 @@ sources:
   org.osbuild.inline:
     items:
       sha256:5ef477a297674dc16b6d212f37875f579a51370d9794a36e57cf0ad91562774e:
-        data: IyBSdW4gaW5pdGlhbC1zZXR1cCBvbiBmaXJzdCBib290CiMgQ3JlYXRlZCBieSBvc2J1aWxkCmZpcnN0Ym9vdCAtLXJlY29uZmlnCg==
         encoding: base64
-version: '2'
+        data: IyBSdW4gaW5pdGlhbC1zZXR1cCBvbiBmaXJzdCBib290CiMgQ3JlYXRlZCBieSBvc2J1aWxkCmZpcnN0Ym9vdCAtLXJlY29uZmlnCg==

--- a/test/data/images-ref/gen-image-def
+++ b/test/data/images-ref/gen-image-def
@@ -49,7 +49,7 @@ def generate_reference_image(images_base_dir: str, distro_name: str, distro_ver:
         manifest = json.load(fp)
     yaml_path = generated[0].with_suffix(".yaml")
     with yaml_path.open("w", encoding="utf8") as fp:
-        yaml.dump(manifest, fp, Dumper=Dumper)
+        yaml.dump(manifest, fp, Dumper=Dumper, sort_keys=False)
     print(f"image generated in {yaml_path}")
 
 


### PR DESCRIPTION
When generating the "images" library reference yaml we used the
default yaml.dump() implementation. This will reoder the keys
which is undesirable for us as it moves e.g. the `type: ...`
key at the end of a block. But in a osbuild manifest this is
the one of the most important pieces of information.

So this commit changes the code to not sort the yaml keys.

---


test: re-generate the reference images with yaml
 `sort_keys=False`

Trivial update to use the previous commit:
```
./gen-image-def ~/devel/osbuild/images centos 9 x86_64 ami
./gen-image-def ~/devel/osbuild/images fedora 40 x86_64 minimal_raw
./gen-image-def ~/devel/osbuild/images fedora 40 x86_64 minimal-raw
./gen-image-def ~/devel/osbuild/images fedora 40 aarch64 minimal-raw
```
