### PR TITLE
example/centos: introduce `${architecture}`

### DIFF
--- a/example/centos/centos-9-aarch64-ami.yaml
+++ b/example/centos/centos-9-aarch64-ami.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: aarch64
   modifications:
     locale: en_US.UTF-8
     timezone: UTC
@@ -10,11 +11,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -32,15 +33,15 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             # https://github.com/osbuild/images/blob/v0.86.0/pkg/distro/rhel/rhel9/ami.go#L189
-            # https://github.com/osbuild/images/blob/v0.86.0/pkg/platform/aarch64.go#L37
+            # https://github.com/osbuild/images/blob/v0.86.0/pkg/platform/${architecture}.go#L37
             - "@core"
             - NetworkManager-cloud-setup
             - authselect-compat
@@ -104,7 +105,7 @@ otk.define:
         packageset: ${packages.os}
         packagename: "kernel"
 
-otk.include: "common/partition-table/aarch64/default.yaml"
+otk.include: "common/partition-table/${architecture}/default.yaml"
 
 otk.target.osbuild:
   pipelines:
@@ -202,7 +203,7 @@ otk.target.osbuild:
               PasswordAuthentication: false
         - otk.external.otk-make-fstab-stage:
             ${filesystem}
-        - otk.include: fragment/grub2/aarch64.yaml
+        - otk.include: fragment/grub2/${architecture}.yaml
         - type: org.osbuild.systemd
           options:
             enabled_services:
@@ -218,7 +219,7 @@ otk.target.osbuild:
               - tuned
             default_target: multi-user.target
         - otk.include: "fragment/selinux/targeted.yaml"
-    - otk.include: "pipeline/image/aarch64.yaml"
+    - otk.include: "pipeline/image/${architecture}.yaml"
   sources:
     otk.external.osbuild-make-depsolve-dnf4-curl-source:
       packagesets:

--- a/example/centos/centos-9-aarch64-edge-commit.yaml
+++ b/example/centos/centos-9-aarch64-edge-commit.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: aarch64
   modifications:
     locale: C.UTF-8
     timezone: America/New_York
@@ -10,11 +11,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -31,11 +32,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - NetworkManager
@@ -193,7 +194,7 @@ otk.target.osbuild:
               references:
                 - name:os
           options:
-            ref: centos/9/aarch64/edge
+            ref: centos/9/${architecture}/edge
             os_version: 9-stream
     - name: commit-archive
       build: name:build

--- a/example/centos/centos-9-aarch64-image-installer.yaml
+++ b/example/centos/centos-9-aarch64-image-installer.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: aarch64
   modifications:
     timezone: America/New_York
   # XXX these sizes are currently hardcoded in `images` in the future they
@@ -15,11 +16,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -46,11 +47,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - "@core"
@@ -112,11 +113,11 @@ otk.define:
             - dracut-config-rescue
     anaconda:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - aajohan-comfortaa-fonts
@@ -279,7 +280,7 @@ otk.target.osbuild:
               otk.include: "common/gpgkeys.yaml"
         - type: org.osbuild.buildstamp
           options:
-            arch: aarch64
+            arch: ${architecture}
             product: CentOS Stream
             version: 9-stream
             final: true
@@ -309,7 +310,7 @@ otk.target.osbuild:
         - type: org.osbuild.lorax-script
           options:
             path: 99-generic/runtime-postinstall.tmpl
-            basearch: aarch64
+            basearch: ${architecture}
             product:
               name: ''
               version: ''
@@ -429,9 +430,9 @@ otk.target.osbuild:
             kernel:
               dir: /images/pxeboot
               opts:
-                - inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64
-                - inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64:/osbuild.ks
-            isolabel: CentOS-Stream-9-BaseOS-aarch64
+                - inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-${architecture}
+                - inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-${architecture}:/osbuild.ks
+            isolabel: CentOS-Stream-9-BaseOS-${architecture}
             architectures:
               - AA64
             vendor: centos
@@ -553,7 +554,7 @@ otk.target.osbuild:
               url: file:///run/install/repo/liveimg.tar.gz
         - type: org.osbuild.discinfo
           options:
-            basearch: aarch64
+            basearch: ${architecture}
             release: CentOS Stream 9-stream
     - name: bootiso
       build: name:build
@@ -567,7 +568,7 @@ otk.target.osbuild:
                 - name:bootiso-tree
           options:
             filename: installer.iso
