### PR TITLE
example: centos9-qcow/ami with depsolve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ format:
 
 .PHONY: test
 test: external
+	cp $(shell (which "osbuild-gen-depsolve-dnf4")) ./external/
+	cp $(shell (which "osbuild-make-depsolve-dnf4-rpm-stage")) ./external/
+	cp $(shell (which "osbuild-make-depsolve-dnf4-curl-source")) ./external/
 	@pytest
 
 .PHONY: push-check

--- a/example/centos/centos-9-x86_64-ami.yaml
+++ b/example/centos/centos-9-x86_64-ami.yaml
@@ -6,6 +6,103 @@ otk.define:
       filename: "image.raw"
   kernel:
     cmdline: console=tty0 console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295
+  packages:
+    build:
+      otk.external.osbuild-gen-depsolve-dnf4:
+        architecture: x86_64
+        module_platform_id: c9s
+        releasever: "9"
+        repositories:
+          - id: "AppStream"
+            baseurl: "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20240901"
+          - id: "BaseOS"
+            baseurl: "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20240901"
+        packages:
+          include:
+            - coreutils
+            - dosfstools
+            - glibc
+            - grub2-pc
+            - platform-python
+            - policycoreutils
+            - python3
+            - python3-pyyaml
+            - rpm
+            - selinux-policy-targeted
+            - systemd
+            - xfsprogs
+            - xz
+          exclude: []
+    os:
+      otk.external.osbuild-gen-depsolve-dnf4:
+        architecture: x86_64
+        module_platform_id: c9s
+        releasever: "9"
+        repositories:
+          - id: "AppStream"
+            baseurl: "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20240901"
+          - id: "BaseOS"
+            baseurl: "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20240901"
+        packages:
+          include:
+            # https://github.com/osbuild/images/blob/v0.86.0/pkg/distro/rhel/rhel9/ami.go#L189
+            # https://github.com/osbuild/images/blob/v0.86.0/pkg/platform/x86_64.go#L37
+            - "@core"
+            - NetworkManager-cloud-setup
+            - authselect-compat
+            - chrony
+            - cloud-init
+            - cloud-utils-growpart
+            - dhcp-client
+            - dosfstools
+            - dracut-config-generic
+            - efibootmgr
+            - gdisk
+            - grub2
+            - grub2-efi-x64
+            - grub2-pc
+            - kernel
+            - langpacks-en
+            - redhat-release
+            - redhat-release-eula
+            - rsync
+            - selinux-policy-targeted
+            - shim-x64
+            - tar
+            - tuned
+            - xfsprogs
+            - yum-utils
+          exclude:
+            - aic94xx-firmware
+            - alsa-firmware
+            - alsa-tools-firmware
+            - biosdevname
+            - firewalld
+            - iprutils
+            - ivtv-firmware
+            - iwl1000-firmware
+            - iwl100-firmware
+            - iwl105-firmware
+            - iwl135-firmware
+            - iwl2000-firmware
+            - iwl2030-firmware
+            - iwl3160-firmware
+            - iwl3945-firmware
+            - iwl4965-firmware
+            - iwl5000-firmware
+            - iwl5150-firmware
+            - iwl6000-firmware
+            - iwl6000g2a-firmware
+            - iwl6000g2b-firmware
+            - iwl6050-firmware
+            - iwl7260-firmware
+            - libertas-sd8686-firmware
+            - libertas-sd8787-firmware
+            - libertas-usb8388-firmware
+            - plymouth
+            - dracut-config-rescue
+            - qemu-guest-agent
+
 otk.include: "common/gen-partition-table-x86_64.yaml"
 
 otk.target.osbuild:
@@ -13,91 +110,10 @@ otk.target.osbuild:
     - name: build
       runner: org.osbuild.centos9
       stages:
-        - type: org.osbuild.rpm
-          inputs:
-            packages:
-              type: org.osbuild.files
-              origin: org.osbuild.source
-              references:
-                - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
-                - id: sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0
-                - id: sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a
-                - id: sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d
-                - id: sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a
-                - id: sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98
-                - id: sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d
-                - id: sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5
-                - id: sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49
-                - id: sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15
-                - id: sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88
-                - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
-                - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
-                - id: sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b
-                - id: sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5
-                - id: sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49
-                - id: sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15
-                - id: sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88
-                - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
-                - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
-                - id: sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b
-          options:
+        - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
+            packageset: ${packages.build}
             gpgkeys:
-              - '-----BEGIN PGP PUBLIC KEY BLOCK-----
-
-
-                mQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn
-
-                rIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ
-
-                8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X
-
-                5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c
-
-                aevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e
-
-                f+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7
-
-                JINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m
-
-                vufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk
-
-                nHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry
-
-                Gat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y
-
-                m4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB
-
-                tDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5
-
-                QGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB
-
-                Ah4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl
-
-                Gy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs
-
-                N3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD
-
-                vOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq
-
-                a0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw
-
-                byaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg
-
-                q4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X
-
-                407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z
-
-                V6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG
-
-                rCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32
-
-                o8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy
-
-                yy+mHmSv
-
-                =kkH7
-
-                -----END PGP PUBLIC KEY BLOCK-----'
+              - "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----"
         - type: org.osbuild.selinux
           options:
             file_contexts: etc/selinux/targeted/contexts/files/file_contexts
@@ -110,98 +126,10 @@ otk.target.osbuild:
           options:
             root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
             kernel_opts: console=tty0 console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295
-        - type: org.osbuild.rpm
-          inputs:
-            packages:
-              type: org.osbuild.files
-              origin: org.osbuild.source
-              references:
-                - id: sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00
-                - id: sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5
-                - id: sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00
-                - id: sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d
-                - id: sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4
-                - id: sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253
-                - id: sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c
-                - id: sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49
-                - id: sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15
-                - id: sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe
-                - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
-                - id: sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a
-                - id: sha256:1ec523ebf26771bd12d4da16d6e041b9be98c6999ab8ad53afc8d82afb56e75c
-                - id: sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe
-                - id: sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942
-                - id: sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f
-                - id: sha256:fed83cba0a72e3b9f6af32c0dbc2c45a0bde5ebcc0a8e4ca27678844d9b82c84
-                - id: sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694
-                - id: sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00
-                - id: sha256:368f9ec3b56023c66a7e2a4bd2609dced16bbd5354833cbb3e2eec5c90462133
-                - id: sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a
-                - id: sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053
-                - id: sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6
-                - id: sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca
-                - id: sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334
-                - id: sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7
-                - id: sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb
-                - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
-          options:
+        - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
+            packageset: ${packages.os}
             gpgkeys:
-              - '-----BEGIN PGP PUBLIC KEY BLOCK-----
-
-
-                mQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn
-
-                rIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ
-
-                8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X
-
-                5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c
-
-                aevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e
-
-                f+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7
-
-                JINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m
-
-                vufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk
-
-                nHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry
-
-                Gat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y
-
-                m4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB
-
-                tDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5
-
-                QGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB
-
-                Ah4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl
-
-                Gy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs
-
-                N3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD
-
-                vOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq
-
-                a0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw
-
-                byaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg
-
-                q4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X
-
-                407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z
-
-                V6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG
-
-                rCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32
-
-                o8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy
-
-                yy+mHmSv
-
-                =kkH7
-
-                -----END PGP PUBLIC KEY BLOCK-----'
+              - "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----"
         - type: org.osbuild.fix-bls
           options:
             prefix: ''
@@ -344,73 +272,7 @@ otk.target.osbuild:
                   platform: i386-pc
                   filesystem: ${filesystem}
   sources:
-    org.osbuild.curl:
-      items:
-        sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
-          url: https://example.com/repo/packages/dosfstools
-        sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca:
-          url: https://example.com/repo/packages/redhat-release
-        sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d:
-          url: https://example.com/repo/packages/glibc
-        sha256:1ec523ebf26771bd12d4da16d6e041b9be98c6999ab8ad53afc8d82afb56e75c:
-          url: https://example.com/repo/packages/authselect-compat
-        sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49:
-          url: https://example.com/repo/packages/xfsprogs
-        sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053:
-          url: https://example.com/repo/packages/langpacks-en
-        sha256:368f9ec3b56023c66a7e2a4bd2609dced16bbd5354833cbb3e2eec5c90462133:
-          url: https://example.com/repo/packages/gdisk
-        sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
-          url: https://example.com/repo/packages/coreutils
-        sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942:
-          url: https://example.com/repo/packages/cloud-init
-        sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a:
-          url: https://example.com/repo/packages/@core
-        sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b:
-          url: https://example.com/repo/packages/python3-pyyaml
-        sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00:
-          url: https://example.com/repo/packages/dracut-config-generic
-        sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe:
-          url: https://example.com/repo/packages/chrony
-        sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c:
-          url: https://example.com/repo/packages/kernel
-        sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334:
-          url: https://example.com/repo/packages/redhat-release-eula
-        sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
-          url: https://example.com/repo/packages/platform-python
-        sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a:
-          url: https://example.com/repo/packages/xz
-        sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7:
-          url: https://example.com/repo/packages/rsync
-        sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb:
-          url: https://example.com/repo/packages/tar
-        sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253:
-          url: https://example.com/repo/packages/shim-x64
-        sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700:
-          url: https://example.com/repo/packages/policycoreutils
-        sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88:
-          url: https://example.com/repo/packages/rpm
-        sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5:
-          url: https://example.com/repo/packages/grub2-pc
-        sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f:
-          url: https://example.com/repo/packages/cloud-utils-growpart
-        sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb:
-          url: https://example.com/repo/packages/tuned
-        sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528:
-          url: https://example.com/repo/packages/selinux-policy-targeted
-        sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:
-          url: https://example.com/repo/packages/python3
-        sha256:d90b7202318ad799fdf7fc011a6a3d09cb586853981e5c53f381c771e0dc549a:
-          url: https://example.com/repo/packages/grub2
-        sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4:
-          url: https://example.com/repo/packages/grub2-efi-x64
-        sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98:
-          url: https://example.com/repo/packages/systemd
-        sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d:
-          url: https://example.com/repo/packages/efibootmgr
-        sha256:fcb160b10ea6f210b8da239c09ea1b28cbcefefe1502486111fcd5ac6d8d99a6:
-          url: https://example.com/repo/packages/NetworkManager-cloud-setup
-        sha256:fe841d961c3a0038f8a5d15250baff1c2e8efee10e72292ceb5bab8f2633f694:
-          url: https://example.com/repo/packages/yum-utils
-        sha256:fed83cba0a72e3b9f6af32c0dbc2c45a0bde5ebcc0a8e4ca27678844d9b82c84:
-          url: https://example.com/repo/packages/dhcp-client
+    otk.external.osbuild-make-depsolve-dnf4-curl-source:
+      packagesets:
+        - ${packages.build}
+        - ${packages.os}

--- a/example/centos/centos-9-x86_64-qcow2.yaml
+++ b/example/centos/centos-9-x86_64-qcow2.yaml
@@ -6,6 +6,111 @@ otk.define:
     # empty
   kernel:
     cmdline: console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0
