### PR TITLE
example/centos: import minimal-raw

### DIFF
--- a/example/centos/centos-9-aarch64-minimal-raw.yaml
+++ b/example/centos/centos-9-aarch64-minimal-raw.yaml
@@ -51,6 +51,15 @@ otk.define:
             - shim-aa64
             - xfsprogs
           exclude: []
+  files:
+    otk.external.osbuild-gen-inline-files:
+      inline:
+        kickstart:
+          contents: |
+            # Run initial-setup on first boot
+            # Created by osbuild
+            firstboot --reconfig
+            lang en_US.UTF-8
   kernel:
     cmdline: ro
     package:
@@ -104,14 +113,16 @@ otk.target.osbuild:
         - otk.include: fragment/grub2/aarch64.yaml
         - type: org.osbuild.copy
           inputs:
+            # XXX note we're only keeping the hash here since it corresponds to the reference
+            # XXX manifest and the same in the input
             file-cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9:
               type: org.osbuild.files
               origin: org.osbuild.source
               references:
-                - id: sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9
+                - id: ${files.const.files.kickstart.id}
           options:
             paths:
-              - from: input://file-cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9/sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9
+              - from: input://file-cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9/${files.const.files.kickstart.id}
                 to: tree:///root/anaconda-ks.cfg
                 remove_destination: true
         - type: org.osbuild.chown
@@ -151,8 +162,6 @@ otk.target.osbuild:
             packagesets:
               - ${packages.build}
               - ${packages.os}
-        - org.osbuild.inline:
-            items:
-              sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9:
-                encoding: base64
-                data: IyBSdW4gaW5pdGlhbC1zZXR1cCBvbiBmaXJzdCBib290CiMgQ3JlYXRlZCBieSBvc2J1aWxkCmZpcnN0Ym9vdCAtLXJlY29uZmlnCmxhbmcgZW5fVVMuVVRGLTgK
+        - otk.external.osbuild-make-inline-source:
+            const:
+              files: ${files.const.files}

--- a/example/centos/centos-9-aarch64-minimal-raw.yaml
+++ b/example/centos/centos-9-aarch64-minimal-raw.yaml
@@ -1,0 +1,158 @@
+otk.version: "1"
+
+otk.define:
+  filesystem:
+    modifications:
+    # empty
+  packages:
+    build:
+      otk.external.osbuild-gen-depsolve-dnf4:
+        architecture: aarch64
+        module_platform_id: c9s
+        releasever: "9"
+        repositories:
+          otk.include: "common/repositories/aarch64.yaml"
+        packages:
+          include:
+            - coreutils
+            - dosfstools
+            - glibc
+            - platform-python
+            - policycoreutils
+            - python3
+            - rpm
+            - selinux-policy-targeted
+            - systemd
+            - xfsprogs
+            - xz
+          exclude: []
+    os:
+      otk.external.osbuild-gen-depsolve-dnf4:
+        architecture: aarch64
+        module_platform_id: c9s
+        releasever: "9"
+        repositories:
+          otk.include: "common/repositories/aarch64.yaml"
+        packages:
+          include:
+            - "@core"
+            - NetworkManager-wifi
+            - dosfstools
+            - dracut-config-generic
+            - efibootmgr
+            - grub2-efi-aa64
+            - grub2-tools
+            - initial-setup
+            - iwl3160-firmware
+            - iwl7260-firmware
+            - kernel
+            - libxkbcommon
+            - selinux-policy-targeted
+            - shim-aa64
+            - xfsprogs
+          exclude: []
+  kernel:
+    cmdline: ro
+    package:
+      otk.external.osbuild-get-dnf4-package-info:
+        packageset: ${packages.os}
+        packagename: "kernel"
+
+otk.include: "common/partition-table/aarch64/minimal-raw.yaml"
+
+otk.target.osbuild:
+  pipelines:
+    - otk.include: "pipeline/build/generic.yaml"
+    - name: os
+      build: name:build
+      stages:
+        - type: org.osbuild.kernel-cmdline
+          options:
+            root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
+            kernel_opts: ${kernel.cmdline}
+        - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
+            packageset: ${packages.os}
+            gpgkeys:
+              otk.include: "common/gpgkeys.yaml"
+        - type: org.osbuild.fix-bls
+          options:
+            prefix: ''
+        - type: org.osbuild.locale
+          options:
+            language: C.UTF-8
+        - type: org.osbuild.timezone
+          options:
+            zone: America/New_York
+        - type: org.osbuild.sysconfig
+          options:
+            kernel:
+              update_default: true
+              default_kernel: kernel
+            network:
+              networking: true
+              no_zero_conf: true
+        - type: org.osbuild.systemd.unit
+          options:
+            unit: grub-boot-success.timer
+            dropin: 10-disable-if-greenboot.conf
+            config:
+              Unit:
+                ConditionPathExists: '!/usr/libexec/greenboot/greenboot'
+            unit-type: global
+        - otk.external.otk-make-fstab-stage:
+            ${filesystem}
+        - otk.include: fragment/grub2/aarch64.yaml
+        - type: org.osbuild.copy
+          inputs:
+            file-cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9:
+              type: org.osbuild.files
+              origin: org.osbuild.source
+              references:
+                - id: sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9
+          options:
+            paths:
+              - from: input://file-cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9/sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9
+                to: tree:///root/anaconda-ks.cfg
+                remove_destination: true
+        - type: org.osbuild.chown
+          options:
+            items:
+              /root/anaconda-ks.cfg:
+                user: root
+                group: root
+        - type: org.osbuild.systemd
+          options:
+            enabled_services:
+              - NetworkManager.service
+              - firewalld.service
+              - sshd.service
+              - initial-setup.service
+        - type: org.osbuild.selinux
+          options:
+            file_contexts: etc/selinux/targeted/contexts/files/file_contexts
+    - otk.include: pipeline/image/aarch64.yaml
+    - name: xz
+      build: name:build
+      stages:
+        - type: org.osbuild.xz
+          inputs:
+            file:
+              type: org.osbuild.files
+              origin: org.osbuild.pipeline
+              references:
+                name:image:
+                  file: disk.img
+          options:
+            filename: disk.raw.xz
+  sources:
+    otk.op.join:
+      values:
+        - otk.external.osbuild-make-depsolve-dnf4-curl-source:
+            packagesets:
+              - ${packages.build}
+              - ${packages.os}
+        - org.osbuild.inline:
+            items:
+              sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9:
+                encoding: base64
+                data: IyBSdW4gaW5pdGlhbC1zZXR1cCBvbiBmaXJzdCBib290CiMgQ3JlYXRlZCBieSBvc2J1aWxkCmZpcnN0Ym9vdCAtLXJlY29uZmlnCmxhbmcgZW5fVVMuVVRGLTgK

