### PR TITLE
test: use `fstab` stage in `gen-image-def` to find UUIDs

### DIFF
--- a/test/data/images-ref/gen-image-def
+++ b/test/data/images-ref/gen-image-def
@@ -17,12 +17,13 @@ class Dumper(yaml.Dumper):  # pylint: disable=too-many-ancestors
         return super().increase_indent(flow=flow, indentless=False)
 
 
-def uuid_for_label(fs_label, osbuild_manifest):
+def uuid_for_path(path, osbuild_manifest):
     for p in osbuild_manifest["pipelines"]:
         for stage in p["stages"]:
-            if stage["type"].startswith("org.osbuild.mkfs."):
-                if stage["options"].get("label") == fs_label:
-                    return stage["options"].get("uuid")
+            if stage["type"] == "org.osbuild.fstab":
+                for fs in stage["options"]["filesystems"]:
+                    if fs["path"] == path:
+                        return fs["uuid"]
     return ""
 
 
@@ -61,9 +62,9 @@ def generate_reference_image(images_base_dir: str, distro_name: str, distro_ver:
     # "gen-manifests" and "otk-gen-partition-tables" but the partition
     # table code is called slightly differently which means that the UUIDs
     # get out of sync. We need this (f)ugly helper to fix it:
-    if rootfs_uuid := uuid_for_label("root", json.loads(manifest_str)):
+    if rootfs_uuid := uuid_for_path("/", json.loads(manifest_str)):
         manifest_str = manifest_str.replace(rootfs_uuid, "9851898e-0b30-437d-8fad-51ec16c3697f")
-    if bootfs_uuid := uuid_for_label("boot", json.loads(manifest_str)):
+    if bootfs_uuid := uuid_for_path("/boot", json.loads(manifest_str)):
         manifest_str = manifest_str.replace(bootfs_uuid, "dbd21911-1c4e-4107-8a9f-14fe6e751358")
 
     # now convert to json


### PR DESCRIPTION
This commit changes the `gen-image-def` script to use the `org.osbuild.fstab` stage to find the UUIDs of the root and boot partitions. We used to use the `mkfs.*` stage and the `label` parameter but it turns out that `s390x` and `ppc64le` do not use the label paramter so the UUID is not found.

Thanks to Florian Schüller <florian.schueller@redhat.com> for finding and testing.