### PR TITLE
example/centos: fix-bls fragment

### DIFF
--- a/example/centos/centos-9-aarch64-ami.yaml
+++ b/example/centos/centos-9-aarch64-ami.yaml
@@ -119,9 +119,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options:
-            prefix: ''
+        - otk.include: "fragment/fix-bls/empty-prefix.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.keymap
           options:

--- a/example/centos/centos-9-aarch64-edge-commit.yaml
+++ b/example/centos/centos-9-aarch64-edge-commit.yaml
@@ -138,8 +138,7 @@ otk.target.osbuild:
                 dbpath: /usr/share/rpm
                 disable_dracut: true
                 ostree_booted: true
-        - type: org.osbuild.fix-bls
-          options: {}
+        - otk.include: "fragment/fix-bls/default.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:

--- a/example/centos/centos-9-aarch64-image-installer.yaml
+++ b/example/centos/centos-9-aarch64-image-installer.yaml
@@ -440,8 +440,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options: {}
+        - otk.include: "fragment/fix-bls/default.yaml"
         - type: org.osbuild.locale
           options:
             language: C.UTF-8

--- a/example/centos/centos-9-aarch64-minimal-raw.yaml
+++ b/example/centos/centos-9-aarch64-minimal-raw.yaml
@@ -85,9 +85,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options:
-            prefix: ''
+        - otk.include: "fragment/fix-bls/empty-prefix.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:

--- a/example/centos/centos-9-aarch64-qcow2.yaml
+++ b/example/centos/centos-9-aarch64-qcow2.yaml
@@ -126,9 +126,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options:
-            prefix: ''
+        - otk.include: "fragment/fix-bls/empty-prefix.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:

--- a/example/centos/centos-9-aarch64-tar.yaml
+++ b/example/centos/centos-9-aarch64-tar.yaml
@@ -51,8 +51,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options: {}
+        - otk.include: "fragment/fix-bls/default.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:

--- a/example/centos/centos-9-aarch64-vhd.yaml
+++ b/example/centos/centos-9-aarch64-vhd.yaml
@@ -136,9 +136,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options:
-            prefix: ''
+        - otk.include: "fragment/fix-bls/empty-prefix.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.keymap
           options:

--- a/example/centos/centos-9-ppc64le-tar.yaml
+++ b/example/centos/centos-9-ppc64le-tar.yaml
@@ -51,8 +51,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options: {}
+        - otk.include: "fragment/fix-bls/default.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:

--- a/example/centos/centos-9-s390x-tar.yaml
+++ b/example/centos/centos-9-s390x-tar.yaml
@@ -51,8 +51,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options: {}
+        - otk.include: "fragment/fix-bls/default.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:

--- a/example/centos/centos-9-x86_64-ami.yaml
+++ b/example/centos/centos-9-x86_64-ami.yaml
@@ -131,9 +131,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options:
-            prefix: ''
+        - otk.include: "fragment/fix-bls/empty-prefix.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.keymap
           options:

--- a/example/centos/centos-9-x86_64-edge-commit.yaml
+++ b/example/centos/centos-9-x86_64-edge-commit.yaml
@@ -151,8 +151,7 @@ otk.target.osbuild:
                 dbpath: /usr/share/rpm
                 disable_dracut: true
                 ostree_booted: true
-        - type: org.osbuild.fix-bls
-          options: {}
+        - otk.include: "fragment/fix-bls/default.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:

--- a/example/centos/centos-9-x86_64-image-installer.yaml
+++ b/example/centos/centos-9-x86_64-image-installer.yaml
@@ -454,8 +454,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options: {}
+        - otk.include: "fragment/fix-bls/default.yaml"
         - type: org.osbuild.locale
           options:
             language: C.UTF-8

--- a/example/centos/centos-9-x86_64-minimal-raw.yaml
+++ b/example/centos/centos-9-x86_64-minimal-raw.yaml
@@ -84,9 +84,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options:
-            prefix: ''
+        - otk.include: "fragment/fix-bls/empty-prefix.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:

--- a/example/centos/centos-9-x86_64-ova.yaml
+++ b/example/centos/centos-9-x86_64-ova.yaml
@@ -83,9 +83,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options:
-            prefix: ''
+        - otk.include: "fragment/fix-bls/empty-prefix.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:

--- a/example/centos/centos-9-x86_64-qcow2.yaml
+++ b/example/centos/centos-9-x86_64-qcow2.yaml
@@ -127,9 +127,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options:
-            prefix: ''
+        - otk.include: "fragment/fix-bls/empty-prefix.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:

--- a/example/centos/centos-9-x86_64-tar.yaml
+++ b/example/centos/centos-9-x86_64-tar.yaml
@@ -51,8 +51,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options: {}
+        - otk.include: "fragment/fix-bls/default.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:

--- a/example/centos/centos-9-x86_64-vhd.yaml
+++ b/example/centos/centos-9-x86_64-vhd.yaml
@@ -136,9 +136,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options:
-            prefix: ''
+        - otk.include: "fragment/fix-bls/empty-prefix.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.keymap
           options:

--- a/example/centos/centos-9-x86_64-vmdk.yaml
+++ b/example/centos/centos-9-x86_64-vmdk.yaml
@@ -80,9 +80,7 @@ otk.target.osbuild:
             packageset: ${packages.os}
             gpgkeys:
               otk.include: "common/gpgkeys.yaml"
-        - type: org.osbuild.fix-bls
-          options:
-            prefix: ''
+        - otk.include: "fragment/fix-bls/empty-prefix.yaml"
         - otk.include: "fragment/locale.yaml"
         - type: org.osbuild.timezone
           options:

--- a/example/centos/fragment/fix-bls/default.yaml
+++ b/example/centos/fragment/fix-bls/default.yaml
@@ -1,0 +1,6 @@
+# If `/boot` is on a separate partition the `empty` BLS fragment should be used, otherwise the default version
+# is used.
+#
+# See: https://github.com/osbuild/images/blob/v0.90.0/pkg/manifest/os.go#L439
+type: org.osbuild.fix-bls
+options: {}

--- a/example/centos/fragment/fix-bls/empty-prefix.yaml
+++ b/example/centos/fragment/fix-bls/empty-prefix.yaml
@@ -1,0 +1,7 @@
+# If `/boot` is on a separate partition the `empty` BLS fragment should be used, otherwise the default version
+# is used.
+#
+# See: https://github.com/osbuild/images/blob/v0.90.0/pkg/manifest/os.go#L439
+type: org.osbuild.fix-bls
+options:
+  prefix: ''


### PR DESCRIPTION
Introduce a new fix-bls fragment that comes in two variants, one with an empty prefix and one with the default options selected. Perhaps this can be further deduplicated later on (doing this based on a modification?).

Split out from #240.