--- a/example/centos/centos-9-x86_64-minimal-raw.yaml
+++ b/example/centos/centos-9-x86_64-minimal-raw.yaml
@@ -1,0 +1,157 @@
+otk.version: "1"
+
+otk.define:
+  filesystem:
+    modifications:
+    # empty
+  packages:
+    build:
+      otk.external.osbuild-gen-depsolve-dnf4:
+        architecture: x86_64
+        module_platform_id: c9s
+        releasever: "9"
+        repositories:
+          otk.include: "common/repositories/x86_64.yaml"
+        packages:
+          include:
+            - coreutils
+            - dosfstools
+            - glibc
+            - platform-python
+            - policycoreutils
+            - python3
+            - rpm
+            - selinux-policy-targeted
+            - systemd
+            - xfsprogs
+            - xz
+          exclude: []
+    os:
+      otk.external.osbuild-gen-depsolve-dnf4:
+        architecture: x86_64
+        module_platform_id: c9s
+        releasever: "9"
+        repositories:
+          otk.include: "common/repositories/x86_64.yaml"
+        packages:
+          include:
+            - "@core"
+            - NetworkManager-wifi
+            - dosfstools
+            - dracut-config-generic
+            - efibootmgr
+            - grub2-efi-x64
+            - initial-setup
+            - iwl3160-firmware
+            - iwl7260-firmware
+            - kernel
+            - libxkbcommon
+            - selinux-policy-targeted
+            - shim-x64
+            - xfsprogs
+          exclude: []
+  kernel:
+    cmdline: ro
+    package:
+      otk.external.osbuild-get-dnf4-package-info:
+        packageset: ${packages.os}
+        packagename: "kernel"
+
+otk.include: "common/partition-table/x86_64/minimal-raw.yaml"
+
+otk.target.osbuild:
+  pipelines:
+    - otk.include: "pipeline/build/generic.yaml"
+    - name: os
+      build: name:build
+      stages:
+        - type: org.osbuild.kernel-cmdline
+          options:
+            root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
+            kernel_opts: ${kernel.cmdline}
+        - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
+            packageset: ${packages.os}
+            gpgkeys:
+              otk.include: "common/gpgkeys.yaml"
+        - type: org.osbuild.fix-bls
+          options:
+            prefix: ''
+        - type: org.osbuild.locale
+          options:
+            language: C.UTF-8
+        - type: org.osbuild.timezone
+          options:
+            zone: America/New_York
+        - type: org.osbuild.sysconfig
+          options:
+            kernel:
+              update_default: true
+              default_kernel: kernel
+            network:
+              networking: true
+              no_zero_conf: true
+        - type: org.osbuild.systemd.unit
+          options:
+            unit: grub-boot-success.timer
+            dropin: 10-disable-if-greenboot.conf
+            config:
+              Unit:
+                ConditionPathExists: '!/usr/libexec/greenboot/greenboot'
+            unit-type: global
+        - otk.external.otk-make-fstab-stage:
+            ${filesystem}
+        - otk.include: fragment/grub2/x86_64-no-bios.yaml
+        - type: org.osbuild.copy
+          inputs:
+            file-cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9:
+              type: org.osbuild.files
+              origin: org.osbuild.source
+              references:
+                - id: sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9
+          options:
+            paths:
+              - from: input://file-cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9/sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9
+                to: tree:///root/anaconda-ks.cfg
+                remove_destination: true
+        - type: org.osbuild.chown
+          options:
+            items:
+              /root/anaconda-ks.cfg:
+                user: root
+                group: root
+        - type: org.osbuild.systemd
+          options:
+            enabled_services:
+              - NetworkManager.service
+              - firewalld.service
+              - sshd.service
+              - initial-setup.service
+        - type: org.osbuild.selinux
+          options:
+            file_contexts: etc/selinux/targeted/contexts/files/file_contexts
+    - otk.include: pipeline/image/x86_64-no-bios.yaml
+    - name: xz
+      build: name:build
+      stages:
+        - type: org.osbuild.xz
+          inputs:
+            file:
+              type: org.osbuild.files
+              origin: org.osbuild.pipeline
+              references:
+                name:image:
+                  file: disk.img
+          options:
+            filename: disk.raw.xz
+  sources:
+    otk.op.join:
+      values:
+        - otk.external.osbuild-make-depsolve-dnf4-curl-source:
+            packagesets:
+              - ${packages.build}
+              - ${packages.os}
+        - org.osbuild.inline:
+            items:
+              sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9:
+                encoding: base64
+                data: IyBSdW4gaW5pdGlhbC1zZXR1cCBvbiBmaXJzdCBib290CiMgQ3JlYXRlZCBieSBvc2J1aWxkCmZpcnN0Ym9vdCAtLXJlY29uZmlnCmxhbmcgZW5fVVMuVVRGLTgK

