### PR TITLE
Add externals for managing embedded files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ osbuild-gen-depsolve-dnf4 = "otk_external_osbuild.command.gen_depsolve_dnf4:main
 osbuild-make-depsolve-dnf4-rpm-stage = "otk_external_osbuild.command.make_depsolve_dnf4_rpm_stage:main"
 osbuild-make-depsolve-dnf4-curl-source = "otk_external_osbuild.command.make_depsolve_dnf4_curl_source:main"
 osbuild-get-dnf4-package-info = "otk_external_osbuild.command.get_dnf4_package_info:main"
+osbuild-gen-inline-files = "otk_external_osbuild.command.gen_inline_files:main"
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ osbuild-make-depsolve-dnf4-rpm-stage = "otk_external_osbuild.command.make_depsol
 osbuild-make-depsolve-dnf4-curl-source = "otk_external_osbuild.command.make_depsolve_dnf4_curl_source:main"
 osbuild-get-dnf4-package-info = "otk_external_osbuild.command.get_dnf4_package_info:main"
 osbuild-gen-inline-files = "otk_external_osbuild.command.gen_inline_files:main"
+osbuild-make-inline-source = "otk_external_osbuild.command.make_inline_source:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/otk_external_osbuild/command/gen_inline_files.py
+++ b/src/otk_external_osbuild/command/gen_inline_files.py
@@ -1,27 +1,43 @@
 import base64
 import hashlib
 import json
+import pathlib
 import sys
 from typing import TextIO
+
+
+def process_contents(contents):
+    digest = hashlib.sha256(contents).hexdigest()
+    source_id = f"sha256:{digest}"
+    b64contents = base64.b64encode(contents).decode("utf8")
+    return {
+        "id": source_id,
+        "data": b64contents,
+    }
 
 
 def root(input_stream: TextIO) -> None:
     data = json.loads(input_stream.read())
     tree = data["tree"]
 
-    files = tree["files"]
+    inline_files = tree.get("inline", {})
     inlines: dict = {}
-    for name, item in files.items():
+    for name, item in inline_files.items():
         contents = item["contents"].encode("utf8")
+        inlines[name] = process_contents(contents)
 
-        digest = hashlib.sha256(contents).hexdigest()
-        source_id = f"sha256:{digest}"
+    inline_paths = tree.get("paths", {})
+    for name, item in inline_paths.items():
+        path = item["path"]
+        read_type = item["type"]
+        if read_type == "text":
+            contents = pathlib.Path(path).read_text(encoding="utf-8").encode("utf-8")
+        elif read_type == "binary":
+            contents = pathlib.Path(path).read_bytes()
+        else:
+            raise ValueError(f"invalid type for inline path {path}: {read_type}")
 