-            volid: CentOS-Stream-9-BaseOS-aarch64
+            volid: CentOS-Stream-9-BaseOS-${architecture}
             sysid: LINUX
             efi: images/efiboot.img
             isolevel: 3

--- a/example/centos/centos-9-aarch64-minimal-raw.yaml
+++ b/example/centos/centos-9-aarch64-minimal-raw.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: aarch64
   modifications:
     locale: C.UTF-8
     timezone: America/New_York
@@ -10,11 +11,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -31,11 +32,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - "@core"
@@ -70,7 +71,7 @@ otk.define:
         packageset: ${packages.os}
         packagename: "kernel"
 
-otk.include: "common/partition-table/aarch64/minimal-raw.yaml"
+otk.include: "common/partition-table/${architecture}/minimal-raw.yaml"
 
 otk.target.osbuild:
   pipelines:
@@ -104,7 +105,7 @@ otk.target.osbuild:
             unit-type: global
         - otk.external.otk-make-fstab-stage:
             ${filesystem}
-        - otk.include: fragment/grub2/aarch64.yaml
+        - otk.include: fragment/grub2/${architecture}.yaml
         - type: org.osbuild.copy
           inputs:
             # XXX note we're only keeping the hash here since it corresponds to the reference
@@ -133,7 +134,7 @@ otk.target.osbuild:
               - sshd.service
               - initial-setup.service
         - otk.include: "fragment/selinux/targeted.yaml"
-    - otk.include: pipeline/image/aarch64.yaml
+    - otk.include: pipeline/image/${architecture}.yaml
     - name: xz
       build: name:build
       stages:

--- a/example/centos/centos-9-aarch64-qcow2.yaml
+++ b/example/centos/centos-9-aarch64-qcow2.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: aarch64
   modifications:
     locale: C.UTF-8
     timezone: America/New_York
@@ -10,11 +11,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -32,11 +33,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - "@core"
@@ -111,7 +112,7 @@ otk.define:
         packageset: ${packages.os}
         packagename: "kernel"
 
-otk.include: "common/partition-table/aarch64/default.yaml"
+otk.include: "common/partition-table/${architecture}/default.yaml"
 
 otk.target.osbuild:
   pipelines:
@@ -137,12 +138,12 @@ otk.target.osbuild:
               no_zero_conf: true
         - otk.external.otk-make-fstab-stage:
             ${filesystem}
-        - otk.include: fragment/grub2/aarch64.yaml
+        - otk.include: fragment/grub2/${architecture}.yaml
         - type: org.osbuild.systemd
           options:
             default_target: multi-user.target
         - otk.include: "fragment/selinux/targeted.yaml"
-    - otk.include: pipeline/image/aarch64.yaml
+    - otk.include: pipeline/image/${architecture}.yaml
     - name: qcow2
       build: name:build
       stages:

--- a/example/centos/centos-9-aarch64-tar.yaml
+++ b/example/centos/centos-9-aarch64-tar.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: aarch64
   modifications:
     locale: C.UTF-8
     timezone: America/New_York
@@ -9,11 +10,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -29,11 +30,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - selinux-policy-targeted

--- a/example/centos/centos-9-aarch64-vhd.yaml
+++ b/example/centos/centos-9-aarch64-vhd.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: aarch64
   modifications:
     locale: en_US.UTF-8
     timezone: Etc/UTC
@@ -10,11 +11,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -33,11 +34,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - "@Server"
@@ -121,7 +122,7 @@ otk.define:
         packageset: ${packages.os}
         packagename: "kernel"
 
-otk.include: "common/partition-table/aarch64/vhd.yaml"
+otk.include: "common/partition-table/${architecture}/vhd.yaml"
 
 otk.target.osbuild:
   pipelines:
@@ -284,7 +285,7 @@ otk.target.osbuild:
               - waagent
             default_target: multi-user.target
         - otk.include: "fragment/selinux/targeted.yaml"
-    - otk.include: "pipeline/image/aarch64.yaml"
+    - otk.include: "pipeline/image/${architecture}.yaml"
     - name: vpc
       build: name:build
       stages:

--- a/example/centos/centos-9-aarch64-wsl.yaml
+++ b/example/centos/centos-9-aarch64-wsl.yaml
@@ -1,14 +1,15 @@
 otk.version: "1"
 
 otk.define:
+  architecture: aarch64
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -24,11 +25,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: aarch64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/aarch64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - alternatives

--- a/example/centos/centos-9-ppc64le-tar.yaml
+++ b/example/centos/centos-9-ppc64le-tar.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: ppc64le
   modifications:
     locale: C.UTF-8
     timezone: America/New_York
