### PR TITLE
many: use new "pseudo" repos from images

### DIFF
--- a/example/centos/centos-9-aarch64-qcow2.yaml
+++ b/example/centos/centos-9-aarch64-qcow2.yaml
@@ -11,7 +11,7 @@ otk.define:
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/aarch64.yaml"
         packages:
           include:
             - coreutils
@@ -33,7 +33,7 @@ otk.define:
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/aarch64.yaml"
         packages:
           include:
             - "@core"

--- a/example/centos/centos-9-ppc64le-tar.yaml
+++ b/example/centos/centos-9-ppc64le-tar.yaml
@@ -10,7 +10,7 @@ otk.define:
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/s390x.yaml"
+          otk.include: "common/repositories/ppc64le.yaml"
         packages:
           include:
             - coreutils
@@ -30,7 +30,7 @@ otk.define:
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/s390x.yaml"
+          otk.include: "common/repositories/ppc64le.yaml"
         packages:
           include:
             - selinux-policy-targeted

--- a/example/centos/common/repositories/x86_64.yaml
+++ b/example/centos/common/repositories/x86_64.yaml
@@ -2,3 +2,5 @@
   baseurl: "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-appstream-20240901"
 - id: "BaseOS"
   baseurl: "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20240901"
+- id: "RT"
+  baseurl: "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-rt-20240901"

--- a/test/data/images-ref/centos/9/aarch64/ami/centos_9-aarch64-ami-empty.yaml
+++ b/test/data/images-ref/centos/9/aarch64/ami/centos_9-aarch64-ami-empty.yaml
@@ -28,6 +28,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b
+              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
+              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -162,6 +164,8 @@ pipelines:
               - id: sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34
               - id: sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c
               - id: sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127
+              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
+              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -524,6 +528,10 @@ sources:
         url: https://example.com/repo/packages/chrony
       sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c:
         url: https://example.com/repo/packages/kernel
+      sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-appstream
+      sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1:
         url: https://example.com/repo/packages/exclude:iwl4965-firmware
       sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334:

--- a/test/data/images-ref/centos/9/aarch64/edge-commit/centos_9-aarch64-edge_commit-empty.yaml
+++ b/test/data/images-ref/centos/9/aarch64/edge-commit/centos_9-aarch64-edge_commit-empty.yaml
@@ -22,6 +22,8 @@ pipelines:
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
+              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
+              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -185,6 +187,8 @@ pipelines:
               - id: sha256:557bd0eaadc03a42f7034eaed1acbf4299219213aef48dddee1594d0d0017c37
               - id: sha256:e243470295e7a4ed4c248443bf78f4d827988f58767c47592545f77e76839439
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
+              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
+              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
         options:
           dbpath: /usr/share/rpm
           gpgkeys:
@@ -392,12 +396,16 @@ sources:
         url: https://example.com/repo/packages/kernel
       sha256:6a406152d00694615f91b8b047dc939d75c834790e521ff3997e3734111518e6:
         url: https://example.com/repo/packages/criu
+      sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-appstream
       sha256:6e5afe9033e4767cc4ccec7ec2d18958a28dcfb7b8982cae4afde231b5bb8fad:
         url: https://example.com/repo/packages/keyutils
       sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682:
         url: https://example.com/repo/packages/hostname
       sha256:75406d2ab1a318d214d3f17ad722986010c2d69fbac331fb855689191889f812:
         url: https://example.com/repo/packages/fdo-owner-cli
+      sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:772a6043284a6f653b3a220d1a7fa5a482dcd910f81308b3e53e20abbe8acfee:
         url: https://example.com/repo/packages/skopeo
       sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5:

--- a/test/data/images-ref/centos/9/aarch64/qcow2/centos_9-aarch64-qcow2-empty.yaml
+++ b/test/data/images-ref/centos/9/aarch64/qcow2/centos_9-aarch64-qcow2-empty.yaml
@@ -27,6 +27,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c
+              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
+              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -168,6 +170,8 @@ pipelines:
               - id: sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
               - id: sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b
+              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
+              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -466,6 +470,10 @@ sources:
         url: https://example.com/repo/packages/chrony
       sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c:
         url: https://example.com/repo/packages/kernel
+      sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-appstream
+      sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1:
         url: https://example.com/repo/packages/exclude:iwl4965-firmware
       sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876:

