### PR TITLE
Containerfile: include externals in the container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 htmlcov
 dictionary.dic
 demo
+/container_built.info

--- a/Containerfile
+++ b/Containerfile
@@ -1,10 +1,9 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS build
+FROM registry.fedoraproject.org/fedora:latest AS build_python
 
-RUN \
-    microdnf install -y \
+RUN dnf install -y \
         python3-pip \
         python3-pyyaml \
-        && microdnf clean all
+        && dnf clean all
 
 WORKDIR /src
 
@@ -12,6 +11,36 @@ COPY pyproject.toml /src/
 COPY src /src/src
 
 RUN pip install --no-dependencies .
-RUN rm -rf src/*
+
+# ----
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS build_go
+
+ARG CONTAINERS_STORAGE_THIN_TAGS="containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper"
+ENV CONTAINERS_STORAGE_THIN_TAGS=${CONTAINERS_STORAGE_THIN_TAGS}
+
+ARG IMAGES_REF="github.com/osbuild/images"
+ENV IMAGES_REF=${IMAGES_REF}
+
+COPY Makefile .
+
+RUN make external
+
+# ----
+# no osbuild-depsolve-dnf here:
+# FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.fedoraproject.org/fedora:latest
+
+RUN dnf install -y \
+    python3-pyyaml \
+    osbuild-depsolve-dnf \
+    && dnf clean all
+
+COPY --from=build_python /usr/local/bin/otk /usr/local/bin/
+COPY --from=build_python /usr/local/bin/osbuild* /usr/libexec/otk/external/
+COPY --from=build_python /usr/local/lib/ /usr/local/lib/
+
+COPY --from=build_go /opt/app-root/src/external/* /usr/local/libexec/otk/external/
+
+WORKDIR /app
 
 ENTRYPOINT ["otk"]

--- a/Containerfile
+++ b/Containerfile
@@ -15,12 +15,6 @@ RUN pip install --no-dependencies .
 # ----
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS build_go
 
-ARG CONTAINERS_STORAGE_THIN_TAGS="containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper"
-ENV CONTAINERS_STORAGE_THIN_TAGS=${CONTAINERS_STORAGE_THIN_TAGS}
-
-ARG IMAGES_REF="github.com/osbuild/images"
-ENV IMAGES_REF=${IMAGES_REF}
-
 COPY Makefile .
 
 RUN make external

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,21 @@ check-pre-commit:
 	  exit 1; \
 	}
 
-.PHONY: container
-container: ## rebuild the upstream container "ghcr.io/osbuild/otk" locally
+
+SRC_CONTAINER_FILES=$(shell find src 2>/dev/null|| echo "src") \
+                    Makefile \
+                    pyproject.toml
+
+container_built.info: Containerfile $(SRC_CONTAINER_FILES) # internal rule to avoid rebuilding if not necessary
 	podman build --build-arg CONTAINERS_STORAGE_THIN_TAGS="$(CONTAINERS_STORAGE_THIN_TAGS)" \
 	             --build-arg IMAGES_REF="$(IMAGES_REF)" \
 	             --tag otk \
 	             --pull=newer .
+	echo "Container last built on" > $@
+	date >> $@
+
+.PHONY: container
+container: container_built.info ## rebuild the upstream container "ghcr.io/osbuild/otk" locally
 
 CONTAINER_TEST_FILE?=example/centos/centos-9-x86_64-tar.yaml
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,19 @@ You can find `otk`'s documentation in the [/doc](./doc) subdirectory. This READM
 If you want to quickly run and try out `otk` without installation the easiest is to run our container image:
 
 ```
-podman run -i ghcr.io/osbuild/otk < omnifest.yaml
+podman run -i -v .:/app:z ghcr.io/osbuild/otk compile /app/test/data/base/01-define.yaml
+```
+
+or rebuild the container locally
+
+```shell
+make container
+```
+
+and run an example
+
+```shell
+make container-test
 ```
 
 If you want to hack on `otk` then read the [installation instructions](./doc/00-installation.md).


### PR DESCRIPTION
Does it make sense to create a container for now which "just works"?
(related to #221)

This version of the container includes `otk` and all external commands to have it working for now.

build with
```
podman build --tag otk --pull=newer .
```

run e.g. with

```
podman run --rm -ti -v .:/app otk:latest compile /app/example/centos/centos-9-x86_64-tar.yaml
```