--- a/example/centos/centos-9-x86_64-minimal-raw.yaml
+++ b/example/centos/centos-9-x86_64-minimal-raw.yaml
@@ -50,6 +50,15 @@ otk.define:
             - shim-x64
             - xfsprogs
           exclude: []
+  files:
+    otk.external.osbuild-gen-inline-files:
+      inline:
+        kickstart:
+          contents: |
+            # Run initial-setup on first boot
+            # Created by osbuild
+            firstboot --reconfig
+            lang en_US.UTF-8
   kernel:
     cmdline: ro
     package:
@@ -103,14 +112,16 @@ otk.target.osbuild:
         - otk.include: fragment/grub2/x86_64-no-bios.yaml
         - type: org.osbuild.copy
           inputs:
+            # XXX note we're only keeping the hash here since it corresponds to the reference
+            # XXX manifest and the same in the input
             file-cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9:
               type: org.osbuild.files
               origin: org.osbuild.source
               references:
-                - id: sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9
+                - id: ${files.const.files.kickstart.id}
           options:
             paths:
-              - from: input://file-cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9/sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9
+              - from: input://file-cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9/${files.const.files.kickstart.id}
                 to: tree:///root/anaconda-ks.cfg
                 remove_destination: true
         - type: org.osbuild.chown
@@ -150,8 +161,6 @@ otk.target.osbuild:
             packagesets:
               - ${packages.build}
               - ${packages.os}
-        - org.osbuild.inline:
-            items:
-              sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9:
-                encoding: base64
-                data: IyBSdW4gaW5pdGlhbC1zZXR1cCBvbiBmaXJzdCBib290CiMgQ3JlYXRlZCBieSBvc2J1aWxkCmZpcnN0Ym9vdCAtLXJlY29uZmlnCmxhbmcgZW5fVVMuVVRGLTgK
+        - otk.external.osbuild-make-inline-source:
+            const:
+              files: ${files.const.files}

--- a/example/centos/common/partition-table/aarch64/minimal-raw.yaml
+++ b/example/centos/common/partition-table/aarch64/minimal-raw.yaml
@@ -1,0 +1,41 @@
+otk.define:
+  filesystem:
+    otk.external.otk-gen-partition-table:
+      modifications:
+        ${filesystem.modifications}
+      properties:
+        type: gpt
+        bios: true
+        default_size: "2 GiB"
+        uuid: D209C89E-EA5E-4FBD-B161-B461CCE297E0
+        start_offset: "8 MiB"
+        create:
+          bios_boot_partition: false
+          esp_partition: true
+          esp_partition_size: "200 MiB"
+      partitions:
+        - name: boot
+          mountpoint: /boot
+          label: boot
+          size: "600 MiB"
+          type: "xfs"
+          fs_mntops: defaults
+          # XXX: should we derive this automatically from the mountpoint?
+          part_type: BC13C2FF-59E6-4262-A352-B275FD6F7172
+          # we use hardcoded uuids for compatibility with "images"
+          part_uuid: CB07C243-BC44-4717-853E-28852021225B
+        - name: root
+          mountpoint: /
+          label: root
+          type: "xfs"
+          size: "2 GiB"
+          fs_mntops: defaults
+          # XXX: should we derive this automatically from the mountpoint?
+          part_type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          # we use hardcoded uuids for compatibility with "images"
+          part_uuid: 6264D520-3FB9-423F-8AB8-7A0A8E3D3562
+  # XXX: it would be nicer if the "fs_options" could be part of their
+  # stages directly without this indirection.
+  fs_options:
+    otk.external.otk-make-partition-mounts-devices:
+      ${filesystem}

