### PR TITLE
test: only replace root_uuid if there is one

### DIFF
--- a/test/data/images-ref/gen-image-def
+++ b/test/data/images-ref/gen-image-def
@@ -61,8 +61,8 @@ def generate_reference_image(images_base_dir: str, distro_name: str, distro_ver:
     # "gen-manifests" and "otk-gen-partition-tables" but the partition
     # table code is called slightly differently which means that the UUIDs
     # get out of sync. We need this (f)ugly helper to fix it:
-    rootfs_uuid = uuid_for_label("root", json.loads(manifest_str))
-    manifest_str = manifest_str.replace(rootfs_uuid, "9851898e-0b30-437d-8fad-51ec16c3697f")
+    if rootfs_uuid := uuid_for_label("root", json.loads(manifest_str)):
+        manifest_str = manifest_str.replace(rootfs_uuid, "9851898e-0b30-437d-8fad-51ec16c3697f")
     if bootfs_uuid := uuid_for_label("boot", json.loads(manifest_str)):
         manifest_str = manifest_str.replace(bootfs_uuid, "dbd21911-1c4e-4107-8a9f-14fe6e751358")
 


### PR DESCRIPTION
This commit fixes the issue that some image types (like tar) do not have a rootfs so replacing the uuid of root will give funny results.