### PR TITLE
example: extract `grub2` and ue `partition` external in centos9 ami too

### DIFF
--- a/example/centos/centos-9-x86_64-ami.yaml
+++ b/example/centos/centos-9-x86_64-ami.yaml
@@ -1,5 +1,13 @@
 otk.version: "1"
 
+otk.define:
+  filesystem:
+    modifications:
+      filename: "image.raw"
+  kernel:
+    cmdline: console=tty0 console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295
+otk.include: "common/gen-partition-table-x86_64.yaml"
+
 otk.target.osbuild:
   pipelines:
     - name: build
@@ -100,7 +108,7 @@ otk.target.osbuild:
       stages:
         - type: org.osbuild.kernel-cmdline
           options:
-            root_fs_uuid: 1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1
+            root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
             kernel_opts: console=tty0 console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295
         - type: org.osbuild.rpm
           inputs:
@@ -290,35 +298,9 @@ otk.target.osbuild:
           options:
             config:
               PasswordAuthentication: false
-        - type: org.osbuild.fstab
-          options:
-            filesystems:
-              - uuid: 1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1
-                vfs_type: xfs
-                path: /
-                options: defaults
-              - uuid: 44019259-d936-49a3-a807-063467c4551a
-                vfs_type: xfs
-                path: /boot
-                options: defaults
-              - uuid: 7B77-95E7
-                vfs_type: vfat
-                path: /boot/efi
-                options: defaults,uid=0,gid=0,umask=077,shortname=winnt
-                passno: 2
-        - type: org.osbuild.grub2
-          options:
-            root_fs_uuid: 1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1
-            boot_fs_uuid: 44019259-d936-49a3-a807-063467c4551a
-            kernel_opts: console=tty0 console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295
-            legacy: i386-pc
-            uefi:
-              vendor: centos
-              unified: true
-            saved_entry: ffffffffffffffffffffffffffffffff-0-0.noarch
-            write_cmdline: false
-            config:
-              default: saved
+        - otk.external.otk-make-fstab-stage:
+            ${filesystem}
+        - otk.include: fragment/grub2.yaml
         - type: org.osbuild.systemd
           options:
             enabled_services:
@@ -339,130 +321,39 @@ otk.target.osbuild:
     - name: image
       build: name:build
       stages:
-        - type: org.osbuild.truncate
-          options:
-            filename: image.raw
-            size: '10737418240'
-        - type: org.osbuild.sfdisk
-          options:
-            label: gpt
-            uuid: D209C89E-EA5E-4FBD-B161-B461CCE297E0
-            partitions:
-              - bootable: true
-                size: 2048
-                start: 2048
-                type: 21686148-6449-6E6F-744E-656564454649
-                uuid: FAC7F1FB-3E8D-4137-A512-961DE09A5549
-              - size: 409600
-                start: 4096
-                type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
-                uuid: 68B2905B-DF3E-4FB3-80FA-49D1E773AA33
-              - size: 2097152
-                start: 413696
-                type: BC13C2FF-59E6-4262-A352-B275FD6F7172
-                uuid: CB07C243-BC44-4717-853E-28852021225B
-              - size: 18460639
-                start: 2510848
-                type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
-                uuid: 6264D520-3FB9-423F-8AB8-7A0A8E3D3562
-          devices:
-            device:
-              type: org.osbuild.loopback
-              options:
-                filename: image.raw
-                lock: true
-        - type: org.osbuild.mkfs.fat
-          options:
-            volid: 7B7795E7
-          devices:
-            device:
-              type: org.osbuild.loopback
-              options:
-                filename: image.raw
-                start: 4096
-                size: 409600
-                lock: true
-        - type: org.osbuild.mkfs.xfs
-          options:
-            uuid: 44019259-d936-49a3-a807-063467c4551a
-            label: boot
-          devices:
-            device:
-              type: org.osbuild.loopback
-              options:
-                filename: image.raw
-                start: 413696
-                size: 2097152
-                lock: true
-        - type: org.osbuild.mkfs.xfs
-          options:
-            uuid: 1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1
-            label: root
-          devices:
-            device:
-              type: org.osbuild.loopback
-              options:
-                filename: image.raw
-                start: 2510848
-                size: 18460639
-                lock: true
-        - type: org.osbuild.copy
-          inputs:
-            root-tree:
-              type: org.osbuild.tree
-              origin: org.osbuild.pipeline
-              references:
-                - name:os
-          options:
-            paths:
-              - from: input://root-tree/
-                to: mount://-/
-          devices:
-            '-':
-              type: org.osbuild.loopback
-              options:
-                filename: image.raw
-                start: 2510848
-                size: 18460639
-            boot:
-              type: org.osbuild.loopback
-              options:
-                filename: image.raw
-                start: 413696
-                size: 2097152
-            boot-efi:
-              type: org.osbuild.loopback
-              options:
-                filename: image.raw
-                start: 4096
-                size: 409600
-          mounts:
-            - name: '-'
-              type: org.osbuild.xfs
-              source: '-'
-              target: /
-            - name: boot
-              type: org.osbuild.xfs
-              source: boot
-              target: /boot
-            - name: boot-efi
-              type: org.osbuild.fat
-              source: boot-efi
-              target: /boot/efi
-        - type: org.osbuild.grub2.inst
-          options:
-            filename: image.raw
-            platform: i386-pc
-            location: 2048
-            core:
-              type: mkimage
-              partlabel: gpt
-              filesystem: xfs
-            prefix:
-              type: partition
-              partlabel: gpt
-              number: 2
-              path: /grub2
+        otk.op.join:
+          values:
+            - otk.external.otk-make-partition-stages:
+                ${filesystem}
+            - - type: org.osbuild.copy
+                inputs:
+                  root-tree:
+                    type: org.osbuild.tree
+                    origin: org.osbuild.pipeline
+                    references:
+                      - name:os
+                options:
+                  paths:
+                    - from: input://root-tree/
+                      to: mount://-/
+                devices:
+                  ${fs_options.devices}
+                mounts:
+                  ${fs_options.mounts}
+              - type: org.osbuild.grub2.inst
+                options:
+                  filename: image.raw
+                  platform: i386-pc
+                  location: 2048
+                  core:
+                    type: mkimage
+                    partlabel: gpt
+                    filesystem: xfs
+                  prefix:
+                    type: partition
+                    partlabel: gpt
+                    number: 2
+                    path: /grub2
   sources:
     org.osbuild.curl:
       items:

--- a/example/centos/centos-9-x86_64-qcow2.yaml
+++ b/example/centos/centos-9-x86_64-qcow2.yaml
@@ -4,6 +4,8 @@ otk.define:
   filesystem:
     modifications:
     # empty
+  kernel:
+    cmdline: console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0
 otk.include: "common/gen-partition-table-x86_64.yaml"
 
 otk.target.osbuild:
@@ -221,19 +223,7 @@ otk.target.osbuild:
               no_zero_conf: true
         - otk.external.otk-make-fstab-stage:
             ${filesystem}
-        - type: org.osbuild.grub2
-          options:
-            root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
-            boot_fs_uuid: ${filesystem.const.partition_map.boot.uuid}
-            kernel_opts: console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0
-            legacy: i386-pc
-            uefi:
-              vendor: centos
-              unified: true
-            saved_entry: ffffffffffffffffffffffffffffffff-0-0.noarch
-            write_cmdline: false
-            config:
-              default: saved
+        - otk.include: fragment/grub2.yaml
         - type: org.osbuild.systemd
           options:
             default_target: multi-user.target

--- a/example/centos/fragment/grub2.yaml
+++ b/example/centos/fragment/grub2.yaml
@@ -1,14 +1,13 @@
-- type: org.osbuild.grub2
-  options:
-  root_fs_uuid: ${filesystem.root.uuid}
-  boot_fs_uuid: ${filesystem.boot.uuid}
-  kernel_opts: '{{ " ".join(kernel_opts_list) }}'
+type: org.osbuild.grub2
+options:
+  root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
+  boot_fs_uuid: ${filesystem.const.partition_map.boot.uuid}
+  kernel_opts: ${kernel.cmdline}
   legacy: i386-pc
   uefi:
     vendor: centos
     unified: true