--- a/test/data/images-ref/centos/9/aarch64/tar/centos_9-aarch64-tar-empty.yaml
+++ b/test/data/images-ref/centos/9/aarch64/tar/centos_9-aarch64-tar-empty.yaml
@@ -20,6 +20,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
+              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
+              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -97,6 +99,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
+              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
+              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -193,6 +197,10 @@ sources:
         url: https://example.com/repo/packages/glibc
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
+      sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-appstream
+      sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
         url: https://example.com/repo/packages/platform-python
       sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a:

--- a/test/data/images-ref/centos/9/ppc64le/tar/centos_9-ppc64le-tar-empty.yaml
+++ b/test/data/images-ref/centos/9/ppc64le/tar/centos_9-ppc64le-tar-empty.yaml
@@ -20,6 +20,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
+              - id: sha256:1324cffcaa49021bb7da2de54cbe95be0565e2e213ec4bb657a5ab06f9ea5d4f
+              - id: sha256:7b507ea13181aff07a2d7827448ac14aab25f1c82939d72893eb7d06483e335e
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -97,6 +99,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
+              - id: sha256:1324cffcaa49021bb7da2de54cbe95be0565e2e213ec4bb657a5ab06f9ea5d4f
+              - id: sha256:7b507ea13181aff07a2d7827448ac14aab25f1c82939d72893eb7d06483e335e
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -189,10 +193,14 @@ pipelines:
 sources:
   org.osbuild.curl:
     items:
+      sha256:1324cffcaa49021bb7da2de54cbe95be0565e2e213ec4bb657a5ab06f9ea5d4f:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-ppc64le-appstream
       sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d:
         url: https://example.com/repo/packages/glibc
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
+      sha256:7b507ea13181aff07a2d7827448ac14aab25f1c82939d72893eb7d06483e335e:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-ppc64le-baseos
       sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
         url: https://example.com/repo/packages/platform-python
       sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a:

--- a/test/data/images-ref/centos/9/s390x/tar/centos_9-s390x-tar-empty.yaml
+++ b/test/data/images-ref/centos/9/s390x/tar/centos_9-s390x-tar-empty.yaml
@@ -20,6 +20,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
+              - id: sha256:b8d091abda67af8480100d621faa0a7648cb9aee4682b0e12606595f0583c639
+              - id: sha256:dabb2041d791bbe2ff130c6b7412f5469083ec6796cd23032bae8eca1d350ac0
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -97,6 +99,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
+              - id: sha256:b8d091abda67af8480100d621faa0a7648cb9aee4682b0e12606595f0583c639
+              - id: sha256:dabb2041d791bbe2ff130c6b7412f5469083ec6796cd23032bae8eca1d350ac0
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -203,10 +207,14 @@ sources:
         url: https://example.com/repo/packages/policycoreutils
       sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88:
         url: https://example.com/repo/packages/rpm
+      sha256:b8d091abda67af8480100d621faa0a7648cb9aee4682b0e12606595f0583c639:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-s390x-appstream
       sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528:
         url: https://example.com/repo/packages/selinux-policy-targeted
       sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:
         url: https://example.com/repo/packages/python3
+      sha256:dabb2041d791bbe2ff130c6b7412f5469083ec6796cd23032bae8eca1d350ac0:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-s390x-baseos
       sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98:
         url: https://example.com/repo/packages/systemd
       sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62:

--- a/test/data/images-ref/centos/9/x86_64/ami/centos_9-x86_64-ami-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/ami/centos_9-x86_64-ami-empty.yaml
@@ -30,6 +30,9 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b
+              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
+              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
+              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -164,6 +167,9 @@ pipelines:
               - id: sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34
               - id: sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c
               - id: sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127
+              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
+              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
+              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -496,6 +502,8 @@ sources:
     items:
       sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
         url: https://example.com/repo/packages/dosfstools
+      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3:
         url: https://example.com/repo/packages/exclude:iwl3160-firmware
       sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2:
@@ -524,6 +532,8 @@ sources:
         url: https://example.com/repo/packages/gdisk
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
+      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942:
         url: https://example.com/repo/packages/cloud-init
       sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a:
@@ -554,6 +564,8 @@ sources:
         url: https://example.com/repo/packages/exclude:iwl4965-firmware
       sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334:
         url: https://example.com/repo/packages/redhat-release-eula
+      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0:
         url: https://example.com/repo/packages/exclude:iwl2000-firmware
       sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:

