### PR TITLE
otk: do not allow duplicated yaml keys

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ repos:
         args:
           - --markdown-linebreak-ext=md
       - id: end-of-file-fixer
-      - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.35.1

--- a/.yamllint
+++ b/.yamllint
@@ -4,3 +4,7 @@ extends: default
 rules:
   document-start: disable
   line-length: disable
+
+ignore:
+  - test/data/error/09-duplicated-key.yaml
+  - test/data/error/10-duplicated-key-no-otk.yaml

--- a/src/otk/error.py
+++ b/src/otk/error.py
@@ -17,6 +17,10 @@ class ParseKeyError(ParseTypeError):
     """A required key was missing for a position in the omnifest."""
 
 
+class ParseDuplicatedYamlKeyError(ParseError):
+    """A yaml key is duplicated."""
+
+
 class ParseVersionError(ParseKeyError):
     """The `otk.version` key is missing from an omnifest."""
 

--- a/test/data/error/09-duplicated-key.err
+++ b/test/data/error/09-duplicated-key.err
@@ -1,0 +1,1 @@
+09-duplicated-key.yaml has duplicated yaml keys: duplicated 'otk.include' key found, try using otk.include.<uniq-tag>, e.g. otk.include.foo

--- a/test/data/error/09-duplicated-key.yaml
+++ b/test/data/error/09-duplicated-key.yaml
@@ -1,0 +1,5 @@
+otk.version: 1
+
+otk.target.osbuild:
+  otk.include: "foo.yaml"
+  otk.include: "bar.yaml"

--- a/test/data/error/10-duplicated-key-no-otk.err
+++ b/test/data/error/10-duplicated-key-no-otk.err
@@ -1,0 +1,1 @@
+10-duplicated-key-no-otk.yaml has duplicated yaml keys: duplicated 'foo' key found

--- a/test/data/error/10-duplicated-key-no-otk.yaml
+++ b/test/data/error/10-duplicated-key-no-otk.yaml
@@ -1,0 +1,5 @@
+otk.version: 1
+
+otk.target.osbuild:
+  foo: bar
+  foo: baz


### PR DESCRIPTION
This commit will make the yaml loader error when duplicated yaml keys are used. This can easily happen with e.g.:
```yaml
otk.include: foo.yaml
...
[lots of stuff]
...
otk.include: bar.yaml
```
with the default yaml loader this would make the value of `otk.include=bar.yaml` which leads to confusing and hard to understand errors. Best is to simply error with a reasonable error message.

The correct way in otk to write this would be:
```
otk.include.foo: foo.yaml
...
otk.include.bar: bar.yaml
```

This will now yield errors like:
```
...
file .../otk/test/data/error/09-duplicated-key.yaml has duplicated yaml keys: duplicate 'otk.include' key found, try using otk.include.<uniq-tag>, e.g. otk.include.foo
```

Note that this PR also removes one of the `yaml` linters (`check-yaml`), see the individual commit message for details.