--- a/example/centos/common/partition-table/x86_64/minimal-raw.yaml
+++ b/example/centos/common/partition-table/x86_64/minimal-raw.yaml
@@ -1,0 +1,41 @@
+otk.define:
+  filesystem:
+    otk.external.otk-gen-partition-table:
+      modifications:
+        ${filesystem.modifications}
+      properties:
+        type: gpt
+        bios: false
+        default_size: "2 GiB"
+        uuid: D209C89E-EA5E-4FBD-B161-B461CCE297E0
+        start_offset: "8 MiB"
+        create:
+          bios_boot_partition: false
+          esp_partition: true
+          esp_partition_size: "200 MiB"
+      partitions:
+        - name: boot
+          mountpoint: /boot
+          label: boot
+          size: "600 MiB"
+          type: "xfs"
+          fs_mntops: defaults
+          # XXX: should we derive this automatically from the mountpoint?
+          part_type: BC13C2FF-59E6-4262-A352-B275FD6F7172
+          # we use hardcoded uuids for compatibility with "images"
+          part_uuid: CB07C243-BC44-4717-853E-28852021225B
+        - name: root
+          mountpoint: /
+          label: root
+          type: "xfs"
+          size: "2 GiB"
+          fs_mntops: defaults
+          # XXX: should we derive this automatically from the mountpoint?
+          part_type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          # we use hardcoded uuids for compatibility with "images"
+          part_uuid: 6264D520-3FB9-423F-8AB8-7A0A8E3D3562
+  # XXX: it would be nicer if the "fs_options" could be part of their
+  # stages directly without this indirection.
+  fs_options:
+    otk.external.otk-make-partition-mounts-devices:
+      ${filesystem}

--- a/example/centos/fragment/grub2/x86_64-no-bios.yaml
+++ b/example/centos/fragment/grub2/x86_64-no-bios.yaml
@@ -1,0 +1,12 @@
+type: org.osbuild.grub2
+options:
+  root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
+  boot_fs_uuid: ${filesystem.const.partition_map.boot.uuid}
+  kernel_opts: ${kernel.cmdline}
+  uefi:
+    vendor: centos
+    unified: true
+  saved_entry: ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64
+  write_cmdline: false
+  config:
+    default: saved

--- a/example/centos/pipeline/image/x86_64-no-bios.yaml
+++ b/example/centos/pipeline/image/x86_64-no-bios.yaml
@@ -1,0 +1,22 @@
+name: image
+build: name:build
+stages:
+  otk.op.join:
+    values:
+      - otk.external.otk-make-partition-stages:
+          ${filesystem}
+      - - type: org.osbuild.copy
+          inputs:
+            root-tree:
+              type: org.osbuild.tree
+              origin: org.osbuild.pipeline
+              references:
+                - name:os
+          options:
+            paths:
+              - from: input://root-tree/
+                to: mount://-/
+          devices:
+            ${fs_options.devices}
+          mounts:
+            ${fs_options.mounts}

