### PR TITLE
example: drop hardcoding kernel version from image-isntaller

### DIFF
--- a/example/centos/centos-9-aarch64-image-installer.yaml
+++ b/example/centos/centos-9-aarch64-image-installer.yaml
@@ -258,6 +258,12 @@ otk.define:
             - xorg-x11-xauth
             - xz
           exclude: []
+  kernel:
+    anaconda:
+      package:
+        otk.external.osbuild-get-dnf4-package-info:
+          packageset: ${packages.anaconda}
+          packagename: "kernel"
 
 otk.target.osbuild:
   pipelines:
@@ -308,8 +314,7 @@ otk.target.osbuild:
         - type: org.osbuild.dracut
           options:
             kernel:
-              # XXX: which kernel here, from the anaconda or os package set?
-              - 8-2.fk1.aarch64
+              - ${kernel.anaconda.package.version}-${kernel.anaconda.package.release}.${kernel.anaconda.package.arch}
             modules:
               - bash
               - systemd
@@ -471,10 +476,9 @@ otk.target.osbuild:
                 - name:anaconda-tree
           options:
             paths:
-              # XXX: kernel from anaconda package set(?)
-              - from: input://tree/boot/vmlinuz-8-2.fk1.aarch64
+              - from: input://tree/boot/vmlinuz-${kernel.anaconda.package.version}-${kernel.anaconda.package.release}.${kernel.anaconda.package.arch}
                 to: tree:///images/pxeboot/vmlinuz
-              - from: input://tree/boot/initramfs-8-2.fk1.aarch64.img
+              - from: input://tree/boot/initramfs-${kernel.anaconda.package.version}-${kernel.anaconda.package.release}.${kernel.anaconda.package.arch}.img
                 to: tree:///images/pxeboot/initrd.img
         - type: org.osbuild.squashfs
           inputs:

--- a/example/centos/centos-9-x86_64-image-installer.yaml
+++ b/example/centos/centos-9-x86_64-image-installer.yaml
@@ -271,6 +271,12 @@ otk.define:
             - xorg-x11-xauth
             - xz
           exclude: []
+  kernel:
+    anaconda:
+      package:
+        otk.external.osbuild-get-dnf4-package-info:
+          packageset: ${packages.anaconda}
+          packagename: "kernel"
 
 otk.target.osbuild:
   pipelines:
@@ -321,7 +327,7 @@ otk.target.osbuild:
         - type: org.osbuild.dracut
           options:
             kernel:
-              - 8-2.fk1.x86_64
+              - ${kernel.anaconda.package.version}-${kernel.anaconda.package.release}.${kernel.anaconda.package.arch}
             modules:
               - bash
               - systemd
@@ -484,9 +490,9 @@ otk.target.osbuild:
                 - name:anaconda-tree
           options:
             paths:
-              - from: input://tree/boot/vmlinuz-8-2.fk1.x86_64
+              - from: input://tree/boot/vmlinuz-${kernel.anaconda.package.version}-${kernel.anaconda.package.release}.${kernel.anaconda.package.arch}
                 to: tree:///images/pxeboot/vmlinuz
-              - from: input://tree/boot/initramfs-8-2.fk1.x86_64.img
+              - from: input://tree/boot/initramfs-${kernel.anaconda.package.version}-${kernel.anaconda.package.release}.${kernel.anaconda.package.arch}.img
                 to: tree:///images/pxeboot/initrd.img
         - type: org.osbuild.squashfs
           inputs:


### PR DESCRIPTION
This commit moves the image installer to use the
`osbuild-get-dnf4-package-info` external to get details about
the kernel version and use that in the anaconda pipeline.


[draft as this requires https://github.com/osbuild/otk/pull/236 and I also want someone experienced with images to double check, I'm 85% confident that picking the kernel version from the anaconda packageset is the right move but we cannot differenciate this in our tests right now so it requires (careful) manual checking.