@@ -9,11 +10,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: s390x
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/ppc64le.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -29,11 +30,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: s390x
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/ppc64le.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - selinux-policy-targeted

--- a/example/centos/centos-9-s390x-tar.yaml
+++ b/example/centos/centos-9-s390x-tar.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: s390x
   modifications:
     locale: C.UTF-8
     timezone: America/New_York
@@ -9,11 +10,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: s390x
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/s390x.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -29,11 +30,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: s390x
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/s390x.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - selinux-policy-targeted

--- a/example/centos/centos-9-x86_64-ami.yaml
+++ b/example/centos/centos-9-x86_64-ami.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: x86_64
   modifications:
     locale: en_US.UTF-8
     timezone: UTC
@@ -10,11 +11,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -33,15 +34,15 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             # https://github.com/osbuild/images/blob/v0.86.0/pkg/distro/rhel/rhel9/ami.go#L189
-            # https://github.com/osbuild/images/blob/v0.86.0/pkg/platform/x86_64.go#L37
+            # https://github.com/osbuild/images/blob/v0.86.0/pkg/platform/${architecture}.go#L37
             - "@core"
             - NetworkManager-cloud-setup
             - authselect-compat
@@ -105,7 +106,7 @@ otk.define:
         packageset: ${packages.os}
         packagename: "kernel"
 
-otk.include: "common/partition-table/x86_64/default.yaml"
+otk.include: "common/partition-table/${architecture}/default.yaml"
 
 otk.target.osbuild:
   pipelines:
@@ -221,7 +222,7 @@ otk.target.osbuild:
               PasswordAuthentication: false
         - otk.external.otk-make-fstab-stage:
             ${filesystem}
-        - otk.include: "fragment/grub2/x86_64.yaml"
+        - otk.include: "fragment/grub2/${architecture}.yaml"
         - type: org.osbuild.systemd
           options:
             enabled_services:
@@ -237,7 +238,7 @@ otk.target.osbuild:
               - tuned
             default_target: multi-user.target
         - otk.include: "fragment/selinux/targeted.yaml"
-    - otk.include: "pipeline/image/x86_64.yaml"
+    - otk.include: "pipeline/image/${architecture}.yaml"
   sources:
     otk.external.osbuild-make-depsolve-dnf4-curl-source:
       packagesets:

--- a/example/centos/centos-9-x86_64-edge-commit.yaml
+++ b/example/centos/centos-9-x86_64-edge-commit.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: x86_64
   modifications:
     locale: C.UTF-8
     timezone: America/New_York
@@ -10,11 +11,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -32,11 +33,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - NetworkManager
@@ -206,7 +207,7 @@ otk.target.osbuild:
               references:
                 - name:os
           options:
-            ref: centos/9/x86_64/edge
+            ref: centos/9/${architecture}/edge
             os_version: 9-stream
     - name: commit-archive
       build: name:build

--- a/example/centos/centos-9-x86_64-image-installer.yaml
+++ b/example/centos/centos-9-x86_64-image-installer.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: x86_64
   modifications:
     timezone: America/New_York
   # XXX these sizes are currently hardcoded in `images` in the future they
@@ -15,11 +16,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -50,11 +51,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - "@core"
@@ -118,11 +119,11 @@ otk.define:
             - dracut-config-rescue
     anaconda:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - aajohan-comfortaa-fonts
@@ -292,7 +293,7 @@ otk.target.osbuild:
               otk.include: "common/gpgkeys.yaml"
         - type: org.osbuild.buildstamp
           options:
-            arch: x86_64
+            arch: ${architecture}
             product: CentOS Stream
             version: 9-stream
             final: true
@@ -322,7 +323,7 @@ otk.target.osbuild:
         - type: org.osbuild.lorax-script
           options:
             path: 99-generic/runtime-postinstall.tmpl
-            basearch: x86_64
+            basearch: ${architecture}
             product:
               name: ''
               version: ''
@@ -443,9 +444,9 @@ otk.target.osbuild:
             kernel:
               dir: /images/pxeboot
               opts:
-                - inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64
-                - inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64:/osbuild.ks
-            isolabel: CentOS-Stream-9-BaseOS-x86_64
+                - inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-${architecture}
+                - inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-${architecture}:/osbuild.ks
+            isolabel: CentOS-Stream-9-BaseOS-${architecture}
             architectures:
               - X64
             vendor: centos
