### PR TITLE
test: add a new `normalize_rpm_refs` helper

### DIFF
--- a/test/test_against_images_refs.py
+++ b/test/test_against_images_refs.py
@@ -33,6 +33,50 @@ def reference_manifests():
     return tc
 
 
+def normalize_rpm_refs(manifest):
+    """Normalize the rpm references, i.e. sort and remove duplicationed
+    hashes.
+    """
+    for pipeline in manifest["pipelines"]:
+        for stage in pipeline["stages"]:
+            if stage["type"] == "org.osbuild.rpm":
+                # sort file hashes/remove duplicated hashes ("images will
+                # write duplicated hashes if a package appears multiple
+                # times in it's inputs)
+                ids = set(x["id"]
+                          for x in stage["inputs"]["packages"]["references"])
+                refs = sorted([{"id": i}
+                               for i in ids], key=lambda x: x["id"])
+                stage["inputs"]["packages"]["references"] = refs
+
+
+def test_normalize_rpm_refs():
+    fake_manifest = {
+        "pipelines": [
+            {
+                "name": "foo",
+                "stages": [
+                    {
+                        "type": "org.osbuild.rpm",
+                        "inputs": {
+                            "packages": {
+                                "references": [
+                                    {"id": "sha256:222"},
+                                    {"id": "sha256:222"},
+                                    {"id": "sha256:111"},
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+    normalize_rpm_refs(fake_manifest)
+    assert fake_manifest["pipelines"][0]["stages"][0]["inputs"]["packages"]["references"] == [
+        {"id": "sha256:111"}, {"id": "sha256:222"}]
+
+
 @pytest.mark.parametrize("tc", reference_manifests())
 def test_images_ref(tmp_path, monkeypatch, tc):
     monkeypatch.setenv("OSBUILD_TESTING_RNG_SEED", "0")
@@ -40,6 +84,7 @@ def test_images_ref(tmp_path, monkeypatch, tc):
 
     with tc.ref_yaml_path.open() as fp:
         ref_manifest = yaml.safe_load(fp)
+        normalize_rpm_refs(ref_manifest)
 
     otk_json = tmp_path / "manifest-otk.json"
     run(["compile",
@@ -48,5 +93,6 @@ def test_images_ref(tmp_path, monkeypatch, tc):
          ])
     with otk_json.open() as fp:
         manifest = json.load(fp)
+        normalize_rpm_refs(manifest)
 
     assert manifest == ref_manifest


### PR DESCRIPTION
This commit adds a new `normalize_rpm_refs()` helper that will normalize the rpm file inputs for comparison, i.e. it will sort the hashes and remove duplicates. This is important because the "images" library writes duplicated input rpm packages from the inputs as duplicated hashes into the references.

But in our test we only need to worry about that exactly the right rpm files got included, the order is not important.

[split out from https://github.com/osbuild/otk/pull/196]