### PR TITLE
Implement makefile building from scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ htmlcov
 dictionary.dic
 demo
 /container_built.info
+/external
+/rpmbuild

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,33 @@
+# needed for venv
+.ONESHELL:
 
-check-pre-commit:
+.PHONY: help
+help:
+	@echo 'Usage:'
+	@echo '  make <target>'
+	@echo ''
+	@echo 'Targets:'
+	@awk 'match($$0, /^([a-zA-Z_\/-]+):.*?## (.*)$$/, m) {printf "  \033[36m%-30s\033[0m %s\n", m[1], m[2]}' $(MAKEFILE_LIST) | sort
+
+# Keep this in sync with e.g. https://github.com/containers/podman/blob/2981262215f563461d449b9841741339f4d9a894/Makefile#L51
+CONTAINERS_STORAGE_THIN_TAGS=containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper
+IMAGES_REF ?= github.com/osbuild/images
+
+SRC_DIR?=$(CURDIR)
+EXTERNAL_DIR?=$(SRC_DIR)/external
+VENV_DIR?=$(SRC_DIR)/venv
+
+EXTERNAL_GO_EXECUTABLES:= otk-gen-partition-table \
+                          otk-make-fstab-stage \
+                          otk-make-grub2-inst-stage \
+                          otk-resolve-containers \
+                          otk-resolve-ostree-commit \
+                          otk-make-partition-mounts-devices \
+                          otk-make-partition-stages
+
+EXTERNAL_GO_EXECUTABLES_FULLPATH:=$(addprefix $(EXTERNAL_DIR)/, $(EXTERNAL_GO_EXECUTABLES))
+
+check-pre-commit: # internal rule to check if pre-commit is installed
 	@which pre-commit >/dev/null 2>&1 || { \
           echo >&2 -e "Please install https://pre-commit.com !\n"; \
 	  echo >&2 "Either with 'pip install pre-commit'"; \
@@ -30,74 +58,80 @@ container-test: container ## run an example command in the container to test it
 	podman run --rm -ti -v .:/app otk:latest compile /app/$(CONTAINER_TEST_FILE)
 
 .PHONY: lint
-lint: check-pre-commit
+lint: check-pre-commit ## run all linters against the project
 	pre-commit run --all-files
 
 .PHONY: type
-type: check-pre-commit
+type: check-pre-commit ## run type checks
 	pre-commit run --all-files mypy
 
 .PHONY: format
-format:
+format: ## format all python source files
 	@find src test -name '*.py' | xargs autopep8 --in-place
 
 .PHONY: test
-test: external
-	cp $(shell (which "osbuild-gen-depsolve-dnf4")) ./external/
-	cp $(shell (which "osbuild-get-dnf4-package-info")) ./external/
-	cp $(shell (which "osbuild-make-depsolve-dnf4-rpm-stage")) ./external/
-	cp $(shell (which "osbuild-make-depsolve-dnf4-curl-source")) ./external/
+test: external | $(VENV_DIR) ## run all tests
+	source $(VENV_DIR)/bin/activate
 	@pytest
 
 .PHONY: push-check
-push-check: test lint type
+push-check: test lint type ## run tests, linters and type checks to avoid problems in a pull request
 
 .PHONY: git-diff-check
-git-diff-check:
+git-diff-check: # internal rule to check for git changes
 	@git diff --exit-code
 	@git diff --cached --exit-code
 
 ## Package building
 SRCDIR ?= $(abspath .)
 COMMIT = $(shell (cd "$(SRCDIR)" && git rev-parse HEAD 2>/dev/null || echo "INVALID" ))
-RPM_SPECFILE=rpmbuild/SPECS/otk-$(COMMIT).spec
-RPM_TARBALL=rpmbuild/SOURCES/otk-$(COMMIT).tar.gz
+RPM_BUILD_DIR?=rpmbuild
+RPM_SPECFILE=$(RPM_BUILD_DIR)/SPECS/otk-$(COMMIT).spec
+RPM_TARBALL=$(RPM_BUILD_DIR)/SOURCES/otk-$(COMMIT).tar.gz
 
 $(RPM_SPECFILE):
 	mkdir -p $(CURDIR)/rpmbuild/SPECS
 	(echo "%global commit $(COMMIT)"; git show HEAD:otk.spec 2>/dev/null || echo "INVALID SETUP" ) > $(RPM_SPECFILE)
 
-$(RPM_TARBALL):
-	mkdir -p $(CURDIR)/rpmbuild/SOURCES
+$(RPM_TARBALL): # internal rule to creat the source tar ball
+	mkdir -p $(CURDIR)/$(RPM_BUILD_DIR)/SOURCES
 	git archive --prefix=otk-$(COMMIT)/ --format=tar.gz HEAD > $(RPM_TARBALL)
 
 .PHONY: srpm
-srpm: git-diff-check $(RPM_SPECFILE) $(RPM_TARBALL)
+srpm: git-diff-check $(RPM_SPECFILE) $(RPM_TARBALL) ## create the source RPM
 	rpmbuild -bs \
-		--define "_topdir $(CURDIR)/rpmbuild" \
+		--define "_topdir $(CURDIR)/$(RPM_BUILD_DIR)" \
 		$(RPM_SPECFILE)
 
 .PHONY: rpm
-rpm: git-diff-check $(RPM_SPECFILE) $(RPM_TARBALL)
+rpm: git-diff-check $(RPM_SPECFILE) $(RPM_TARBALL) rpm-prerequisites | $(VENV_DIR) ## create the RPM
+	source $(VENV_DIR)/bin/activate
 	rpmbuild -bb \
-		--define "_topdir $(CURDIR)/rpmbuild" \
+		--define "_topdir $(CURDIR)/$(RPM_BUILD_DIR)" \
 		$(RPM_SPECFILE)
+
+rpm-prerequisites: # internal rule to install packages needed to build the RPM
+	sudo dnf install -y python3-wheel
+
+$(EXTERNAL_DIR):
+	mkdir -p $@
+
+$(EXTERNAL_GO_EXECUTABLES_FULLPATH): | $(EXTERNAL_DIR)
+	GOBIN=$(dir $@) go install -tags "$(CONTAINERS_STORAGE_THIN_TAGS)" "$(IMAGES_REF)"/cmd/$(notdir $@)@main ;
 
 # Note that "external" will most likely in the future build from internal
 # sources instead of pulling of the network
 .PHONY: external
-# # Keep this in sync with e.g. https://github.com/containers/podman/blob/2981262215f563461d449b9841741339f4d9a894/Makefile#L51
-CONTAINERS_STORAGE_THIN_TAGS=containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper
-IMAGES_REF ?= github.com/osbuild/images
-external:
-	mkdir -p "$(SRCDIR)/external"
-	set -e ; \
-	for otk_cmd in gen-partition-table \
-			make-fstab-stage \
-			make-grub2-inst-stage \
-			resolve-containers \
-			resolve-ostree-commit \
-			make-partition-mounts-devices \
-			make-partition-stages; do \
-		GOBIN="$(SRCDIR)/external" go install -tags "$(CONTAINERS_STORAGE_THIN_TAGS)" "$(IMAGES_REF)"/cmd/otk-$${otk_cmd}@main ; \
-	done
+external: $(EXTERNAL_GO_EXECUTABLES_FULLPATH)
+
+clean: ## clean all build artifacts
+	rm -rf $(VENV_DIR)
+	rm -rf $(EXTERNAL_DIR)
+	rm -rf $(RPM_BUILD_DIR)
+
+$(VENV_DIR): pyproject.toml | $(EXTERNAL_DIR)
+	python3 -m venv $@
+	source $@/bin/activate
+	pip install -e ".[dev]"
+	ln -sf $(VENV_DIR)/bin/osbuild-* $(EXTERNAL_DIR)/
+	touch $@

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ format: ## format all python source files
 
 .PHONY: test
 test: external | $(VENV_DIR) ## run all tests
-	source $(VENV_DIR)/bin/activate
+	. $(VENV_DIR)/bin/activate
 	@pytest
 
 .PHONY: push-check
@@ -105,7 +105,7 @@ srpm: git-diff-check $(RPM_SPECFILE) $(RPM_TARBALL) ## create the source RPM
 
 .PHONY: rpm
 rpm: git-diff-check $(RPM_SPECFILE) $(RPM_TARBALL) rpm-prerequisites | $(VENV_DIR) ## create the RPM
-	source $(VENV_DIR)/bin/activate
+	. $(VENV_DIR)/bin/activate
 	rpmbuild -bb \
 		--define "_topdir $(CURDIR)/$(RPM_BUILD_DIR)" \
 		$(RPM_SPECFILE)
@@ -131,7 +131,7 @@ clean: ## clean all build artifacts
 
 $(VENV_DIR): pyproject.toml | $(EXTERNAL_DIR)
 	python3 -m venv $@
-	source $@/bin/activate
+	. $@/bin/activate
 	pip install -e ".[dev]"
 	ln -sf $(VENV_DIR)/bin/osbuild-* $(EXTERNAL_DIR)/
 	touch $@

--- a/otk.spec
+++ b/otk.spec
@@ -43,9 +43,12 @@ cp -a example/* %{buildroot}%{_datadir}/otk/example/
 %doc doc
 %{_datadir}/otk
 %{_bindir}/otk
-%{_bindir}/otk_external_osbuild
+%{_bindir}/osbuild-gen-depsolve-dnf4
+%{_bindir}/osbuild-make-depsolve-dnf4-curl-source
+%{_bindir}/osbuild-make-depsolve-dnf4-rpm-stage
+%{_bindir}/osbuild-get-dnf4-package-info
 %{python3_sitelib}/otk
-%{python3_sitelib}/otk_osbuild
+%{python3_sitelib}/otk_external_osbuild
 %{python3_sitelib}/otk-%{version}.dist-info
 
 


### PR DESCRIPTION
This fixes the Makefile and introduces new targets.
e.g. `make test` now also sets up the venv and externals
Now the following rules should be working:

* help: new
* clean: new - be aware this also removes venv as it will be rebuilt anyway
* test: did not setup the environment before
* rpm: was failing in the current version

also updates `.gitignore` to match (so [this](https://github.com/osbuild/otk/pull/220#issuecomment-2371727229) is obsolete)