@@ -518,8 +519,8 @@ otk.target.osbuild:
             kernel:
               dir: /images/pxeboot
               opts:
-                - inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64
-                - inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64:/osbuild.ks
+                - inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-${architecture}
+                - inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-${architecture}:/osbuild.ks
         - type: org.osbuild.truncate
           options:
             filename: images/efiboot.img
@@ -583,7 +584,7 @@ otk.target.osbuild:
               url: file:///run/install/repo/liveimg.tar.gz
         - type: org.osbuild.discinfo
           options:
-            basearch: x86_64
+            basearch: ${architecture}
             release: CentOS Stream 9-stream
     - name: bootiso
       build: name:build
@@ -597,7 +598,7 @@ otk.target.osbuild:
                 - name:bootiso-tree
           options:
             filename: installer.iso
-            volid: CentOS-Stream-9-BaseOS-x86_64
+            volid: CentOS-Stream-9-BaseOS-${architecture}
             sysid: LINUX
             boot:
               image: isolinux/isolinux.bin

--- a/example/centos/centos-9-x86_64-minimal-raw.yaml
+++ b/example/centos/centos-9-x86_64-minimal-raw.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: x86_64
   modifications:
     locale: C.UTF-8
     timezone: America/New_York
@@ -10,11 +11,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -31,11 +32,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - "@core"
@@ -69,7 +70,7 @@ otk.define:
         packageset: ${packages.os}
         packagename: "kernel"
 
-otk.include: "common/partition-table/x86_64/minimal-raw.yaml"
+otk.include: "common/partition-table/${architecture}/minimal-raw.yaml"
 
 otk.target.osbuild:
   pipelines:
@@ -103,7 +104,7 @@ otk.target.osbuild:
             unit-type: global
         - otk.external.otk-make-fstab-stage:
             ${filesystem}
-        - otk.include: fragment/grub2/x86_64-no-bios.yaml
+        - otk.include: fragment/grub2/${architecture}-no-bios.yaml
         - type: org.osbuild.copy
           inputs:
             # XXX note we're only keeping the hash here since it corresponds to the reference
@@ -132,7 +133,7 @@ otk.target.osbuild:
               - sshd.service
               - initial-setup.service
         - otk.include: "fragment/selinux/targeted.yaml"
-    - otk.include: pipeline/image/x86_64-no-bios.yaml
+    - otk.include: pipeline/image/${architecture}-no-bios.yaml
     - name: xz
       build: name:build
       stages:

--- a/example/centos/centos-9-x86_64-ova.yaml
+++ b/example/centos/centos-9-x86_64-ova.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: x86_64
   modifications:
     locale: en_US.UTF-8
     timezone: America/New_York
@@ -10,11 +11,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -34,11 +35,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - "@core"
@@ -68,7 +69,7 @@ otk.define:
         packageset: ${packages.os}
         packagename: "kernel"
 
-otk.include: "common/partition-table/x86_64/vhd_vmdk_ova.yaml"
+otk.include: "common/partition-table/${architecture}/vhd_vmdk_ova.yaml"
 
 otk.target.osbuild:
   pipelines:
@@ -94,9 +95,9 @@ otk.target.osbuild:
               no_zero_conf: true
         - otk.external.otk-make-fstab-stage:
             ${filesystem}
-        - otk.include: "fragment/grub2/x86_64.yaml"
+        - otk.include: "fragment/grub2/${architecture}.yaml"
         - otk.include: "fragment/selinux/targeted.yaml"
-    - otk.include: pipeline/image/x86_64.yaml
+    - otk.include: pipeline/image/${architecture}.yaml
     - name: vmdk
       build: name:build
       stages:

--- a/example/centos/centos-9-x86_64-qcow2.yaml
+++ b/example/centos/centos-9-x86_64-qcow2.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: x86_64
   modifications:
     locale: C.UTF-8
     timezone: America/New_York
@@ -10,11 +11,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -33,11 +34,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - "@core"
@@ -112,7 +113,7 @@ otk.define:
         packageset: ${packages.os}
         packagename: "kernel"
 
-otk.include: "common/partition-table/x86_64/default.yaml"
+otk.include: "common/partition-table/${architecture}/default.yaml"
 
 otk.target.osbuild:
   pipelines:
@@ -138,12 +139,12 @@ otk.target.osbuild:
               no_zero_conf: true
         - otk.external.otk-make-fstab-stage:
             ${filesystem}