-        b64contents = base64.b64encode(contents).decode("utf8")
-        inlines[name] = {
-            "id": source_id,
-            "data": b64contents,
-        }
+        inlines[name] = process_contents(contents)
 
     output = {
         "tree": {

--- a/src/otk_external_osbuild/command/gen_inline_files.py
+++ b/src/otk_external_osbuild/command/gen_inline_files.py
@@ -1,0 +1,42 @@
+import base64
+import hashlib
+import json
+import sys
+from typing import TextIO
+
+
+def root(input_stream: TextIO) -> None:
+    data = json.loads(input_stream.read())
+    tree = data["tree"]
+
+    files = tree["files"]
+    inlines: dict = {}
+    for name, item in files.items():
+        contents = item["contents"].encode("utf8")
+
+        digest = hashlib.sha256(contents).hexdigest()
+        source_id = f"sha256:{digest}"
+
+        b64contents = base64.b64encode(contents).decode("utf8")
+        inlines[name] = {
+            "id": source_id,
+            "data": b64contents,
+        }
+
+    output = {
+        "tree": {
+            "const": {
+                "files": inlines,
+            }
+        }
+    }
+
+    sys.stdout.write(json.dumps(output))
+
+
+def main():
+    root(sys.stdin)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/otk_external_osbuild/command/gen_inline_files.py
+++ b/src/otk_external_osbuild/command/gen_inline_files.py
@@ -28,6 +28,9 @@ def root(input_stream: TextIO) -> None:
 
     inline_paths = tree.get("paths", {})
     for name, item in inline_paths.items():
+        if name in inlines:
+            raise KeyError(f"duplicate name found for inline files: {name}")
+
         path = item["path"]
         read_type = item["type"]
         if read_type == "text":

--- a/src/otk_external_osbuild/command/make_inline_source.py
+++ b/src/otk_external_osbuild/command/make_inline_source.py
@@ -1,0 +1,33 @@
+import json
+import sys
+from typing import TextIO
+
+
+def root(input_stream: TextIO) -> None:
+    data = json.load(input_stream)
+    tree = data["tree"]
+    files = tree["const"]["files"]
+
+    items = {}
+
+    for file in files.values():
+        items[file["id"]] = {
+            "encoding": "base64",
+            "data": file["data"],
+        }
+
+    sys.stdout.write(
+        json.dumps(
+            {
+                "tree": {"org.osbuild.inline": {"items": items}}
+            }
+        )
+    )
+
+
+def main():
+    root(sys.stdin)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_gen_inline_files.py
+++ b/test/test_gen_inline_files.py
@@ -1,11 +1,12 @@
 import json
+import os
 from io import StringIO
 
 from otk_external_osbuild.command.gen_inline_files import root
 
 test_input = {
     "tree": {
-        "files": {
+        "inline": {
             "bob": {
                 "contents": "Hello Bob\nHow's it going?\n"
             },
@@ -27,6 +28,14 @@ expected_output = {
                 "test": {
                     "id": "sha256:0f26599ad3142e51c0781c93677eba62b4a28db327bc9eb443aaa764976045de",
                     "data": "TGV0J3MgdGVzdCB0aGUgaW5saW5lIGZpbGUgZ2VuZXJhdG9yLg==",
+                },
+                "path-text": {
+                    "id": "sha256:aac460f1c46997623431e7212c5e34e1f1cb2088989f5738da0d4d034844a219",
+                    "data": "VGV4dCBmcm9tIGEgZmlsZSBvbiBkaXNr",
+                },
+                "path-bytes": {
+                    "id": "sha256:176e605efa4b7ae0ad5315f0959d3d37a8dead002bf65009029994a4d2f50c90",
+                    "data": "Qnl0ZXMgZnJvbSBhIGZpbGUgb24gZGlzaw==",
                 }
             }
         }
@@ -34,7 +43,24 @@ expected_output = {
 }
 
 
-def test_gen_inline_files(capsys):
+def test_gen_inline_files(capsys, tmp_path):
+    # add temporary file paths to input struct
+    input_txt = tmp_path / "embed-file.txt"
+    input_txt.write_text("Text from a file on disk", encoding="utf-8")
+
+    input_bytes = tmp_path / "embed-file.bin"
+    input_bytes.write_bytes("Bytes from a file on disk".encode("utf-8"))
+    test_input["tree"]["paths"] = {
+        "path-text": {
+            "path": os.fspath(input_txt),
+            "type": "text",
+        },
+        "path-bytes": {
+            "path": os.fspath(input_bytes),
+            "type": "binary",
+        }
+    }
+
     root(StringIO(json.dumps(test_input)))
     output = json.loads(capsys.readouterr().out)
     assert output == expected_output

--- a/test/test_gen_inline_files.py
+++ b/test/test_gen_inline_files.py
@@ -2,6 +2,7 @@ import json
 import os
 from io import StringIO
 
+import pytest
 from otk_external_osbuild.command.gen_inline_files import root
 
 test_input = {
@@ -64,3 +65,28 @@ def test_gen_inline_files(capsys, tmp_path):
     root(StringIO(json.dumps(test_input)))
     output = json.loads(capsys.readouterr().out)
     assert output == expected_output
+
+
+def test_gen_inline_files_name_collision():
+    input_with_collisions = {
+        "tree": {
+            "inline": {
+                "dupe": {
+                    "contents": "Hello Bob\nHow's it going?\n"
+                },
+                "test": {
+                    "contents": "Let's test the inline file generator."
+                }
+            },
+            "paths": {
+                "dupe": {
+                    "path": "/does/not/matter",
+                    "type": "text",
+                }
+            }
+        }
+    }
+
+    with pytest.raises(KeyError) as exc:
+        root(StringIO(json.dumps(input_with_collisions)))
+    assert exc.value.args[0] == "duplicate name found for inline files: dupe"

--- a/test/test_gen_inline_files.py
+++ b/test/test_gen_inline_files.py
@@ -1,0 +1,40 @@
+import json
+from io import StringIO
+
+from otk_external_osbuild.command.gen_inline_files import root
+
+test_input = {
+    "tree": {
+        "files": {
+            "bob": {
+                "contents": "Hello Bob\nHow's it going?\n"
+            },
+            "test": {
+                "contents": "Let's test the inline file generator."
+            }
+        }
+    }
+}
+
+expected_output = {
+    "tree": {
+        "const": {
+            "files": {
+                "bob": {
+                    "id": "sha256:5e557cb2cceecc1845e8210350c4aa09d2925a3bfbe54c59c10e02e3d03555f6",
+                    "data": "SGVsbG8gQm9iCkhvdydzIGl0IGdvaW5nPwo=",
+                },
+                "test": {
+                    "id": "sha256:0f26599ad3142e51c0781c93677eba62b4a28db327bc9eb443aaa764976045de",
+                    "data": "TGV0J3MgdGVzdCB0aGUgaW5saW5lIGZpbGUgZ2VuZXJhdG9yLg==",
+                }
+            }
+        }
+    }
+}
+
+
+def test_gen_inline_files(capsys):
+    root(StringIO(json.dumps(test_input)))
+    output = json.loads(capsys.readouterr().out)
+    assert output == expected_output

--- a/test/test_make_inline_source.py
+++ b/test/test_make_inline_source.py
@@ -1,0 +1,29 @@
+import json
+from io import StringIO
+from test.test_gen_inline_files import expected_output
+
+from otk_external_osbuild.command.make_inline_source import root
+
+# use the output from test_gen_inline_files
+test_input = expected_output
+
+
+def test_make_inline_source(capsys):
+    root(StringIO(json.dumps(test_input)))
+    output = json.loads(capsys.readouterr().out)
+    assert output == {
+        "tree": {
+            "org.osbuild.inline": {
+                "items": {
+                    "sha256:5e557cb2cceecc1845e8210350c4aa09d2925a3bfbe54c59c10e02e3d03555f6": {
+                        "encoding": "base64",
+                        "data": "SGVsbG8gQm9iCkhvdydzIGl0IGdvaW5nPwo=",
+                    },
+                    "sha256:0f26599ad3142e51c0781c93677eba62b4a28db327bc9eb443aaa764976045de": {
+                        "encoding": "base64",
+                        "data": "TGV0J3MgdGVzdCB0aGUgaW5saW5lIGZpbGUgZ2VuZXJhdG9yLg==",
+                    },
+                }
+            }
+        }
+    }

--- a/test/test_make_inline_source.py
+++ b/test/test_make_inline_source.py
@@ -23,6 +23,14 @@ def test_make_inline_source(capsys):
                         "encoding": "base64",
                         "data": "TGV0J3MgdGVzdCB0aGUgaW5saW5lIGZpbGUgZ2VuZXJhdG9yLg==",
                     },
+                    "sha256:aac460f1c46997623431e7212c5e34e1f1cb2088989f5738da0d4d034844a219": {
+                        "encoding": "base64",
+                        "data": "VGV4dCBmcm9tIGEgZmlsZSBvbiBkaXNr",
+                    },
+                    "sha256:176e605efa4b7ae0ad5315f0959d3d37a8dead002bf65009029994a4d2f50c90": {
+                        "encoding": "base64",
+                        "data": "Qnl0ZXMgZnJvbSBhIGZpbGUgb24gZGlzaw==",
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR adds two externals:

**external: add new `gen-inline-files` external**

Will be used to generate inline files for manifests.

To add a file in a manifest as in-line content we need an ID, which is
the sha256 hash of the contents and the file contents in base64.

**external: add new `make-inline-source` external**

Takes the output from gen-inline-files and generates the
org.osbuild.inline source structure for the manifest.