+  packages:
+    build:
+      otk.external.osbuild-gen-depsolve-dnf4:
+        architecture: x86_64
+        module_platform_id: c9s
+        releasever: "9"
+        repositories:
+          - id: "AppStream"
+            baseurl: "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20240901"
+          - id: "BaseOS"
+            baseurl: "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20240901"
+        packages:
+          include:
+            - coreutils
+            - dosfstools
+            - glibc
+            - grub2-pc
+            - platform-python
+            - policycoreutils
+            - python3
+            - qemu-img
+            - rpm
+            - selinux-policy-targeted
+            - systemd
+            - xfsprogs
+            - xz
+          exclude: []
+    os:
+      otk.external.osbuild-gen-depsolve-dnf4:
+        architecture: x86_64
+        module_platform_id: c9s
+        releasever: "9"
+        repositories:
+          - id: "AppStream"
+            baseurl: "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20240901"
+          - id: "BaseOS"
+            baseurl: "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20240901"
+        packages:
+          include:
+            - "@core"
+            - authselect-compat
+            - chrony
+            - cloud-init
+            - cloud-utils-growpart
+            - cockpit-system
+            - cockpit-ws
+            - dnf-utils
+            - dosfstools
+            - dracut-config-generic
+            - efibootmgr
+            - grub2-efi-x64
+            - grub2-pc
+            - kernel
+            - nfs-utils
+            - oddjob
+            - oddjob-mkhomedir
+            - psmisc
+            - python3-jsonschema
+            - qemu-guest-agent
+            - redhat-release
+            - redhat-release-eula
+            - rsync
+            - selinux-policy-targeted
+            - shim-x64
+            - tar
+            - tcpdump
+            - tuned
+            - xfsprogs
+          exclude:
+            - aic94xx-firmware
+            - alsa-firmware
+            - alsa-lib
+            - alsa-tools-firmware
+            - biosdevname
+            - dnf-plugin-spacewalk
+            - dracut-config-rescue
+            - fedora-release
+            - fedora-repos
+            - firewalld
+            - iprutils
+            - ivtv-firmware
+            - iwl100-firmware
+            - iwl1000-firmware
+            - iwl105-firmware
+            - iwl135-firmware
+            - iwl2000-firmware
+            - iwl2030-firmware
+            - iwl3160-firmware
+            - iwl3945-firmware
+            - iwl4965-firmware
+            - iwl5000-firmware
+            - iwl5150-firmware
+            - iwl6000-firmware
+            - iwl6000g2a-firmware
+            - iwl6000g2b-firmware
+            - iwl6050-firmware
+            - iwl7260-firmware
+            - langpacks-*
+            - langpacks-en
+            - libertas-sd8787-firmware
+            - nss
+            - plymouth
+            - rng-tools
+            - udisks2
+
 otk.include: "common/gen-partition-table-x86_64.yaml"
 
 otk.target.osbuild:
@@ -13,90 +118,10 @@ otk.target.osbuild:
     - name: build
       runner: org.osbuild.centos9
       stages:
-        - type: org.osbuild.rpm
-          inputs:
-            packages:
-              type: org.osbuild.files
-              origin: org.osbuild.source
-              references:
-                - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
-                - id: sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0
-                - id: sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a
-                - id: sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d
-                - id: sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a
-                - id: sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98
-                - id: sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d
-                - id: sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5
-                - id: sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49
-                - id: sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15
-                - id: sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88
-                - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
-                - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
-                - id: sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5
-                - id: sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49
-                - id: sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15
-                - id: sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88
-                - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
-                - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
-                - id: sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c
-          options:
+        - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
+            packageset: ${packages.build}
             gpgkeys:
-              - '-----BEGIN PGP PUBLIC KEY BLOCK-----
-
-
-                mQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn
-
-                rIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ
-
-                8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X
-
-                5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c
-
-                aevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e
-
-                f+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7
-
-                JINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m
-
-                vufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk
-
-                nHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry
-
-                Gat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y
-
-                m4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB
-
-                tDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5
-
-                QGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB
-
-                Ah4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl
-
-                Gy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs
-
-                N3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD
-
-                vOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq
-
-                a0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw
-
-                byaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg
-
-                q4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X
-
-                407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z
-
-                V6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG
-
-                rCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32
-
-                o8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy
-
-                yy+mHmSv
-
-                =kkH7
-
-                -----END PGP PUBLIC KEY BLOCK-----'
+              - "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----"
         - type: org.osbuild.selinux
           options:
             file_contexts: etc/selinux/targeted/contexts/files/file_contexts
