### PR TITLE
example/centos: locale fragment

### DIFF
--- a/example/centos/centos-9-aarch64-ami.yaml
+++ b/example/centos/centos-9-aarch64-ami.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: en_US.UTF-8
   filesystem:
     modifications:
       filename: "image.raw"
@@ -120,9 +122,7 @@ otk.target.osbuild:
         - type: org.osbuild.fix-bls
           options:
             prefix: ''
-        - type: org.osbuild.locale
-          options:
-            language: en_US.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.keymap
           options:
             keymap: us

--- a/example/centos/centos-9-aarch64-edge-commit.yaml
+++ b/example/centos/centos-9-aarch64-edge-commit.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: C.UTF-8
   filesystem:
     modifications:
     # empty
@@ -138,9 +140,7 @@ otk.target.osbuild:
                 ostree_booted: true
         - type: org.osbuild.fix-bls
           options: {}
-        - type: org.osbuild.locale
-          options:
-            language: C.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:
             zone: America/New_York

--- a/example/centos/centos-9-aarch64-minimal-raw.yaml
+++ b/example/centos/centos-9-aarch64-minimal-raw.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: C.UTF-8
   filesystem:
     modifications:
     # empty
@@ -86,9 +88,7 @@ otk.target.osbuild:
         - type: org.osbuild.fix-bls
           options:
             prefix: ''
-        - type: org.osbuild.locale
-          options:
-            language: C.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:
             zone: America/New_York

--- a/example/centos/centos-9-aarch64-qcow2.yaml
+++ b/example/centos/centos-9-aarch64-qcow2.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: C.UTF-8
   filesystem:
     modifications:
     # empty
@@ -127,9 +129,7 @@ otk.target.osbuild:
         - type: org.osbuild.fix-bls
           options:
             prefix: ''
-        - type: org.osbuild.locale
-          options:
-            language: C.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:
             zone: America/New_York

--- a/example/centos/centos-9-aarch64-tar.yaml
+++ b/example/centos/centos-9-aarch64-tar.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: C.UTF-8
   kernel:
     cmdline: console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0
   packages:
@@ -51,9 +53,7 @@ otk.target.osbuild:
               otk.include: "common/gpgkeys.yaml"
         - type: org.osbuild.fix-bls
           options: {}
-        - type: org.osbuild.locale
-          options:
-            language: C.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:
             zone: America/New_York

--- a/example/centos/centos-9-aarch64-vhd.yaml
+++ b/example/centos/centos-9-aarch64-vhd.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: en_US.UTF-8
   filesystem:
     modifications:
     # empty
@@ -137,9 +139,7 @@ otk.target.osbuild:
         - type: org.osbuild.fix-bls
           options:
             prefix: ''
-        - type: org.osbuild.locale
-          options:
-            language: en_US.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.keymap
           options:
             keymap: us

--- a/example/centos/centos-9-ppc64le-tar.yaml
+++ b/example/centos/centos-9-ppc64le-tar.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: C.UTF-8
   kernel:
     cmdline: console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0
   packages:
@@ -51,9 +53,7 @@ otk.target.osbuild:
               otk.include: "common/gpgkeys.yaml"
         - type: org.osbuild.fix-bls
           options: {}
-        - type: org.osbuild.locale
-          options:
-            language: C.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:
             zone: America/New_York

--- a/example/centos/centos-9-s390x-tar.yaml
+++ b/example/centos/centos-9-s390x-tar.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: C.UTF-8
   kernel:
     cmdline: console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0
   packages:
@@ -51,9 +53,7 @@ otk.target.osbuild:
               otk.include: "common/gpgkeys.yaml"
         - type: org.osbuild.fix-bls
           options: {}
-        - type: org.osbuild.locale
-          options:
-            language: C.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:
             zone: America/New_York

--- a/example/centos/centos-9-x86_64-ami.yaml
+++ b/example/centos/centos-9-x86_64-ami.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: en_US.UTF-8
   filesystem:
     modifications:
       filename: "image.raw"
