### PR TITLE
src: include current file in every raise()

### DIFF
--- a/src/otk/tree.py
+++ b/src/otk/tree.py
@@ -17,9 +17,9 @@ def must_be(kind: Type) -> Callable:
     def decorator(function):
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
-            if not isinstance(args[1], kind):
+            if not isinstance(args[2], kind):
                 raise TransformDirectiveTypeError(
-                    f"otk.define expects a {kind!r} as its argument but received a `{type(args[1])}`: `{args[1]!r}`")
+                    f"otk.define expects a {kind!r} as its argument but received a `{type(args[2])}`: `{args[2]!r}`")
             return function(*args, **kwargs)
 
         return wrapper
@@ -34,7 +34,7 @@ def must_pass(*vs):
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
             for v in vs:
-                v(args[1])
+                v(args[2])
             return function(*args, **kwargs)
 
         return wrapper

--- a/test/test_directive.py
+++ b/test/test_directive.py
@@ -3,53 +3,57 @@ from otk.context import CommonContext
 from otk.error import (TransformDirectiveArgumentError,
                        TransformDirectiveTypeError)
 from otk.transform import op_join
+from otk.traversal import State
 
 
 def test_op_seq_join():
     ctx = CommonContext()
+    state = State("")
 
     l1 = [1, 2, 3]
     l2 = [4, 5, 6]
 
     d = {"values": [l1, l2]}
 
-    assert op_join(ctx, d) == [1, 2, 3, 4, 5, 6]
+    assert op_join(ctx, state, d) == [1, 2, 3, 4, 5, 6]
 
 
 def test_op_join_unhappy():
     ctx = CommonContext()
+    state = State("")
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, 1)
+        op_join(ctx, state, 1)
 
     with pytest.raises(TransformDirectiveArgumentError):
-        op_join(ctx, {})
+        op_join(ctx, state, {})
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, {"values": 1})
+        op_join(ctx, state, {"values": 1})
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, {"values": [1, {2: 3}]})
+        op_join(ctx, state, {"values": [1, {2: 3}]})
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, 1)
+        op_join(ctx, state, 1)
 
     with pytest.raises(TransformDirectiveArgumentError):
-        op_join(ctx, {})
+        op_join(ctx, state, {})
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, {"values": 1})
+        op_join(ctx, state, {"values": 1})
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, {"values": [1, {2: 3}]})
+        op_join(ctx, state, {"values": [1, {2: 3}]})
 
 
 def test_op_map_join():
     ctx = CommonContext()
+    state = State("")
 
     d1 = {"foo": "bar"}
     d2 = {"bar": "foo"}
 
     d = {"values": [d1, d2]}
 
-    assert op_join(ctx, d) == {"foo": "bar", "bar": "foo"}
+    assert op_join(ctx, state, d) == {"foo": "bar", "bar": "foo"}

--- a/test/test_substitute_vars.py
+++ b/test/test_substitute_vars.py
@@ -3,24 +3,28 @@ import re
 import pytest
 from otk.context import CommonContext
 from otk.transform import substitute_vars
+from otk.traversal import State
 from otk.error import ParseError, TransformDirectiveTypeError, TransformVariableLookupError, TransformVariableTypeError
 
 
 def test_simple_sub_var():
+    state = State("")
     context = CommonContext()
     context.define("my_var", "foo")
 
-    assert substitute_vars(context, "${my_var}") == "foo"
+    assert substitute_vars(context, state, "${my_var}") == "foo"
 
 
 def test_simple_sub_var_nested():
+    state = State("")
     context = CommonContext()
     context.define("my_var", [1, 2])
 
-    assert substitute_vars(context, "${my_var}") == [1, 2]
+    assert substitute_vars(context, state, "${my_var}") == [1, 2]
 
 
 def test_simple_sub_var_nested_fail():
+    state = State("")
     context = CommonContext()
     context.define("my_var", [1, 2])
     data = "a${my_var}"
@@ -30,46 +34,50 @@ def test_simple_sub_var_nested_fail():
     )
 
     with pytest.raises(TransformDirectiveTypeError, match=expected_error):
-        substitute_vars(context, data)
+        substitute_vars(context, state, data)
 
 
 def test_sub_var_multiple():
+    state = State("")
     context = CommonContext()
     context.define("a", "foo")
     context.define("b", "bar")
 
-    assert substitute_vars(context, "${a}-${b}") == "foo-bar"
+    assert substitute_vars(context, state, "${a}-${b}") == "foo-bar"
 
 
 def test_sub_var_missing_var_in_context():
