### PR TITLE
external: make package name avaiable

### DIFF
--- a/src/otk_external_osbuild/command/get_dnf4_package_info.py
+++ b/src/otk_external_osbuild/command/get_dnf4_package_info.py
@@ -22,6 +22,7 @@ def root(input_stream: TextIO) -> None:
         json.dumps(
             {
                 "tree": {
+                    "name": pkg["name"],
                     "version": pkg["version"],
                     "release": pkg["release"],
                     "arch": pkg["arch"],

--- a/test/test_get_dnf4_package_info.py
+++ b/test/test_get_dnf4_package_info.py
@@ -36,6 +36,7 @@ def test_make_depsolve_dnf4_curl_source(capsys):
     output = json.loads(capsys.readouterr().out)
     assert output == {
         "tree": {
+            "name": "foo",
             "version": "1",
             "release": "fc30",
             "arch": "c64",


### PR DESCRIPTION
Make the package name available in the package info external. This can then be used for (for example) the sysconfig deduplication or other places that need the kernel name *without* introducing an extra variable elsewhere.