### PR TITLE
test: tweak gen-images() to be smarter about the UUID hacks

### DIFF
--- a/test/data/images-ref/centos/9/aarch64/ami/centos_9-aarch64-ami-empty.yaml
+++ b/test/data/images-ref/centos/9/aarch64/ami/centos_9-aarch64-ami-empty.yaml
@@ -96,7 +96,7 @@ pipelines:
     stages:
       - type: org.osbuild.kernel-cmdline
         options:
-          root_fs_uuid: faedb185-077c-44cd-97f1-c7105c700e2e
+          root_fs_uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
           kernel_opts: console=ttyS0,115200n8 console=tty0 net.ifnames=0 nvme_core.io_timeout=4294967295
             iommu.strict=0
       - type: org.osbuild.rpm
@@ -312,11 +312,11 @@ pipelines:
       - type: org.osbuild.fstab
         options:
           filesystems:
-            - uuid: faedb185-077c-44cd-97f1-c7105c700e2e
+            - uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
               vfs_type: xfs
               path: /
               options: defaults
-            - uuid: 956ad99b-3c45-462e-adc0-6a6935bba9c9
+            - uuid: dbd21911-1c4e-4107-8a9f-14fe6e751358
               vfs_type: xfs
               path: /boot
               options: defaults
@@ -327,8 +327,8 @@ pipelines:
               passno: 2
       - type: org.osbuild.grub2
         options:
-          root_fs_uuid: faedb185-077c-44cd-97f1-c7105c700e2e
-          boot_fs_uuid: 956ad99b-3c45-462e-adc0-6a6935bba9c9
+          root_fs_uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
+          boot_fs_uuid: dbd21911-1c4e-4107-8a9f-14fe6e751358
           kernel_opts: console=ttyS0,115200n8 console=tty0 net.ifnames=0 nvme_core.io_timeout=4294967295
             iommu.strict=0
           uefi:
@@ -398,7 +398,7 @@ pipelines:
               lock: true
       - type: org.osbuild.mkfs.xfs
         options:
-          uuid: 956ad99b-3c45-462e-adc0-6a6935bba9c9
+          uuid: dbd21911-1c4e-4107-8a9f-14fe6e751358
           label: boot
         devices:
           device:
@@ -410,7 +410,7 @@ pipelines:
               lock: true
       - type: org.osbuild.mkfs.xfs
         options:
-          uuid: faedb185-077c-44cd-97f1-c7105c700e2e
+          uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
           label: root
         devices:
           device:

--- a/test/data/images-ref/centos/9/aarch64/qcow2/centos_9-aarch64-qcow2-empty.yaml
+++ b/test/data/images-ref/centos/9/aarch64/qcow2/centos_9-aarch64-qcow2-empty.yaml
@@ -95,7 +95,7 @@ pipelines:
     stages:
       - type: org.osbuild.kernel-cmdline
         options:
-          root_fs_uuid: 4cf525cb-ec45-4d20-941d-9f681f9d5c27
+          root_fs_uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
           kernel_opts: console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0
       - type: org.osbuild.rpm
         inputs:
@@ -246,11 +246,11 @@ pipelines:
       - type: org.osbuild.fstab
         options:
           filesystems:
-            - uuid: 4cf525cb-ec45-4d20-941d-9f681f9d5c27
+            - uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
               vfs_type: xfs
               path: /
               options: defaults
-            - uuid: 2e303eee-0576-4377-ab7b-ede5d3b982a5
+            - uuid: dbd21911-1c4e-4107-8a9f-14fe6e751358
               vfs_type: xfs
               path: /boot
               options: defaults
@@ -261,8 +261,8 @@ pipelines:
               passno: 2
       - type: org.osbuild.grub2
         options:
-          root_fs_uuid: 4cf525cb-ec45-4d20-941d-9f681f9d5c27
-          boot_fs_uuid: 2e303eee-0576-4377-ab7b-ede5d3b982a5
+          root_fs_uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
+          boot_fs_uuid: dbd21911-1c4e-4107-8a9f-14fe6e751358
           kernel_opts: console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0
           uefi:
             vendor: centos
@@ -320,7 +320,7 @@ pipelines:
               lock: true
       - type: org.osbuild.mkfs.xfs
         options:
-          uuid: 2e303eee-0576-4377-ab7b-ede5d3b982a5
+          uuid: dbd21911-1c4e-4107-8a9f-14fe6e751358
           label: boot
         devices:
           device:
@@ -332,7 +332,7 @@ pipelines:
               lock: true
       - type: org.osbuild.mkfs.xfs
         options:
-          uuid: 4cf525cb-ec45-4d20-941d-9f681f9d5c27
+          uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
           label: root
         devices:
           device:

--- a/test/data/images-ref/gen-image-def
+++ b/test/data/images-ref/gen-image-def
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,too-many-locals
 
 import json
 import os
@@ -15,6 +15,15 @@ import yaml
 class Dumper(yaml.Dumper):  # pylint: disable=too-many-ancestors
     def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:
         return super().increase_indent(flow=flow, indentless=False)
+
+
+def uuid_for_label(fs_label, osbuild_manifest):
+    for p in osbuild_manifest["pipelines"]:
+        for stage in p["stages"]:
+            if stage["type"].startswith("org.osbuild.mkfs."):
+                if stage["options"].get("label") == fs_label:
+                    return stage["options"].get("uuid")
+    return ""
 
 
 def generate_reference_image(images_base_dir: str, distro_name: str, distro_ver: str, arch: str, img_type: str) -> None:
@@ -51,16 +60,11 @@ def generate_reference_image(images_base_dir: str, distro_name: str, distro_ver:
     # XXX: this is hacky, the OSBUILD_TESTING_RNG_SEED is set for both
     # "gen-manifests" and "otk-gen-partition-tables" but the partition
     # table code is called slightly differently which means that the UUIDs
-    # get out of sync. We need this (f)ugly mapping here to fix that.
-    #
-    # "gen-manifests" root UUID -> "otk-gen-partition-table" UUID (qcow2)
-    manifest_str = manifest_str.replace("dde1466f-f75b-4f05-bcf6-8386564c6f79", "9851898e-0b30-437d-8fad-51ec16c3697f")
-    # ami
-    manifest_str = manifest_str.replace("1d5b4d74-fd75-4ba1-a6e1-f1737dd4cdd1", "9851898e-0b30-437d-8fad-51ec16c3697f")
-    # "gen-manifests" boot UUID -> "otk-gen-partition-table" UUID (qcow2)
-    manifest_str = manifest_str.replace("e4520b54-3a3f-4ed3-b8a6-e326beec8e93", "dbd21911-1c4e-4107-8a9f-14fe6e751358")
-    # ami
-    manifest_str = manifest_str.replace("44019259-d936-49a3-a807-063467c4551a", "dbd21911-1c4e-4107-8a9f-14fe6e751358")
+    # get out of sync. We need this (f)ugly helper to fix it:
+    rootfs_uuid = uuid_for_label("root", json.loads(manifest_str))
+    manifest_str = manifest_str.replace(rootfs_uuid, "9851898e-0b30-437d-8fad-51ec16c3697f")
+    if bootfs_uuid := uuid_for_label("boot", json.loads(manifest_str)):
+        manifest_str = manifest_str.replace(bootfs_uuid, "dbd21911-1c4e-4107-8a9f-14fe6e751358")
 
     # now convert to json
     manifest = json.loads(manifest_str)

--- a/test/test_against_images_refs.py
+++ b/test/test_against_images_refs.py
@@ -1,7 +1,6 @@
 import json
 import os
 import pathlib
-import re
 import yaml
 
 import pytest
@@ -88,10 +87,6 @@ def test_images_ref(tmp_path, monkeypatch, tc):
         ref_manifest = yaml.safe_load(fp)
         normalize_rpm_refs(ref_manifest)
 
-    # hack
-    ref_manifest = json.loads(
-        re.sub(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", "", json.dumps(ref_manifest)))
-
     otk_json = tmp_path / "manifest-otk.json"
     run(["compile",
          "-o", os.fspath(otk_json),
@@ -100,9 +95,5 @@ def test_images_ref(tmp_path, monkeypatch, tc):
     with otk_json.open() as fp:
         manifest = json.load(fp)
         normalize_rpm_refs(manifest)
-
-    # hack
-    manifest = json.loads(
-        re.sub(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", "", json.dumps(manifest)))
 
     assert manifest == ref_manifest


### PR DESCRIPTION
This commit tweaks the gen-images-ref to be slightly smarter
about how to handle UUIDs. Instead of the extremly naive table
of uuids generated by "images" and "gen-partition-table" it now
tries to figure out the UUID from images via the "mkfs" stage
of the manifest. This is also a bit (f)ugly but avoids some
busywork.

Hopefully we find a better way but this should give us some
time.
