### PR TITLE
external/depsolve: allow passing options for rpm

### DIFF
--- a/src/otk_external_osbuild/command/make_depsolve_dnf4_rpm_stage.py
+++ b/src/otk_external_osbuild/command/make_depsolve_dnf4_rpm_stage.py
@@ -5,7 +5,15 @@ from typing import TextIO
 
 def root(input_stream: TextIO) -> None:
     data = json.load(input_stream)
-    tree = data["tree"]["packageset"]["const"]["internal"]
+    tree = data["tree"]
+    pkgs = tree["packageset"]["const"]["internal"]
+
+    # allow passing on rpm stage options
+    opts = tree.get("options", {}).get("rpm_stage", {})
+
+    # perhaps gpgkeys should move *under* options?
+    # it should: https://github.com/osbuild/otk/issues/218
+    opts["gpgkeys"] = tree["gpgkeys"]
 
     sys.stdout.write(
         json.dumps(
@@ -20,13 +28,11 @@ def root(input_stream: TextIO) -> None:
                                 {
                                     "id": package["checksum"],
                                 }
-                                for package in tree["packages"]
+                                for package in pkgs["packages"]
                             ],
                         },
                     },
-                    "options": {
-                        "gpgkeys": data["tree"]["gpgkeys"],
-                    },
+                    "options": opts,
                 }
             }
         )

--- a/test/test_make_depsolve_dnf4_rpm_stage.py
+++ b/test/test_make_depsolve_dnf4_rpm_stage.py
@@ -58,3 +58,65 @@ def test_make_depsolve_dnf4_rpm_stage(capsys):
             }
         }
     }
+
+
+fake_input_with_options = {
+    "tree": {
+        "packageset": {
+            "const": {
+                "internal": {
+                    "packages": [
+                        {
+                            "remote_location": "http://example.com/pkg1",
+                            "checksum": "sha256:1234",
+                        },
+                        {
+                            "remote_location": "http://example.com/pkg2",
+                            "checksum": "sha256:5678",
+                        }
+                    ]
+                }
+            }
+        },
+        "gpgkeys": [
+            "gpg-key1"
+        ],
+        "options": {
+            "rpm_stage": {
+                "dbpath": "/usr/share/rpm",
+                "disable_dracut": True,
+            }
+        }
+    }
+}
+
+
+def test_make_depsolve_dnf4_rpm_stage_with_options(capsys):
+    root(StringIO(json.dumps(fake_input_with_options)))
+    output = json.loads(capsys.readouterr().out)
+    assert output == {
+        "tree": {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+                "packages": {
+                    "type": "org.osbuild.files",
+                    "origin": "org.osbuild.source",
+                    "references": [
+                        {
+                            "id": "sha256:1234",
+                        },
+                        {
+                            "id": "sha256:5678",
+                        }
+                    ]
+                }
+            },
+            "options": {
+                "gpgkeys": [
+                    "gpg-key1",
+                ],
+                "disable_dracut": True,
+                "dbpath": "/usr/share/rpm",
+            }
+        }
+    }


### PR DESCRIPTION
Allow the passing of options for the RPM stage. Some of our omnifests will need to do this (e.g. `edge-commit` turns off `dracut` and some other bits and bobs).