--- a/test/data/images-ref/centos/9/aarch64/minimal-raw/centos_9-aarch64-minimal_raw-empty.yaml
+++ b/test/data/images-ref/centos/9/aarch64/minimal-raw/centos_9-aarch64-minimal_raw-empty.yaml
@@ -1,0 +1,442 @@
+version: '2'
+pipelines:
+  - name: build
+    runner: org.osbuild.centos9
+    stages:
+      - type: org.osbuild.rpm
+        inputs:
+          packages:
+            type: org.osbuild.files
+            origin: org.osbuild.source
+            references:
+              - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
+              - id: sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0
+              - id: sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a
+              - id: sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d
+              - id: sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a
+              - id: sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98
+              - id: sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d
+              - id: sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49
+              - id: sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15
+              - id: sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88
+              - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
+              - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
+              - id: sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49
+              - id: sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15
+              - id: sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88
+              - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
+              - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
+              - id: sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a
+              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
+              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+        options:
+          gpgkeys:
+            - '-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+
+              mQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn
+
+              rIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ
+
+              8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X
+
+              5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c
+
+              aevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e
+
+              f+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7
+
+              JINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m
+
+              vufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk
+
+              nHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry
+
+              Gat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y
+
+              m4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB
+
+              tDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5
+
+              QGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB
+
+              Ah4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl
+
+              Gy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs
+
+              N3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD
+
+              vOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq
+
+              a0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw
+
+              byaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg
+
+              q4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X
+
+              407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z
+
+              V6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG
+
+              rCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32
+
+              o8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy
+
+              yy+mHmSv
+
+              =kkH7
+
+              -----END PGP PUBLIC KEY BLOCK-----'
+      - type: org.osbuild.selinux
+        options:
+          file_contexts: etc/selinux/targeted/contexts/files/file_contexts
+          labels:
+            /usr/bin/cp: system_u:object_r:install_exec_t:s0
+  - name: os
+    build: name:build
+    stages:
+      - type: org.osbuild.kernel-cmdline
+        options:
+          root_fs_uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
+          kernel_opts: ro
+      - type: org.osbuild.rpm
+        inputs:
+          packages:
+            type: org.osbuild.files
+            origin: org.osbuild.source
+            references:
+              - id: sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00
+              - id: sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d
+              - id: sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387
+              - id: sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d
+              - id: sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f
+              - id: sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c
+              - id: sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49
+              - id: sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15
+              - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
+              - id: sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a
+              - id: sha256:f4273aed83076f85fdab08afe889a0d6d8e363c676fcd2972f8665fd1ef71cd9
+              - id: sha256:690674223d17be8d11986a73e422c435b29788b99344aa7705076848e59bf944
+              - id: sha256:f19322aff95a0dab072e7d976be364f553e46efd51e1a602adae348b7c38af29
+              - id: sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7
+              - id: sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018
+              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
+              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+        options:
+          gpgkeys:
+            - '-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+
+              mQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn
+
+              rIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ
+
+              8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X
+
+              5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c
+
+              aevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e
+
+              f+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7
+
+              JINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m
+
+              vufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk
+
+              nHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry
+
+              Gat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y
+
+              m4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB
+
+              tDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5
+
+              QGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB
+
+              Ah4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl
+
+              Gy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs
+
+              N3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD
+
+              vOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq
+
+              a0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw
+
+              byaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg
+
+              q4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X
+
+              407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z
+
+              V6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG
+
+              rCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32
+
+              o8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy
+
+              yy+mHmSv
+
+              =kkH7
+
+              -----END PGP PUBLIC KEY BLOCK-----'
+      - type: org.osbuild.fix-bls
+        options:
+          prefix: ''
+      - type: org.osbuild.locale
+        options:
+          language: C.UTF-8
+      - type: org.osbuild.timezone
+        options:
+          zone: America/New_York
+      - type: org.osbuild.sysconfig
+        options:
+          kernel:
+            update_default: true
+            default_kernel: kernel
+          network:
+            networking: true
+            no_zero_conf: true
+      - type: org.osbuild.systemd.unit
+        options:
+          unit: grub-boot-success.timer
+          dropin: 10-disable-if-greenboot.conf
+          config:
+            Unit:
+              ConditionPathExists: '!/usr/libexec/greenboot/greenboot'
+          unit-type: global
+      - type: org.osbuild.fstab
+        options:
+          filesystems:
+            - uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
+              vfs_type: xfs
+              path: /
+              options: defaults
+            - uuid: dbd21911-1c4e-4107-8a9f-14fe6e751358
+              vfs_type: xfs
+              path: /boot
+              options: defaults
+            - uuid: 7B77-95E7
+              vfs_type: vfat
+              path: /boot/efi
+              options: defaults,uid=0,gid=0,umask=077,shortname=winnt
+              passno: 2
+      - type: org.osbuild.grub2
+        options:
+          root_fs_uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
+          boot_fs_uuid: dbd21911-1c4e-4107-8a9f-14fe6e751358
+          kernel_opts: ro
+          uefi:
+            vendor: centos
+            unified: true
+          saved_entry: ffffffffffffffffffffffffffffffff-8-2.fk1.aarch64
+          write_cmdline: false
+          config:
+            default: saved
+      - type: org.osbuild.copy
+        inputs:
+          file-cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9:
+            type: org.osbuild.files
+            origin: org.osbuild.source
+            references:
+              - id: sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9
+        options:
+          paths:
+            - from: input://file-cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9/sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9
+              to: tree:///root/anaconda-ks.cfg
+              remove_destination: true
+      - type: org.osbuild.chown
+        options:
+          items:
+            /root/anaconda-ks.cfg:
+              user: root
+              group: root
+      - type: org.osbuild.systemd
+        options:
+          enabled_services:
+            - NetworkManager.service
+            - firewalld.service
+            - sshd.service
+            - initial-setup.service
+      - type: org.osbuild.selinux
+        options:
+          file_contexts: etc/selinux/targeted/contexts/files/file_contexts
+  - name: image
+    build: name:build
+    stages:
+      - type: org.osbuild.truncate
+        options:
+          filename: disk.img
+          size: '4070572032'
+      - type: org.osbuild.sfdisk
+        options:
+          label: gpt
+          uuid: D209C89E-EA5E-4FBD-B161-B461CCE297E0
+          partitions:
+            - size: 409600
+              start: 18432
+              type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+              uuid: 68B2905B-DF3E-4FB3-80FA-49D1E773AA33
+            - size: 1228800
+              start: 428032
+              type: BC13C2FF-59E6-4262-A352-B275FD6F7172
+              uuid: CB07C243-BC44-4717-853E-28852021225B
+            - size: 6293471
+              start: 1656832
+              type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+              uuid: 6264D520-3FB9-423F-8AB8-7A0A8E3D3562
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              lock: true
+      - type: org.osbuild.mkfs.fat
+        options:
+          volid: 7B7795E7
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 18432
+              size: 409600
+              lock: true
+      - type: org.osbuild.mkfs.xfs
+        options:
+          uuid: dbd21911-1c4e-4107-8a9f-14fe6e751358
+          label: boot
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 428032
+              size: 1228800
+              lock: true
+      - type: org.osbuild.mkfs.xfs
+        options:
+          uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
+          label: root
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 1656832
+              size: 6293471
+              lock: true
+      - type: org.osbuild.copy
+        inputs:
+          root-tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:os
+        options:
+          paths:
+            - from: input://root-tree/
+              to: mount://-/
+        devices:
+          '-':
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 1656832
+              size: 6293471
+          boot:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 428032
+              size: 1228800
+          boot-efi:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 18432
+              size: 409600
+        mounts:
+          - name: '-'
+            type: org.osbuild.xfs
+            source: '-'
+            target: /
+          - name: boot
+            type: org.osbuild.xfs
+            source: boot
+            target: /boot
+          - name: boot-efi
+            type: org.osbuild.fat
+            source: boot-efi
+            target: /boot/efi
+  - name: xz
+    build: name:build
+    stages:
+      - type: org.osbuild.xz
+        inputs:
+          file:
+            type: org.osbuild.files
+            origin: org.osbuild.pipeline
+            references:
+              name:image:
+                file: disk.img
+        options:
+          filename: disk.raw.xz
+sources:
+  org.osbuild.curl:
+    items:
+      sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
+        url: https://example.com/repo/packages/dosfstools
+      sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387:
+        url: https://example.com/repo/packages/grub2-efi-aa64
+      sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d:
+        url: https://example.com/repo/packages/glibc
+      sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49:
+        url: https://example.com/repo/packages/xfsprogs
+      sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
+        url: https://example.com/repo/packages/coreutils
+      sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a:
+        url: https://example.com/repo/packages/@core
+      sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00:
+        url: https://example.com/repo/packages/dracut-config-generic
+      sha256:690674223d17be8d11986a73e422c435b29788b99344aa7705076848e59bf944:
+        url: https://example.com/repo/packages/libxkbcommon
+      sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c:
+        url: https://example.com/repo/packages/kernel
+      sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-appstream
+      sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-baseos
+      sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
+        url: https://example.com/repo/packages/platform-python
+      sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a:
+        url: https://example.com/repo/packages/xz
+      sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700:
+        url: https://example.com/repo/packages/policycoreutils
+      sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88:
+        url: https://example.com/repo/packages/rpm
+      sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018:
+        url: https://example.com/repo/packages/iwl3160-firmware
+      sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528:
+        url: https://example.com/repo/packages/selinux-policy-targeted
+      sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:
+        url: https://example.com/repo/packages/python3
+      sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98:
+        url: https://example.com/repo/packages/systemd
+      sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d:
+        url: https://example.com/repo/packages/efibootmgr
+      sha256:eaa83a86c658bfd0c01894a695993f394ee51794f31dc607f4a47e31cb50fc6d:
+        url: https://example.com/repo/packages/grub2-tools
+      sha256:f19322aff95a0dab072e7d976be364f553e46efd51e1a602adae348b7c38af29:
+        url: https://example.com/repo/packages/NetworkManager-wifi
+      sha256:f4273aed83076f85fdab08afe889a0d6d8e363c676fcd2972f8665fd1ef71cd9:
+        url: https://example.com/repo/packages/initial-setup
+      sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f:
+        url: https://example.com/repo/packages/shim-aa64
+      sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7:
+        url: https://example.com/repo/packages/iwl7260-firmware
+  org.osbuild.inline:
+    items:
+      sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9:
+        encoding: base64
+        data: IyBSdW4gaW5pdGlhbC1zZXR1cCBvbiBmaXJzdCBib290CiMgQ3JlYXRlZCBieSBvc2J1aWxkCmZpcnN0Ym9vdCAtLXJlY29uZmlnCmxhbmcgZW5fVVMuVVRGLTgK

