### PR TITLE
example: tweak `centos9-x86_64` partioning to match upstream

### DIFF
--- a/example/centos/common/gen-partition-table-x86_64.yaml
+++ b/example/centos/common/gen-partition-table-x86_64.yaml
@@ -18,23 +18,20 @@ otk.define:
           label: boot
           size: "1 GiB"
           type: "xfs"
-          # XXX: make default if empty
           fs_mntops: defaults
-          # XXX can we derive this?
+          # XXX: should we derive this automatically from the mountpoint?
           part_type: BC13C2FF-59E6-4262-A352-B275FD6F7172
-          # XXX: yes we use hardcoded uuids
+          # we use hardcoded uuids for compatibility with "images"
           part_uuid: CB07C243-BC44-4717-853E-28852021225B
         - name: root
           mountpoint: /
           label: root
           type: "xfs"
-          # XXX: can/should we be able to leave this empy?
-          size: "5 GiB"
-          # XXX: make default if empty
+          size: "2 GiB"
           fs_mntops: defaults
-          # XXX: can we derive this?
+          # XXX: should we derive this automatically from the mountpoint?
           part_type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
-          # XXX: yes we use hardcoded uuids
+          # we use hardcoded uuids for compatibility with "images"
           part_uuid: 6264D520-3FB9-423F-8AB8-7A0A8E3D3562
   # XXX: it would be nicer if the "fs_options" could be part of their
   # stages directly without this indirection.


### PR DESCRIPTION
The reference partition table for `centos9-x86_64` in [0] has some small divergence:
- different root size
- remove some `XXX` (for now)

This commit fixes this.

[0] https://github.com/osbuild/images/blob/v0.85.0/pkg/distro/rhel/rhel9/partition_tables.go#L25