@@ -109,101 +134,10 @@ otk.target.osbuild:
           options:
             root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
             kernel_opts: console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0
-        - type: org.osbuild.rpm
-          inputs:
-            packages:
-              type: org.osbuild.files
-              origin: org.osbuild.source
-              references:
-                - id: sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00
-                - id: sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5
-                - id: sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00
-                - id: sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d
-                - id: sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4
-                - id: sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253
-                - id: sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c
-                - id: sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49
-                - id: sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15
-                - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
-                - id: sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a
-                - id: sha256:1ec523ebf26771bd12d4da16d6e041b9be98c6999ab8ad53afc8d82afb56e75c
-                - id: sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe
-                - id: sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942
-                - id: sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f
-                - id: sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc
-                - id: sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828
-                - id: sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6
-                - id: sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15
-                - id: sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf
-                - id: sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d
-                - id: sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901
-                - id: sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2
-                - id: sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee
-                - id: sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5
-                - id: sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca
-                - id: sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334
-                - id: sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7
-                - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
-                - id: sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb
-                - id: sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff
-          options:
+        - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
+            packageset: ${packages.os}
             gpgkeys:
-              - '-----BEGIN PGP PUBLIC KEY BLOCK-----
-
-
-                mQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn
-
-                rIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ
-
-                8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X
-
-                5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c
-
-                aevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e
-
-                f+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7
-
-                JINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m
-
-                vufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk
-
-                nHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry
-
-                Gat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y
-
-                m4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB
-
-                tDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5
-
-                QGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB
-
-                Ah4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl
-
-                Gy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs
-
-                N3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD
-
-                vOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq
-
-                a0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw
-
-                byaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg
-
-                q4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X
-
-                407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z
-
-                V6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG
-
-                rCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32
-
-                o8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy
-
-                yy+mHmSv
-
-                =kkH7
-
-                -----END PGP PUBLIC KEY BLOCK-----'
+              - "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB\nAh4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl\nGy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs\nN3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD\nvOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq\na0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw\nbyaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg\nq4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X\n407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z\nV6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG\nrCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32\no8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy\nyy+mHmSv\n=kkH7\n-----END PGP PUBLIC KEY BLOCK-----"
         - type: org.osbuild.fix-bls
           options:
             prefix: ''
@@ -272,81 +206,7 @@ otk.target.osbuild:
               type: qcow2
               compat: '1.1'
   sources:
-    org.osbuild.curl:
-      items:
-        sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
-          url: https://example.com/repo/packages/dosfstools
-        sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca:
-          url: https://example.com/repo/packages/redhat-release
-        sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d:
-          url: https://example.com/repo/packages/glibc
-        sha256:1ec523ebf26771bd12d4da16d6e041b9be98c6999ab8ad53afc8d82afb56e75c:
-          url: https://example.com/repo/packages/authselect-compat
-        sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49:
-          url: https://example.com/repo/packages/xfsprogs
-        sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee:
-          url: https://example.com/repo/packages/python3-jsonschema
-        sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff:
-          url: https://example.com/repo/packages/tcpdump
-        sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901:
-          url: https://example.com/repo/packages/oddjob-mkhomedir
-        sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c:
-          url: https://example.com/repo/packages/qemu-img
-        sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
-          url: https://example.com/repo/packages/coreutils
-        sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942:
-          url: https://example.com/repo/packages/cloud-init
-        sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d:
-          url: https://example.com/repo/packages/oddjob
-        sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a:
-          url: https://example.com/repo/packages/@core
-        sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00:
-          url: https://example.com/repo/packages/dracut-config-generic
-        sha256:5fdc7e383dc7e1b390e40c3012a2aa03978901c45f3597c1c239c51134d03dbe:
-          url: https://example.com/repo/packages/chrony
-        sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c:
-          url: https://example.com/repo/packages/kernel
-        sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334:
-          url: https://example.com/repo/packages/redhat-release-eula
-        sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5:
-          url: https://example.com/repo/packages/qemu-guest-agent
-        sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
-          url: https://example.com/repo/packages/platform-python
-        sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a:
-          url: https://example.com/repo/packages/xz
-        sha256:8ff8d40e4a4c726df40795e3134432ac66f7d055d54639c1026e341b6d2bd6e7:
-          url: https://example.com/repo/packages/rsync
-        sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb:
-          url: https://example.com/repo/packages/tar
-        sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253:
-          url: https://example.com/repo/packages/shim-x64
-        sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700:
-          url: https://example.com/repo/packages/policycoreutils
-        sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88:
-          url: https://example.com/repo/packages/rpm
-        sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5:
-          url: https://example.com/repo/packages/grub2-pc
-        sha256:a77e9cdc1f34c916ec906e61eb889974e144e2e0a8dd613d191f5d877cf2774f:
-          url: https://example.com/repo/packages/cloud-utils-growpart
-        sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb:
-          url: https://example.com/repo/packages/tuned
-        sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2:
-          url: https://example.com/repo/packages/psmisc
-        sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528:
-          url: https://example.com/repo/packages/selinux-policy-targeted
-        sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:
-          url: https://example.com/repo/packages/python3
-        sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828:
-          url: https://example.com/repo/packages/cockpit-ws
-        sha256:cf23a0e72ee5bed7a2cce02a3b6115e97c593554600931c5f348a1f304f93bb6:
-          url: https://example.com/repo/packages/dnf-utils
-        sha256:d7d0ecd0d4332981facb2d959fcd8c2e710f237cf34554b4884de1c3159160cc:
-          url: https://example.com/repo/packages/cockpit-system
-        sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4:
-          url: https://example.com/repo/packages/grub2-efi-x64
-        sha256:dfff1585cd84bf13177a09e93d70be3a39c3bec554f1215a5a4fe5c92bbae8bf:
-          url: https://example.com/repo/packages/nfs-utils
-        sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98:
-          url: https://example.com/repo/packages/systemd
-        sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d:
-          url: https://example.com/repo/packages/efibootmgr
+    otk.external.osbuild-make-depsolve-dnf4-curl-source:
+      packagesets:
+        - ${packages.build}
+        - ${packages.os}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ dependencies = [
 
 [project.scripts]
 otk = "otk.command:root"
-osbuild-gen-depsolve-dnf4 = "otk_external_osbuild.command.gen_depsolve_dnf4:root"
-osbuild-make-depsolve-dnf4-rpm-stage = "otk_external_osbuild.command.make_depsolve_dnf4_rpm_stage:root"
-osbuild-make-depsolve-dnf4-curl-source = "otk_external_osbuild.command.make_depsolve_dnf4_curl_source:root"
+osbuild-gen-depsolve-dnf4 = "otk_external_osbuild.command.gen_depsolve_dnf4:main"
+osbuild-make-depsolve-dnf4-rpm-stage = "otk_external_osbuild.command.make_depsolve_dnf4_rpm_stage:main"
+osbuild-make-depsolve-dnf4-curl-source = "otk_external_osbuild.command.make_depsolve_dnf4_curl_source:main"
 
 [project.optional-dependencies]
 dev = [

--- a/test/test_against_images_refs.py
+++ b/test/test_against_images_refs.py
@@ -81,6 +81,7 @@ def test_normalize_rpm_refs():
 def test_images_ref(tmp_path, monkeypatch, tc):
     monkeypatch.setenv("OSBUILD_TESTING_RNG_SEED", "0")
     monkeypatch.setenv("OTK_EXTERNAL_PATH", "./external")
+    monkeypatch.setenv("OTK_UNDER_TEST", "1")
 
     with tc.ref_yaml_path.open() as fp:
         ref_manifest = yaml.safe_load(fp)


### PR DESCRIPTION
This is another splitout of #196 - now that we have the resolver we use it in the otk files.

[draft as I think we want to de-duplicate and sort the packages list]