### PR TITLE
external: kernel version from depsolve (COMPOSER-2354)

### DIFF
--- a/example/centos/fragment/grub2.yaml
+++ b/example/centos/fragment/grub2.yaml
@@ -7,7 +7,7 @@ options:
   uefi:
     vendor: centos
     unified: true
-  saved_entry: ffffffffffffffffffffffffffffffff-0-0.noarch
+  saved_entry: ffffffffffffffffffffffffffffffff-${packages.os.const.versions.kernel.version}-${packages.os.const.versions.kernel.release}.${packages.os.const.versions.kernel.arch}
   write_cmdline: false
   config:
     default: saved

--- a/src/otk_external_osbuild/command/gen_depsolve_dnf4.py
+++ b/src/otk_external_osbuild/command/gen_depsolve_dnf4.py
@@ -16,6 +16,14 @@ def transform(packages):
     # other externals.
     data["tree"]["const"]["internal"]["packages"] = packages
 
+    # We also store all resolved packages and some meta information about
+    # them, this just turns the list into a more user-friendly accessible
+    # map keyed by package name.
+    data["tree"]["const"]["versions"] = {}
+
+    for package in packages:
+        data["tree"]["const"]["versions"][package["name"]] = package
+
     return data
 
 

--- a/test/test_gen_depsolve_dnf4.py
+++ b/test/test_gen_depsolve_dnf4.py
@@ -45,6 +45,17 @@ def test_gen_depsolve_dnf4_under_test_mock_data(monkeypatch, capsys):
                         },
                     ],
                 },
+                "versions": {
+                    "pkg1": {
+                        "arch": "noarch",
+                        "checksum": "sha256:3d7b91c2dd3273400f26d21a492fcdfdc3dde228cd5627247dfef745ce717755",
+                        "epoch": "",
+                        "name": "pkg1",
+                        "release": "0",
+                        "remote_location": "https://example.com/repo/packages/pkg1",
+                        "version": "0",
+                    },
+                },
             },
         },
     }
@@ -52,7 +63,26 @@ def test_gen_depsolve_dnf4_under_test_mock_data(monkeypatch, capsys):
 
 def make_dnfjson_mock_run_result():
     mock_output = json.dumps({
-        "packages": ["pkg1", "dep-pkg1"],
+        "packages": [
+            {
+                "name": "pkg1",
+                "checksum": "sha256:3d7b91c2dd3273400f26d21a492fcdfdc3dde228cd5627247dfef745ce717755",
+                "remote_location": "https://example.com/repo/packages/pkg1",
+                "version": "0",
+                "epoch": "",
+                "release": "0",
+                "arch": "noarch"
+            },
+            {
+                "name": "pkg1-dep",
+                "checksum": "sha256:3d7b91c2dd3273400f26d21a492fcdfdc3dde228cd5627247dfef745ce717755",
+                "remote_location": "https://example.com/repo/packages/pkg1-dep",
+                "version": "0",
+                "epoch": "",
+                "release": "0",
+                "arch": "noarch"
+            },
+        ],
     })
     run_result = Mock()
     run_result.stdout = mock_output


### PR DESCRIPTION
Provide a (wide) API from the depsolve to query package versions; this is split out from #196 and needs separate discussion; previously:

@mvo5:

> This adds a very broad API to this otk external, I personally would start more targeted, we need the kernel name and version and in images the kernel is handled specially only. So maybe we could do the same here? Something like just expose a const.kernel.{name,version}? We will need to adjust fragments/grub2.yam to match the kernel and the string there includes 0-0.noarch right now which also indicates that we need to tweak our tests to make this better testable.

@supakeen:

> I chose the broad API to not limit ourselves here also taking some inspiration from osbuild-mpp where it is currently possible to get the version of any package.