### PR TITLE
example/centos: kernel-cmdline fragment

### DIFF
--- a/example/centos/centos-9-aarch64-ami.yaml
+++ b/example/centos/centos-9-aarch64-ami.yaml
@@ -111,10 +111,7 @@ otk.target.osbuild:
     - name: os
       build: name:build
       stages:
-        - type: org.osbuild.kernel-cmdline
-          options:
-            root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
-            kernel_opts: ${kernel.cmdline}
+        - otk.include: "fragment/kernel-cmdline.yaml"
         - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
             packageset: ${packages.os}
             gpgkeys:

--- a/example/centos/centos-9-aarch64-minimal-raw.yaml
+++ b/example/centos/centos-9-aarch64-minimal-raw.yaml
@@ -77,10 +77,7 @@ otk.target.osbuild:
     - name: os
       build: name:build
       stages:
-        - type: org.osbuild.kernel-cmdline
-          options:
-            root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
-            kernel_opts: ${kernel.cmdline}
+        - otk.include: "fragment/kernel-cmdline.yaml"
         - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
             packageset: ${packages.os}
             gpgkeys:

--- a/example/centos/centos-9-aarch64-qcow2.yaml
+++ b/example/centos/centos-9-aarch64-qcow2.yaml
@@ -118,10 +118,7 @@ otk.target.osbuild:
     - name: os
       build: name:build
       stages:
-        - type: org.osbuild.kernel-cmdline
-          options:
-            root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
-            kernel_opts: ${kernel.cmdline}
+        - otk.include: "fragment/kernel-cmdline.yaml"
         - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
             packageset: ${packages.os}
             gpgkeys:

--- a/example/centos/centos-9-aarch64-vhd.yaml
+++ b/example/centos/centos-9-aarch64-vhd.yaml
@@ -128,10 +128,7 @@ otk.target.osbuild:
     - name: os
       build: name:build
       stages:
-        - type: org.osbuild.kernel-cmdline
-          options:
-            root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
-            kernel_opts: ${kernel.cmdline}
+        - otk.include: "fragment/kernel-cmdline.yaml"
         - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
             packageset: ${packages.os}
             gpgkeys:

--- a/example/centos/centos-9-x86_64-ami.yaml
+++ b/example/centos/centos-9-x86_64-ami.yaml
@@ -123,10 +123,7 @@ otk.target.osbuild:
     - name: os
       build: name:build
       stages:
-        - type: org.osbuild.kernel-cmdline
-          options:
-            root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
-            kernel_opts: ${kernel.cmdline}
+        - otk.include: "fragment/kernel-cmdline.yaml"
         - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
             packageset: ${packages.os}
             gpgkeys:

--- a/example/centos/centos-9-x86_64-minimal-raw.yaml
+++ b/example/centos/centos-9-x86_64-minimal-raw.yaml
@@ -76,10 +76,7 @@ otk.target.osbuild:
     - name: os
       build: name:build
       stages:
-        - type: org.osbuild.kernel-cmdline
-          options:
-            root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
-            kernel_opts: ${kernel.cmdline}
+        - otk.include: "fragment/kernel-cmdline.yaml"
         - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
             packageset: ${packages.os}
             gpgkeys:

--- a/example/centos/centos-9-x86_64-ova.yaml
+++ b/example/centos/centos-9-x86_64-ova.yaml
@@ -75,10 +75,7 @@ otk.target.osbuild:
     - name: os
       build: name:build
       stages:
-        - type: org.osbuild.kernel-cmdline
-          options:
-            root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
-            kernel_opts: ${kernel.cmdline}
+        - otk.include: "fragment/kernel-cmdline.yaml"
         - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
             packageset: ${packages.os}
             gpgkeys:

--- a/example/centos/centos-9-x86_64-qcow2.yaml
+++ b/example/centos/centos-9-x86_64-qcow2.yaml
@@ -119,10 +119,7 @@ otk.target.osbuild:
     - name: os
       build: name:build
       stages:
-        - type: org.osbuild.kernel-cmdline
-          options:
-            root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
-            kernel_opts: ${kernel.cmdline}
+        - otk.include: "fragment/kernel-cmdline.yaml"
         - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
             packageset: ${packages.os}
             gpgkeys:

--- a/example/centos/centos-9-x86_64-vhd.yaml
+++ b/example/centos/centos-9-x86_64-vhd.yaml
@@ -128,10 +128,7 @@ otk.target.osbuild:
     - name: os
       build: name:build
       stages:
-        - type: org.osbuild.kernel-cmdline
-          options:
-            root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
-            kernel_opts: ${kernel.cmdline}
+        - otk.include: "fragment/kernel-cmdline.yaml"
         - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
             packageset: ${packages.os}
             gpgkeys:

--- a/example/centos/centos-9-x86_64-vmdk.yaml
+++ b/example/centos/centos-9-x86_64-vmdk.yaml
@@ -72,10 +72,7 @@ otk.target.osbuild:
     - name: os
       build: name:build
       stages:
-        - type: org.osbuild.kernel-cmdline
-          options:
-            root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
-            kernel_opts: ${kernel.cmdline}
+        - otk.include: "fragment/kernel-cmdline.yaml"
         - otk.external.osbuild-make-depsolve-dnf4-rpm-stage:
             packageset: ${packages.os}
             gpgkeys:

--- a/example/centos/fragment/kernel-cmdline.yaml
+++ b/example/centos/fragment/kernel-cmdline.yaml
@@ -1,0 +1,4 @@
+type: org.osbuild.kernel-cmdline
+options:
+  root_fs_uuid: ${filesystem.const.partition_map.root.uuid}
+  kernel_opts: ${kernel.cmdline}


### PR DESCRIPTION
New fragment that requires `kernel.cmdline` and the partition external to be in use. Split off from #240.