-  # TODO: expose this somehow from the depsolve (could also be ${depsolve.kernel...})
-  saved_entry: "ffffffffffffffffffffffffffffffff-${kernel-core.version}"
+  saved_entry: ffffffffffffffffffffffffffffffff-0-0.noarch
   write_cmdline: false
   config:
     default: saved

--- a/test/data/images-ref/centos/9/x86_64/ami/centos_9-x86_64-ami-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/ami/centos_9-x86_64-ami-empty.yaml
@@ -98,7 +98,7 @@ pipelines:
     stages:
       - type: org.osbuild.kernel-cmdline
         options:
-          root_fs_uuid: 1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1
+          root_fs_uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
           kernel_opts: console=tty0 console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295
       - type: org.osbuild.rpm
         inputs:
@@ -291,11 +291,11 @@ pipelines:
       - type: org.osbuild.fstab
         options:
           filesystems:
-            - uuid: 1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1
+            - uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
               vfs_type: xfs
               path: /
               options: defaults
-            - uuid: 44019259-d936-49a3-a807-063467c4551a
+            - uuid: dbd21911-1c4e-4107-8a9f-14fe6e751358
               vfs_type: xfs
               path: /boot
               options: defaults
@@ -306,8 +306,8 @@ pipelines:
               passno: 2
       - type: org.osbuild.grub2
         options:
-          root_fs_uuid: 1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1
-          boot_fs_uuid: 44019259-d936-49a3-a807-063467c4551a
+          root_fs_uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
+          boot_fs_uuid: dbd21911-1c4e-4107-8a9f-14fe6e751358
           kernel_opts: console=tty0 console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295
           legacy: i386-pc
           uefi:
@@ -382,7 +382,7 @@ pipelines:
               lock: true
       - type: org.osbuild.mkfs.xfs
         options:
-          uuid: 44019259-d936-49a3-a807-063467c4551a
+          uuid: dbd21911-1c4e-4107-8a9f-14fe6e751358
           label: boot
         devices:
           device:
@@ -394,7 +394,7 @@ pipelines:
               lock: true
       - type: org.osbuild.mkfs.xfs
         options:
-          uuid: 1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1
+          uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
           label: root
         devices:
           device:

--- a/test/data/images-ref/gen-image-def
+++ b/test/data/images-ref/gen-image-def
@@ -53,10 +53,14 @@ def generate_reference_image(images_base_dir: str, distro_name: str, distro_ver:
     # table code is called slightly differently which means that the UUIDs
     # get out of sync. We need this (f)ugly mapping here to fix that.
     #
-    # "gen-manifests" root UUID -> "otk-gen-partition-table" UUID
+    # "gen-manifests" root UUID -> "otk-gen-partition-table" UUID (qcow2)
     manifest_str = manifest_str.replace("dde1466f-f75b-4f05-bcf6-8386564c6f79", "9851898e-0b30-437d-8fad-51ec16c3697f")
-    # "gen-manifests" boot UUID -> "otk-gen-partition-table" UUID
+    # ami
+    manifest_str = manifest_str.replace("1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1", "9851898e-0b30-437d-8fad-51ec16c3697f")
+    # "gen-manifests" boot UUID -> "otk-gen-partition-table" UUID (qcow2)
     manifest_str = manifest_str.replace("e4520b54-3a3f-4ed3-b8a6-e326beec8e93", "dbd21911-1c4e-4107-8a9f-14fe6e751358")
+    # ami
+    manifest_str = manifest_str.replace("44019259-d936-49a3-a807-063467c4551a", "dbd21911-1c4e-4107-8a9f-14fe6e751358")
 
     # now convert to json
     manifest = json.loads(manifest_str)


### PR DESCRIPTION
This PR uses the partition externals in the `example/centos/centos-9-x86_64-ami.yaml` too. As part of this the grub2 stage fragment got also extracted to avoid some obvious duplication.