--- a/test/data/images-ref/centos/9/x86_64/edge-commit/centos_9-x86_64-edge_commit-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/edge-commit/centos_9-x86_64-edge_commit-empty.yaml
@@ -23,6 +23,9 @@ pipelines:
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
+              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
+              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
+              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -210,6 +213,9 @@ pipelines:
               - id: sha256:557bd0eaadc03a42f7034eaed1acbf4299219213aef48dddee1594d0d0017c37
               - id: sha256:e243470295e7a4ed4c248443bf78f4d827988f58767c47592545f77e76839439
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
+              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
+              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
+              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
         options:
           dbpath: /usr/share/rpm
           gpgkeys:
@@ -351,6 +357,8 @@ sources:
     items:
       sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
         url: https://example.com/repo/packages/dosfstools
+      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:0a297cf5549425fa4f7cf9236959e92d97dc3ff0c42506ede88c253073891f11:
         url: https://example.com/repo/packages/clevis-luks
       sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb:
@@ -385,6 +393,8 @@ sources:
         url: https://example.com/repo/packages/fuse-overlayfs
       sha256:3cc2ce65b79da03dbdb0dd90b29f773ed36810fe411347347186840029f631a8:
         url: https://example.com/repo/packages/setools-console
+      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:3fe9a8dfca0f4e96aa36bca306729179202f3854488648a3aca7bdf80bc1bb81:
         url: https://example.com/repo/packages/ignition
       sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0:
@@ -433,6 +443,8 @@ sources:
         url: https://example.com/repo/packages/skopeo
       sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5:
         url: https://example.com/repo/packages/firewalld
+      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a:
         url: https://example.com/repo/packages/openssh-server
       sha256:7e41bc67e45e9633f10b8c4ab76c6cffba2bd76b9d3859f1fe51337e9978c760:

--- a/test/data/images-ref/centos/9/x86_64/qcow2/centos_9-x86_64-qcow2-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/qcow2/centos_9-x86_64-qcow2-empty.yaml
@@ -29,6 +29,9 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c
+              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
+              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
+              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -171,6 +174,9 @@ pipelines:
               - id: sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
               - id: sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b
+              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
+              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
+              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -429,6 +435,8 @@ sources:
     items:
       sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
         url: https://example.com/repo/packages/dosfstools
+      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3:
         url: https://example.com/repo/packages/exclude:iwl3160-firmware
       sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2:
@@ -463,6 +471,8 @@ sources:
         url: https://example.com/repo/packages/qemu-img
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
+      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942:
         url: https://example.com/repo/packages/cloud-init
       sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d:
@@ -495,6 +505,8 @@ sources:
         url: https://example.com/repo/packages/redhat-release-eula
       sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5:
         url: https://example.com/repo/packages/qemu-guest-agent
+      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0:
         url: https://example.com/repo/packages/exclude:iwl2000-firmware
       sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747:

--- a/test/data/images-ref/centos/9/x86_64/tar/centos_9-x86_64-tar-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/tar/centos_9-x86_64-tar-empty.yaml
@@ -20,6 +20,9 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
+              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
+              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
+              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -97,6 +100,9 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
+              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
+              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
+              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -189,10 +195,16 @@ pipelines:
 sources:
   org.osbuild.curl:
     items:
+      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d:
         url: https://example.com/repo/packages/glibc
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
+      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
+      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
         url: https://example.com/repo/packages/platform-python
       sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a:

--- a/test/test_gen_depsolve_dnf4.py
+++ b/test/test_gen_depsolve_dnf4.py
@@ -5,6 +5,7 @@ from unittest.mock import call, Mock, patch
 
 from otk_external_osbuild.command.gen_depsolve_dnf4 import root
 
+# pylint: disable=line-too-long
 
 fake_input = {
     "tree": {
@@ -34,6 +35,11 @@ def test_gen_depsolve_dnf4_under_test_mock_data(monkeypatch, capsys):
             "const": {
                 "internal": {
                     "packages": [
+                        {
+                            "checksum": "sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15",
+                            "name": "https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos",
+                            "remote_location": "https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos",
+                        },
                         {
                             "checksum": "sha256:3d7b91c2dd3273400f26d21a492fcdfdc3dde228cd5627247dfef745ce717755",
                             "name": "pkg1",


### PR DESCRIPTION
This PR uses the new pseudo repos generated via https://github.com/osbuild/images/pull/944

[draft as the tests fail currently, I suspect because the repos needs fixing/updating]