+    state = State("")
     context = CommonContext()
     # toplevel
     expected_err = r"could not find \['a'\]"
     with pytest.raises(TransformVariableLookupError, match=expected_err):
-        substitute_vars(context, "${a}")
+        substitute_vars(context, state, "${a}")
     # subtree
     context.define("a", "foo")
     expected_err = r"tried to look up 'a.b', but prefix 'a' value 'foo' is not a dictionary"
     with pytest.raises(TransformVariableTypeError, match=expected_err):
-        substitute_vars(context, "${a.b}")
+        substitute_vars(context, state, "${a.b}")
 
 
 def test_sub_var_incorrect_var():
+    state = State("")
     context = CommonContext()
     expected_err = r"invalid variable part 'a-' in 'a-', allowed .*"
     with pytest.raises(ParseError, match=expected_err):
-        substitute_vars(context, "${a-}")
+        substitute_vars(context, state, "${a-}")
     # nested
     expected_err = r"invalid variable part 'b-' in 'a.b-', allowed .*"
     with pytest.raises(ParseError, match=expected_err):
-        substitute_vars(context, "${a.b-}")
+        substitute_vars(context, state, "${a.b-}")
     # "recursive"
     expected_err = r"invalid variable part '\$\{b' in 'a.\$\{b', allowed .*"
     with pytest.raises(ParseError, match=expected_err):
-        substitute_vars(context, "${a.${b}}")
+        substitute_vars(context, state, "${a.${b}}")
 
 
 def test_sub_var_multiple_fail():
+    state = State("")
     context = CommonContext()
     context.define("a", "foo")
     context.define("b", [1, 2])
@@ -83,7 +91,7 @@ def test_sub_var_multiple_fail():
 
     # Fails due to non-str type
     with pytest.raises(TransformDirectiveTypeError, match=expected_error):
-        substitute_vars(context, data)
+        substitute_vars(context, state, data)
 
     data = "${a}-${c}"
 
@@ -94,30 +102,32 @@ def test_sub_var_multiple_fail():
 
     # Fails due to non-str type
     with pytest.raises(TransformDirectiveTypeError, match=expected_error):
-        substitute_vars(context, data)
+        substitute_vars(context, state, data)
 
 
 def test_substitute_vars():
+    state = State("")
     ctx = CommonContext()
     ctx.define("str", "bar")
     ctx.define("int", 1)
     ctx.define("float", 1.1)
 
-    assert substitute_vars(ctx, "") == ""
-    assert substitute_vars(ctx, "${str}") == "bar"
-    assert substitute_vars(ctx, "a${str}b") == "abarb"
-    assert substitute_vars(ctx, "${int}") == 1
-    assert substitute_vars(ctx, "a${int}b") == "a1b"
-    assert substitute_vars(ctx, "${float}") == 1.1
-    assert substitute_vars(ctx, "a${float}b") == "a1.1b"
+    assert substitute_vars(ctx, state, "") == ""
+    assert substitute_vars(ctx, state, "${str}") == "bar"
+    assert substitute_vars(ctx, state, "a${str}b") == "abarb"
+    assert substitute_vars(ctx, state, "${int}") == 1
+    assert substitute_vars(ctx, state, "a${int}b") == "a1b"
+    assert substitute_vars(ctx, state, "${float}") == 1.1
+    assert substitute_vars(ctx, state, "a${float}b") == "a1.1b"
 
 
 def test_substitute_vars_unhappy():
+    state = State("")
     ctx = CommonContext()
     ctx.define("dict", {})
 
     with pytest.raises(TransformDirectiveTypeError):
-        substitute_vars(ctx, 1)
+        substitute_vars(ctx, state, 1)
 
     with pytest.raises(TransformDirectiveTypeError):
-        substitute_vars(ctx, "a${dict}b")
+        substitute_vars(ctx, state, "a${dict}b")


### PR DESCRIPTION
This commit adds the current file that was processed in all otk exceptions. This way it's easier for the user to spot where something went wrong.

This will now produce errors like:
```
...
otk.error.TransformDirectiveTypeError: [/home/mvogt/devel/osbuild/otk/example/centos/common/partition-table/x86_64/default.yaml] cannot join ['x']
```

[draft as I think this should be two commits and also it lacks dedicated tests, also there should probably a "state.make_error_prefix()" helper or something so that this is all in one place and externals should also be covered but I still wanted to open it so that it's not forgoten]