### PR TITLE
make: include new externals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ external:
 	for otk_cmd in gen-partition-table \
 			make-fstab-stage \
 			make-grub2-inst-stage \
+			resolve-containers \
+			resolve-ostree-commit \
 			make-partition-mounts-devices \
 			make-partition-stages; do \
 		GOBIN="$(SRCDIR)/external" go install -tags "$(CONTAINERS_STORAGE_THIN_TAGS)" "$(IMAGES_REF)"/cmd/otk-$${otk_cmd}@main ; \


### PR DESCRIPTION
Include the recently merged container resolver and ostree commit resolver externals.

Necessary for #206, was implemented in: https://github.com/osbuild/images/pull/936 and https://github.com/osbuild/images/pull/935