### PR TITLE
Use new `otk-make-grub2-inst-stage` stage in centos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ CONTAINERS_STORAGE_THIN_TAGS=containers_image_openpgp exclude_graphdriver_btrfs 
 IMAGES_REF ?= github.com/osbuild/images
 external:
 	mkdir -p "$(SRCDIR)/external"
+	set -e ; \
 	for otk_cmd in gen-partition-table \
 			make-fstab-stage \
 			make-partition-mounts-devices \

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ external:
 	set -e ; \
 	for otk_cmd in gen-partition-table \
 			make-fstab-stage \
+			make-grub2-inst-stage \
 			make-partition-mounts-devices \
 			make-partition-stages; do \
 		GOBIN="$(SRCDIR)/external" go install -tags "$(CONTAINERS_STORAGE_THIN_TAGS)" "$(IMAGES_REF)"/cmd/otk-$${otk_cmd}@main ; \

--- a/Makefile
+++ b/Makefile
@@ -70,5 +70,5 @@ external:
 			make-fstab-stage \
 			make-partition-mounts-devices \
 			make-partition-stages; do \
-		GOBIN="$(SRCDIR)/external" go install -tags "$(CONTAINERS_STORAGE_THIN_TAGS)" "$(IMAGES_REF)"/cmd/otk-$${otk_cmd}@latest ; \
+		GOBIN="$(SRCDIR)/external" go install -tags "$(CONTAINERS_STORAGE_THIN_TAGS)" "$(IMAGES_REF)"/cmd/otk-$${otk_cmd}@main ; \
 	done

--- a/example/centos/centos-9-x86_64-ami.yaml
+++ b/example/centos/centos-9-x86_64-ami.yaml
@@ -340,20 +340,9 @@ otk.target.osbuild:
                   ${fs_options.devices}
                 mounts:
                   ${fs_options.mounts}
-              - type: org.osbuild.grub2.inst
-                options:
-                  filename: image.raw
+              - otk.external.otk-make-grub2-inst-stage:
                   platform: i386-pc
-                  location: 2048
-                  core:
-                    type: mkimage
-                    partlabel: gpt
-                    filesystem: xfs
-                  prefix:
-                    type: partition
-                    partlabel: gpt
-                    number: 2
-                    path: /grub2
+                  filesystem: ${filesystem}
   sources:
     org.osbuild.curl:
       items:

--- a/example/centos/centos-9-x86_64-qcow2.yaml
+++ b/example/centos/centos-9-x86_64-qcow2.yaml
@@ -252,20 +252,9 @@ otk.target.osbuild:
                   ${fs_options.devices}
                 mounts:
                   ${fs_options.mounts}
-              - type: org.osbuild.grub2.inst
-                options:
-                  filename: disk.img
+              - otk.external.otk-make-grub2-inst-stage:
                   platform: i386-pc
-                  location: 2048
-                  core:
-                    type: mkimage
-                    partlabel: gpt
-                    filesystem: xfs
-                  prefix:
-                    type: partition
-                    partlabel: gpt
-                    number: 2
-                    path: /grub2
+                  filesystem: ${filesystem}
     - name: qcow2
       build: name:build
       stages:


### PR DESCRIPTION
Makefile: add new `make-grub2-inst-stage` external

This adds the new `make-grub2-inst-stage` that was added to images
in https://github.com/osbuild/images/pull/916.

---

example: use new `otk-make-grub2-inst-stage` stage in centos

Use the new `otk-make-grub2-inst-stage` to remove hardcoded
values from the centos examples.