-        - otk.include: "fragment/grub2/x86_64.yaml"
+        - otk.include: "fragment/grub2/${architecture}.yaml"
         - type: org.osbuild.systemd
           options:
             default_target: multi-user.target
         - otk.include: "fragment/selinux/targeted.yaml"
-    - otk.include: "pipeline/image/x86_64.yaml"
+    - otk.include: "pipeline/image/${architecture}.yaml"
     - name: qcow2
       build: name:build
       stages:

--- a/example/centos/centos-9-x86_64-tar.yaml
+++ b/example/centos/centos-9-x86_64-tar.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: x86_64
   modifications:
     locale: C.UTF-8
     timezone: America/New_York
@@ -9,11 +10,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -29,11 +30,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - selinux-policy-targeted

--- a/example/centos/centos-9-x86_64-vhd.yaml
+++ b/example/centos/centos-9-x86_64-vhd.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: x86_64
   modifications:
     locale: en_US.UTF-8
     timezone: Etc/UTC
@@ -9,11 +10,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -33,11 +34,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - "@Server"
@@ -121,7 +122,7 @@ otk.define:
         packageset: ${packages.os}
         packagename: "kernel"
 
-otk.include: "common/partition-table/x86_64/vhd_vmdk_ova.yaml"
+otk.include: "common/partition-table/${architecture}/vhd_vmdk_ova.yaml"
 
 otk.target.osbuild:
   pipelines:
@@ -285,7 +286,7 @@ otk.target.osbuild:
               - waagent
             default_target: multi-user.target
         - otk.include: "fragment/selinux/targeted.yaml"
-    - otk.include: "pipeline/image/x86_64.yaml"
+    - otk.include: "pipeline/image/${architecture}.yaml"
     - name: vpc
       build: name:build
       stages:

--- a/example/centos/centos-9-x86_64-vmdk.yaml
+++ b/example/centos/centos-9-x86_64-vmdk.yaml
@@ -1,6 +1,7 @@
 otk.version: "1"
 
 otk.define:
+  architecture: x86_64
   modifications:
     locale: en_US.UTF-8
     timezone: America/New_York
@@ -9,11 +10,11 @@ otk.define:
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -32,11 +33,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - "@core"
@@ -65,7 +66,7 @@ otk.define:
         packageset: ${packages.os}
         packagename: "kernel"
 
-otk.include: "common/partition-table/x86_64/vhd_vmdk_ova.yaml"
+otk.include: "common/partition-table/${architecture}/vhd_vmdk_ova.yaml"
 
 otk.target.osbuild:
   pipelines:
@@ -91,9 +92,9 @@ otk.target.osbuild:
               no_zero_conf: true
         - otk.external.otk-make-fstab-stage:
             ${filesystem}
-        - otk.include: fragment/grub2/x86_64.yaml
+        - otk.include: "fragment/grub2/${architecture}.yaml"
         - otk.include: "fragment/selinux/targeted.yaml"
-    - otk.include: "pipeline/image/x86_64.yaml"
+    - otk.include: "pipeline/image/${architecture}.yaml"
     - name: vmdk
       build: name:build
       stages:

--- a/example/centos/centos-9-x86_64-wsl.yaml
+++ b/example/centos/centos-9-x86_64-wsl.yaml
@@ -1,14 +1,15 @@
 otk.version: "1"
 
 otk.define:
+  architecture: x86_64
   packages:
     build:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - coreutils
@@ -24,11 +25,11 @@ otk.define:
           exclude: []
     os:
       otk.external.osbuild-gen-depsolve-dnf4:
-        architecture: x86_64
+        architecture: ${architecture}
         module_platform_id: c9s
         releasever: "9"
         repositories:
-          otk.include: "common/repositories/x86_64.yaml"
+          otk.include: "common/repositories/${architecture}.yaml"
         packages:
           include:
             - alternatives

--- a/example/centos/fragment/grub2/x86_64-no-bios.yaml
+++ b/example/centos/fragment/grub2/x86_64-no-bios.yaml
@@ -6,7 +6,7 @@ options:
   uefi:
     vendor: centos
     unified: true
-  saved_entry: ffffffffffffffffffffffffffffffff-8-2.fk1.x86_64
+  saved_entry: ffffffffffffffffffffffffffffffff-${kernel.package.version}-${kernel.package.release}.${kernel.package.arch}
   write_cmdline: false
   config:
     default: saved


### PR DESCRIPTION
A variable containing the targeted architecture makes omnifests less error prone to write. Split out from #240.