### PR TITLE
example: use `${kernel.package...}` more consistently

### DIFF
--- a/example/centos/centos-9-aarch64-image-installer.yaml
+++ b/example/centos/centos-9-aarch64-image-installer.yaml
@@ -308,6 +308,7 @@ otk.target.osbuild:
         - type: org.osbuild.dracut
           options:
             kernel:
+              # XXX: which kernel here, from the anaconda or os package set?
               - 8-2.fk1.aarch64
             modules:
               - bash
@@ -470,6 +471,7 @@ otk.target.osbuild:
                 - name:anaconda-tree
           options:
             paths:
+              # XXX: kernel from anaconda package set(?)
               - from: input://tree/boot/vmlinuz-8-2.fk1.aarch64
                 to: tree:///images/pxeboot/vmlinuz
               - from: input://tree/boot/initramfs-8-2.fk1.aarch64.img

--- a/example/centos/centos-9-x86_64-ami.yaml
+++ b/example/centos/centos-9-x86_64-ami.yaml
@@ -4,8 +4,6 @@ otk.define:
   filesystem:
     modifications:
       filename: "image.raw"
-  kernel:
-    cmdline: console=tty0 console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
@@ -97,6 +95,12 @@ otk.define:
             - plymouth
             - dracut-config-rescue
             - qemu-guest-agent
+  kernel:
+    cmdline: console=tty0 console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295
+    package:
+      otk.external.osbuild-get-dnf4-package-info:
+        packageset: ${packages.os}
+        packagename: "kernel"
 
 otk.include: "common/partition-table/x86_64.yaml"
 

--- a/example/centos/centos-9-x86_64-qcow2.yaml
+++ b/example/centos/centos-9-x86_64-qcow2.yaml
@@ -4,8 +4,6 @@ otk.define:
   filesystem:
     modifications:
     # empty
-  kernel:
-    cmdline: console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
@@ -104,6 +102,12 @@ otk.define:
             - plymouth
             - rng-tools
             - udisks2
+  kernel:
+    cmdline: console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0
+    package:
+      otk.external.osbuild-get-dnf4-package-info:
+        packageset: ${packages.os}
+        packagename: "kernel"
 
 otk.include: "common/partition-table/x86_64.yaml"
 

--- a/example/centos/fragment/grub2/x86_64.yaml
+++ b/example/centos/fragment/grub2/x86_64.yaml
@@ -7,7 +7,7 @@ options:
   uefi:
     vendor: centos
     unified: true
-  saved_entry: ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64
+  saved_entry: ffffffffffffffffffffffffffffffff-${kernel.package.version}-${kernel.package.release}.${kernel.package.arch}
   write_cmdline: false
   config:
     default: saved


### PR DESCRIPTION
This commit adds the `${kernel.package...}` feature for grub2 for x86_64 similar to aarch64. It also adds some TODO in the other places that we need the kernel version and currently hardcoding it.