--- a/test/data/images-ref/centos/9/x86_64/minimal-raw/centos_9-x86_64-minimal_raw-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/minimal-raw/centos_9-x86_64-minimal_raw-empty.yaml
@@ -1,0 +1,443 @@
+version: '2'
+pipelines:
+  - name: build
+    runner: org.osbuild.centos9
+    stages:
+      - type: org.osbuild.rpm
+        inputs:
+          packages:
+            type: org.osbuild.files
+            origin: org.osbuild.source
+            references:
+              - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
+              - id: sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0
+              - id: sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a
+              - id: sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d
+              - id: sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a
+              - id: sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98
+              - id: sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d
+              - id: sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49
+              - id: sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15
+              - id: sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88
+              - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
+              - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
+              - id: sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49
+              - id: sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15
+              - id: sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88
+              - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
+              - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
+              - id: sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a
+              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
+              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
+              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+        options:
+          gpgkeys:
+            - '-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+
+              mQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn
+
+              rIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ
+
+              8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X
+
+              5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c
+
+              aevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e
+
+              f+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7
+
+              JINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m
+
+              vufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk
+
+              nHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry
+
+              Gat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y
+
+              m4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB
+
+              tDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5
+
+              QGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB
+
+              Ah4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl
+
+              Gy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs
+
+              N3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD
+
+              vOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq
+
+              a0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw
+
+              byaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg
+
+              q4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X
+
+              407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z
+
+              V6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG
+
+              rCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32
+
+              o8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy
+
+              yy+mHmSv
+
+              =kkH7
+
+              -----END PGP PUBLIC KEY BLOCK-----'
+      - type: org.osbuild.selinux
+        options:
+          file_contexts: etc/selinux/targeted/contexts/files/file_contexts
+          labels:
+            /usr/bin/cp: system_u:object_r:install_exec_t:s0
+  - name: os
+    build: name:build
+    stages:
+      - type: org.osbuild.kernel-cmdline
+        options:
+          root_fs_uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
+          kernel_opts: ro
+      - type: org.osbuild.rpm
+        inputs:
+          packages:
+            type: org.osbuild.files
+            origin: org.osbuild.source
+            references:
+              - id: sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00
+              - id: sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d
+              - id: sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4
+              - id: sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253
+              - id: sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c
+              - id: sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49
+              - id: sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15
+              - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
+              - id: sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a
+              - id: sha256:f4273aed83076f85fdab08afe889a0d6d8e363c676fcd2972f8665fd1ef71cd9
+              - id: sha256:690674223d17be8d11986a73e422c435b29788b99344aa7705076848e59bf944
+              - id: sha256:f19322aff95a0dab072e7d976be364f553e46efd51e1a602adae348b7c38af29
+              - id: sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7
+              - id: sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018
+              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
+              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
+              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+        options:
+          gpgkeys:
+            - '-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+
+              mQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn
+
+              rIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ
+
+              8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X
+
+              5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c
+
+              aevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e
+
+              f+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7
+
+              JINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m
+
+              vufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk
+
+              nHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry
+
+              Gat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y
+
+              m4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB
+
+              tDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5
+
+              QGNlbnRvcy5vcmc+iQI3BBMBAgAhBQJczFsZAhsDBgsJCAcDAgYVCAIJCgsDFgIB
+
+              Ah4BAheAAAoJEAW1VbOEg8ZdjOsP/2ygSxH9jqffOU9SKyJDlraL2gIutqZ3B8pl
+
+              Gy/Qnb9QD1EJVb4ZxOEhcY2W9VJfIpnf3yBuAto7zvKe/G1nxH4Bt6WTJQCkUjcs
+
+              N3qPWsx1VslsAEz7bXGiHym6Ay4xF28bQ9XYIokIQXd0T2rD3/lNGxNtORZ2bKjD
+
+              vOzYzvh2idUIY1DgGWJ11gtHFIA9CvHcW+SMPEhkcKZJAO51ayFBqTSSpiorVwTq
+
+              a0cB+cgmCQOI4/MY+kIvzoexfG7xhkUqe0wxmph9RQQxlTbNQDCdaxSgwbF2T+gw
+
+              byaDvkS4xtR6Soj7BKjKAmcnf5fn4C5Or0KLUqMzBtDMbfQQihn62iZJN6ZZ/4dg
+
+              q4HTqyVpyuzMXsFpJ9L/FqH2DJ4exGGpBv00ba/Zauy7GsqOc5PnNBsYaHCply0X
+
+              407DRx51t9YwYI/ttValuehq9+gRJpOTTKp6AjZn/a5Yt3h6jDgpNfM/EyLFIY9z
+
+              V6CXqQQ/8JRvaik/JsGCf+eeLZOw4koIjZGEAg04iuyNTjhx0e/QHEVcYAqNLhXG
+
+              rCTTbCn3NSUO9qxEXC+K/1m1kaXoCGA0UWlVGZ1JSifbbMx0yxq/brpEZPUYm+32
+
+              o8XfbocBWljFUJ+6aljTvZ3LQLKTSPW7TFO+GXycAOmCGhlXh2tlc6iTc41PACqy
+
+              yy+mHmSv
+
+              =kkH7
+
+              -----END PGP PUBLIC KEY BLOCK-----'
+      - type: org.osbuild.fix-bls
+        options:
+          prefix: ''
+      - type: org.osbuild.locale
+        options:
+          language: C.UTF-8
+      - type: org.osbuild.timezone
+        options:
+          zone: America/New_York
+      - type: org.osbuild.sysconfig
+        options:
+          kernel:
+            update_default: true
+            default_kernel: kernel
+          network:
+            networking: true
+            no_zero_conf: true
+      - type: org.osbuild.systemd.unit
+        options:
+          unit: grub-boot-success.timer
+          dropin: 10-disable-if-greenboot.conf
+          config:
+            Unit:
+              ConditionPathExists: '!/usr/libexec/greenboot/greenboot'
+          unit-type: global
+      - type: org.osbuild.fstab
+        options:
+          filesystems:
+            - uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
+              vfs_type: xfs
+              path: /
+              options: defaults
+            - uuid: dbd21911-1c4e-4107-8a9f-14fe6e751358
+              vfs_type: xfs
+              path: /boot
+              options: defaults
+            - uuid: 7B77-95E7
+              vfs_type: vfat
+              path: /boot/efi
+              options: defaults,uid=0,gid=0,umask=077,shortname=winnt
+              passno: 2
+      - type: org.osbuild.grub2
+        options:
+          root_fs_uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
+          boot_fs_uuid: dbd21911-1c4e-4107-8a9f-14fe6e751358
+          kernel_opts: ro
+          uefi:
+            vendor: centos
+            unified: true
+          saved_entry: ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64
+          write_cmdline: false
+          config:
+            default: saved
+      - type: org.osbuild.copy
+        inputs:
+          file-cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9:
+            type: org.osbuild.files
+            origin: org.osbuild.source
+            references:
+              - id: sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9
+        options:
+          paths:
+            - from: input://file-cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9/sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9
+              to: tree:///root/anaconda-ks.cfg
+              remove_destination: true
+      - type: org.osbuild.chown
+        options:
+          items:
+            /root/anaconda-ks.cfg:
+              user: root
+              group: root
+      - type: org.osbuild.systemd
+        options:
+          enabled_services:
+            - NetworkManager.service
+            - firewalld.service
+            - sshd.service
+            - initial-setup.service
+      - type: org.osbuild.selinux
+        options:
+          file_contexts: etc/selinux/targeted/contexts/files/file_contexts
+  - name: image
+    build: name:build
+    stages:
+      - type: org.osbuild.truncate
+        options:
+          filename: disk.img
+          size: '4070572032'
+      - type: org.osbuild.sfdisk
+        options:
+          label: gpt
+          uuid: D209C89E-EA5E-4FBD-B161-B461CCE297E0
+          partitions:
+            - size: 409600
+              start: 18432
+              type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+              uuid: 68B2905B-DF3E-4FB3-80FA-49D1E773AA33
+            - size: 1228800
+              start: 428032
+              type: BC13C2FF-59E6-4262-A352-B275FD6F7172
+              uuid: CB07C243-BC44-4717-853E-28852021225B
+            - size: 6293471
+              start: 1656832
+              type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+              uuid: 6264D520-3FB9-423F-8AB8-7A0A8E3D3562
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              lock: true
+      - type: org.osbuild.mkfs.fat
+        options:
+          volid: 7B7795E7
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 18432
+              size: 409600
+              lock: true
+      - type: org.osbuild.mkfs.xfs
+        options:
+          uuid: dbd21911-1c4e-4107-8a9f-14fe6e751358
+          label: boot
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 428032
+              size: 1228800
+              lock: true
+      - type: org.osbuild.mkfs.xfs
+        options:
+          uuid: 9851898e-0b30-437d-8fad-51ec16c3697f
+          label: root
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 1656832
+              size: 6293471
+              lock: true
+      - type: org.osbuild.copy
+        inputs:
+          root-tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:os
+        options:
+          paths:
+            - from: input://root-tree/
+              to: mount://-/
+        devices:
+          '-':
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 1656832
+              size: 6293471
+          boot:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 428032
+              size: 1228800
+          boot-efi:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start: 18432
+              size: 409600
+        mounts:
+          - name: '-'
+            type: org.osbuild.xfs
+            source: '-'
+            target: /
+          - name: boot
+            type: org.osbuild.xfs
+            source: boot
+            target: /boot
+          - name: boot-efi
+            type: org.osbuild.fat
+            source: boot-efi
+            target: /boot/efi
+  - name: xz
+    build: name:build
+    stages:
+      - type: org.osbuild.xz
+        inputs:
+          file:
+            type: org.osbuild.files
+            origin: org.osbuild.pipeline
+            references:
+              name:image:
+                file: disk.img
+        options:
+          filename: disk.raw.xz
+sources:
+  org.osbuild.curl:
+    items:
+      sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
+        url: https://example.com/repo/packages/dosfstools
+      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
+      sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d:
+        url: https://example.com/repo/packages/glibc
+      sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49:
+        url: https://example.com/repo/packages/xfsprogs
+      sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
+        url: https://example.com/repo/packages/coreutils
+      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
+      sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a:
+        url: https://example.com/repo/packages/@core
+      sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00:
+        url: https://example.com/repo/packages/dracut-config-generic
+      sha256:690674223d17be8d11986a73e422c435b29788b99344aa7705076848e59bf944:
+        url: https://example.com/repo/packages/libxkbcommon
+      sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c:
+        url: https://example.com/repo/packages/kernel
+      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
+        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
+      sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
+        url: https://example.com/repo/packages/platform-python
+      sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a:
+        url: https://example.com/repo/packages/xz
+      sha256:9370ee4e95b7172989b9fd3f81860093529113ba42b69be340467d87a94bb253:
+        url: https://example.com/repo/packages/shim-x64
+      sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700:
+        url: https://example.com/repo/packages/policycoreutils
+      sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88:
+        url: https://example.com/repo/packages/rpm
+      sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018:
+        url: https://example.com/repo/packages/iwl3160-firmware
+      sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528:
+        url: https://example.com/repo/packages/selinux-policy-targeted
+      sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:
+        url: https://example.com/repo/packages/python3
+      sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4:
+        url: https://example.com/repo/packages/grub2-efi-x64
+      sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98:
+        url: https://example.com/repo/packages/systemd
+      sha256:e2f24de304a49d3d3c1261466376ab341c3834eb683d806cb534587f4fd48f8d:
+        url: https://example.com/repo/packages/efibootmgr
+      sha256:f19322aff95a0dab072e7d976be364f553e46efd51e1a602adae348b7c38af29:
+        url: https://example.com/repo/packages/NetworkManager-wifi
+      sha256:f4273aed83076f85fdab08afe889a0d6d8e363c676fcd2972f8665fd1ef71cd9:
+        url: https://example.com/repo/packages/initial-setup
+      sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7:
+        url: https://example.com/repo/packages/iwl7260-firmware
+  org.osbuild.inline:
+    items:
+      sha256:cbe2cb6e47e05af3b653e2567e9ee04ba7d9dcf8fdc2cfd15b232a0844c128f9:
+        encoding: base64
+        data: IyBSdW4gaW5pdGlhbC1zZXR1cCBvbiBmaXJzdCBib290CiMgQ3JlYXRlZCBieSBvc2J1aWxkCmZpcnN0Ym9vdCAtLXJlY29uZmlnCmxhbmcgZW5fVVMuVVRGLTgK


### PR DESCRIPTION
Generated manifests and initial deduplication for the minimal-raw image type.

A new partition table is added for the minimal raw images.

Since the x86_64 images here don't support BIOS booting some includes had to be split into non-BIOS versions.

Based on #219.