@@ -132,9 +134,7 @@ otk.target.osbuild:
         - type: org.osbuild.fix-bls
           options:
             prefix: ''
-        - type: org.osbuild.locale
-          options:
-            language: en_US.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.keymap
           options:
             keymap: us

--- a/example/centos/centos-9-x86_64-edge-commit.yaml
+++ b/example/centos/centos-9-x86_64-edge-commit.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: C.UTF-8
   filesystem:
     modifications:
     # empty
@@ -151,9 +153,7 @@ otk.target.osbuild:
                 ostree_booted: true
         - type: org.osbuild.fix-bls
           options: {}
-        - type: org.osbuild.locale
-          options:
-            language: C.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:
             zone: America/New_York

--- a/example/centos/centos-9-x86_64-minimal-raw.yaml
+++ b/example/centos/centos-9-x86_64-minimal-raw.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: C.UTF-8
   filesystem:
     modifications:
     # empty
@@ -85,9 +87,7 @@ otk.target.osbuild:
         - type: org.osbuild.fix-bls
           options:
             prefix: ''
-        - type: org.osbuild.locale
-          options:
-            language: C.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:
             zone: America/New_York

--- a/example/centos/centos-9-x86_64-ova.yaml
+++ b/example/centos/centos-9-x86_64-ova.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: en_US.UTF-8
   filesystem:
     modifications:
     # empty
@@ -84,9 +86,7 @@ otk.target.osbuild:
         - type: org.osbuild.fix-bls
           options:
             prefix: ''
-        - type: org.osbuild.locale
-          options:
-            language: en_US.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:
             zone: America/New_York

--- a/example/centos/centos-9-x86_64-qcow2.yaml
+++ b/example/centos/centos-9-x86_64-qcow2.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: C.UTF-8
   filesystem:
     modifications:
     # empty
@@ -128,9 +130,7 @@ otk.target.osbuild:
         - type: org.osbuild.fix-bls
           options:
             prefix: ''
-        - type: org.osbuild.locale
-          options:
-            language: C.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:
             zone: America/New_York

--- a/example/centos/centos-9-x86_64-tar.yaml
+++ b/example/centos/centos-9-x86_64-tar.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: C.UTF-8
   kernel:
     cmdline: console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0
   packages:
@@ -51,9 +53,7 @@ otk.target.osbuild:
               otk.include: "common/gpgkeys.yaml"
         - type: org.osbuild.fix-bls
           options: {}
-        - type: org.osbuild.locale
-          options:
-            language: C.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:
             zone: America/New_York

--- a/example/centos/centos-9-x86_64-vhd.yaml
+++ b/example/centos/centos-9-x86_64-vhd.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: en_US.UTF-8
   filesystem:
     modifications:
   packages:
@@ -137,9 +139,7 @@ otk.target.osbuild:
         - type: org.osbuild.fix-bls
           options:
             prefix: ''
-        - type: org.osbuild.locale
-          options:
-            language: en_US.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.keymap
           options:
             keymap: us

--- a/example/centos/centos-9-x86_64-vmdk.yaml
+++ b/example/centos/centos-9-x86_64-vmdk.yaml
@@ -1,6 +1,8 @@
 otk.version: "1"
 
 otk.define:
+  modifications:
+    locale: en_US.UTF-8
   filesystem:
     modifications:
   packages:
@@ -81,9 +83,7 @@ otk.target.osbuild:
         - type: org.osbuild.fix-bls
           options:
             prefix: ''
-        - type: org.osbuild.locale
-          options:
-            language: en_US.UTF-8
+        - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:
             zone: America/New_York

--- a/example/centos/fragment/locale.yaml
+++ b/example/centos/fragment/locale.yaml
@@ -1,0 +1,3 @@
+type: org.osbuild.locale
+options:
+  language: ${modifications.locale}


### PR DESCRIPTION
Introduce a locale fragment that fills in an osbuild locale stage with a global define.

Note that the image-installer omnifests are excluded as they currently have dual locales so can't use a single global define.

Split out (and updated) from #240.