### PR TITLE
external: add architecture to the gen-depsolve-dnf4 mocks

### DIFF
--- a/src/otk_external_osbuild/command/gen_depsolve_dnf4.py
+++ b/src/otk_external_osbuild/command/gen_depsolve_dnf4.py
@@ -36,7 +36,8 @@ def mockdata(packages, repos, architecture):
     for repo in repos:
         l = list(urlsplit(repo["baseurl"]))
         l[1] = "example.com"
-        l[2] = "pseudo-repo-pkg:" + l[2].rsplit("-", maxsplit=1)[0]
+        repo = l[2].rsplit("-", maxsplit=1)[0]
+        l[2] = f"passed-arch:{architecture}/passed-repo:{repo}"
         base_url = urlunsplit(l)
         pseudo_repo_pkgs.append({
             "name": f"{base_url}",

--- a/test/data/images-ref/centos/9/aarch64/ami/centos_9-aarch64-ami-empty.yaml
+++ b/test/data/images-ref/centos/9/aarch64/ami/centos_9-aarch64-ami-empty.yaml
@@ -28,8 +28,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -164,8 +164,8 @@ pipelines:
               - id: sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34
               - id: sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c
               - id: sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -478,6 +478,8 @@ sources:
         url: https://example.com/repo/packages/exclude:ivtv-firmware
       sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39:
         url: https://example.com/repo/packages/exclude:iwl6000g2a-firmware
+      sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-appstream
       sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71:
         url: https://example.com/repo/packages/exclude:iwl135-firmware
       sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca:
@@ -528,10 +530,6 @@ sources:
         url: https://example.com/repo/packages/chrony
       sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c:
         url: https://example.com/repo/packages/kernel
-      sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-appstream
-      sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1:
         url: https://example.com/repo/packages/exclude:iwl4965-firmware
       sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334:
@@ -562,6 +560,8 @@ sources:
         url: https://example.com/repo/packages/cloud-utils-growpart
       sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7:
         url: https://example.com/repo/packages/exclude:iwl2030-firmware
+      sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb:
         url: https://example.com/repo/packages/tuned
       sha256:bd0add6fdee6e6ac62a4ff6bc722f2324a918d8ccc4eda21e043252a10481f0c:

--- a/test/data/images-ref/centos/9/aarch64/edge-commit/centos_9-aarch64-edge_commit-empty.yaml
+++ b/test/data/images-ref/centos/9/aarch64/edge-commit/centos_9-aarch64-edge_commit-empty.yaml
@@ -22,8 +22,8 @@ pipelines:
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -187,8 +187,8 @@ pipelines:
               - id: sha256:557bd0eaadc03a42f7034eaed1acbf4299219213aef48dddee1594d0d0017c37
               - id: sha256:e243470295e7a4ed4c248443bf78f4d827988f58767c47592545f77e76839439
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           dbpath: /usr/share/rpm
           gpgkeys:
@@ -336,6 +336,8 @@ sources:
         url: https://example.com/repo/packages/passwd
       sha256:0f75ba9658721aa3a185e6ac18b63b7fa3b709a5ec264be07d1f35408e003a8a:
         url: https://example.com/repo/packages/iptables
+      sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-appstream
       sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca:
         url: https://example.com/repo/packages/redhat-release
       sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387:
@@ -396,16 +398,12 @@ sources:
         url: https://example.com/repo/packages/kernel
       sha256:6a406152d00694615f91b8b047dc939d75c834790e521ff3997e3734111518e6:
         url: https://example.com/repo/packages/criu
-      sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-appstream
       sha256:6e5afe9033e4767cc4ccec7ec2d18958a28dcfb7b8982cae4afde231b5bb8fad:
         url: https://example.com/repo/packages/keyutils
       sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682:
         url: https://example.com/repo/packages/hostname
       sha256:75406d2ab1a318d214d3f17ad722986010c2d69fbac331fb855689191889f812:
         url: https://example.com/repo/packages/fdo-owner-cli
-      sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:772a6043284a6f653b3a220d1a7fa5a482dcd910f81308b3e53e20abbe8acfee:
         url: https://example.com/repo/packages/skopeo
       sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5:
@@ -436,6 +434,8 @@ sources:
         url: https://example.com/repo/packages/containernetworking-plugins
       sha256:a45298c4ca08fadc8220c2166c430c8ce2b0cf5add3459ecb12fb9264c0c5943:
         url: https://example.com/repo/packages/ima-evm-utils
+      sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:aa6d4532f128420f4d741f2834cd8d1d146bbbdc9554aef454b7adb8ff66f748:
         url: https://example.com/repo/packages/gnupg2
       sha256:ac31b31649786ed1bb6501121fd43973040b763991a648e673f6853d15627ecd:

--- a/test/data/images-ref/centos/9/aarch64/image-installer/centos_9-aarch64-image_installer-empty.yaml
+++ b/test/data/images-ref/centos/9/aarch64/image-installer/centos_9-aarch64-image_installer-empty.yaml
@@ -32,8 +32,8 @@ pipelines:
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
               - id: sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c
               - id: sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -288,8 +288,8 @@ pipelines:
               - id: sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387
               - id: sha256:f8c34fd44a3d8c1e0bd784f114de3640389336b9886e019ba236126c060c0b6f
               - id: sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -574,8 +574,8 @@ pipelines:
               - id: sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a
               - id: sha256:1ec523ebf26771bd12d4da16d6e041b9be98c6999ab8ad53afc8d82afb56e75c
               - id: sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -792,6 +792,8 @@ sources:
         url: https://example.com/repo/packages/bind-utils
       sha256:12a5913a6155c548dc77da461c37f570a6a5548fa57c798ca26ef4ce581bdcfe:
         url: https://example.com/repo/packages/kbd
+      sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-appstream
       sha256:15a57c569d41dc1cbb4b45354e7f3b53d7df2a829080e6f0c5c31cc95b2deeaa:
         url: https://example.com/repo/packages/anaconda-dracut
       sha256:15c36857db1d6db3a0ed1981e7b3add34d8ba01ae5477653f987f9b8636f1702:
@@ -926,16 +928,12 @@ sources:
         url: https://example.com/repo/packages/kernel
       sha256:6bf7a859ff31dc024d70c2a79af3c9ccb734ddceab91d1853a36e346ca2ac936:
         url: https://example.com/repo/packages/thai-scalable-waree-fonts
-      sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-appstream
       sha256:6da0721ac59243b94c0066d6899218cb9f82ae4539dfd77c844c46ce75074e12:
         url: https://example.com/repo/packages/kacst-qurn-fonts
       sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682:
         url: https://example.com/repo/packages/hostname
       sha256:72aec6b0d35ecb35b97ca9f0804c8a6ab055855a00ae7e8356276acca976a393:
         url: https://example.com/repo/packages/grub2-tools-minimal
-      sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:761f8a60b54fcf3965300ced84ed9a0db0eb70c89482e61f9e79a1a1ca251f18:
         url: https://example.com/repo/packages/strace
       sha256:7813fd2934106e4936074bd7bf8e05d2ce9afb310b52269868dc06fbee88e980:
@@ -1004,6 +1002,8 @@ sources:
         url: https://example.com/repo/packages/squashfs-tools
       sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018:
         url: https://example.com/repo/packages/iwl3160-firmware
+      sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:ab41c5997e31cbfd7ea7c4251f936b7c2eae16613144b9b345711a6aa0014e3d:
         url: https://example.com/repo/packages/usbutils
       sha256:ab70ba971afad989c2b54e7030af4cba9b0cbfe11de95bdc76552c87f529942a:

--- a/test/data/images-ref/centos/9/aarch64/minimal-raw/centos_9-aarch64-minimal_raw-empty.yaml
+++ b/test/data/images-ref/centos/9/aarch64/minimal-raw/centos_9-aarch64-minimal_raw-empty.yaml
@@ -27,8 +27,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -120,8 +120,8 @@ pipelines:
               - id: sha256:f19322aff95a0dab072e7d976be364f553e46efd51e1a602adae348b7c38af29
               - id: sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7
               - id: sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -387,6 +387,8 @@ sources:
     items:
       sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
         url: https://example.com/repo/packages/dosfstools
+      sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-appstream
       sha256:1a45775633795dff66f531ae980534d4f82b54efa603aaaef0bf1bf9df2ff387:
         url: https://example.com/repo/packages/grub2-efi-aa64
       sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d:
@@ -403,10 +405,6 @@ sources:
         url: https://example.com/repo/packages/libxkbcommon
       sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c:
         url: https://example.com/repo/packages/kernel
-      sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-appstream
-      sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
         url: https://example.com/repo/packages/platform-python
       sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a:
@@ -417,6 +415,8 @@ sources:
         url: https://example.com/repo/packages/rpm
       sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018:
         url: https://example.com/repo/packages/iwl3160-firmware
+      sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528:
         url: https://example.com/repo/packages/selinux-policy-targeted
       sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:

--- a/test/data/images-ref/centos/9/aarch64/qcow2/centos_9-aarch64-qcow2-empty.yaml
+++ b/test/data/images-ref/centos/9/aarch64/qcow2/centos_9-aarch64-qcow2-empty.yaml
@@ -27,8 +27,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -170,8 +170,8 @@ pipelines:
               - id: sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
               - id: sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -416,6 +416,8 @@ sources:
         url: https://example.com/repo/packages/exclude:ivtv-firmware
       sha256:0dc67f06d4a10e86af05f9a118375a3509880de5c947f9eab6476900b50d0a39:
         url: https://example.com/repo/packages/exclude:iwl6000g2a-firmware
+      sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-appstream
       sha256:161916c7546a6dfb94f1e050e71733eb5362bd5483488416b26e0b37203dbe98:
         url: https://example.com/repo/packages/exclude:fedora-repos
       sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71:
@@ -470,10 +472,6 @@ sources:
         url: https://example.com/repo/packages/chrony
       sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c:
         url: https://example.com/repo/packages/kernel
-      sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-appstream
-      sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1:
         url: https://example.com/repo/packages/exclude:iwl4965-firmware
       sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876:
@@ -512,6 +510,8 @@ sources:
         url: https://example.com/repo/packages/cloud-utils-growpart
       sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7:
         url: https://example.com/repo/packages/exclude:iwl2030-firmware
+      sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb:
         url: https://example.com/repo/packages/tuned
       sha256:bceee99a4a82cf20ebeb8d0085d57327f62bf0bcf1a4d3c24f430a9366f353c2:

--- a/test/data/images-ref/centos/9/aarch64/tar/centos_9-aarch64-tar-empty.yaml
+++ b/test/data/images-ref/centos/9/aarch64/tar/centos_9-aarch64-tar-empty.yaml
@@ -20,8 +20,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -99,8 +99,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -193,14 +193,12 @@ pipelines:
 sources:
   org.osbuild.curl:
     items:
+      sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-appstream
       sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d:
         url: https://example.com/repo/packages/glibc
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
-      sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-appstream
-      sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
         url: https://example.com/repo/packages/platform-python
       sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a:
@@ -211,6 +209,8 @@ sources:
         url: https://example.com/repo/packages/policycoreutils
       sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88:
         url: https://example.com/repo/packages/rpm
+      sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528:
         url: https://example.com/repo/packages/selinux-policy-targeted
       sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:

--- a/test/data/images-ref/centos/9/aarch64/vhd/centos_9-aarch64-vhd-empty.yaml
+++ b/test/data/images-ref/centos/9/aarch64/vhd/centos_9-aarch64-vhd-empty.yaml
@@ -29,8 +29,8 @@ pipelines:
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b
               - id: sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -185,8 +185,8 @@ pipelines:
               - id: sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be
               - id: sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5
               - id: sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -558,6 +558,8 @@ sources:
         url: https://example.com/repo/packages/exclude:iwl6000g2a-firmware
       sha256:0ee8cf7e33852f80cd293a8fa8c371f888dc011984ff2836f1198bcdc552dc58:
         url: https://example.com/repo/packages/exclude:buildah
+      sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-appstream
       sha256:141b56438fdc0208877397569000e1a5857ff57807ff3bbaf2622cc87901861d:
         url: https://example.com/repo/packages/exclude:python3-dnf-plugin-spacewalk
       sha256:19ba1894b231183f6dcfffd0adf9b657eb00ea33f1e002cfb04d1f1fc8e79b71:
@@ -620,14 +622,10 @@ sources:
         url: https://example.com/repo/packages/exclude:cockpit-podman
       sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c:
         url: https://example.com/repo/packages/kernel
-      sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-appstream
       sha256:6f1984a96a0a6f38cf4fd688a63af7fc395e68a335cc6def15ce41cffdde0221:
         url: https://example.com/repo/packages/@Server
       sha256:725c887b1ebcd6be8eb9a0ef6b2c476ff6d2dd8f9cf622f8d60953a1f22c94c8:
         url: https://example.com/repo/packages/exclude:python3-hwdata
-      sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:75666699b77db631f576041e8102a55b46758c01b807eacae0f170930ab59b3d:
         url: https://example.com/repo/packages/uuid
       sha256:782c4bb3c7a9beb41e451bceb3f4db6de6a331eb31ca76e6a64296251ba2fdb1:
@@ -672,6 +670,8 @@ sources:
         url: https://example.com/repo/packages/cloud-utils-growpart
       sha256:a918a8d5a29ea7c5834c6d46725660eb441653074ab4d9d8876029abce79bfb7:
         url: https://example.com/repo/packages/exclude:iwl2030-firmware
+      sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:b1eb4c41592e8eb6f7f2c96cdda2162fe214f52f85b01e9b174aa81bf297e01a:
         url: https://example.com/repo/packages/exclude:rhn-setup
       sha256:b6cae3a11438b4ec550ce10b73b35160fafbe9d436fdb4f81fea356fc5bb6fee:

--- a/test/data/images-ref/centos/9/aarch64/wsl/centos_9-aarch64-wsl-empty.yaml
+++ b/test/data/images-ref/centos/9/aarch64/wsl/centos_9-aarch64-wsl-empty.yaml
@@ -19,8 +19,8 @@ pipelines:
               - id: sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88
               - id: sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -141,8 +141,8 @@ pipelines:
               - id: sha256:10d1e54c16c491abf59ec796854ffa14563d54461ebb9092501da34f5a9184bc
               - id: sha256:c06dba625e4dfb0b49cb4013c2a82c8f314143c833c1306da12fa2d77a12e0c4
               - id: sha256:60e3d9a99e40010bb917f75d9ce99530d1f8b322d0b1aea07fe71257a369d943
-              - id: sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca
-              - id: sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c
+              - id: sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02
+              - id: sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -242,6 +242,8 @@ sources:
         url: https://example.com/repo/packages/passwd
       sha256:10d1e54c16c491abf59ec796854ffa14563d54461ebb9092501da34f5a9184bc:
         url: https://example.com/repo/packages/exclude:python-unversioned-command
+      sha256:1346b27a6e2f7d7b7e20a980c43a4388d6c46e11a067ff563319e1445649ac02:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-appstream
       sha256:1a0970a720caab2869fc7eb436e6b7656fc7efbb24cfa72ae5b49e2f6acbd7ca:
         url: https://example.com/repo/packages/redhat-release
       sha256:1a36b318995f3383dfa35c283df090bde63776c52415a421ea201a9667f95ab3:
@@ -280,14 +282,10 @@ sources:
         url: https://example.com/repo/packages/exclude:rpm-plugin-systemd-inhibit
       sha256:6449d2f7bae9905add75f6d3e9b03de90743a1cef971f41aedeeb4139a1780d1:
         url: https://example.com/repo/packages/shadow-utils
-      sha256:6cc4d58608021ccaa0166ec7629107ba866e35f289607a6c69dafcfb3c369fca:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-appstream
       sha256:6fd624e2ceb4409a98b06f7f6161a6259cc88a838b6f43454217ed5a0c18a547:
         url: https://example.com/repo/packages/exclude:gawk-all-langpacks
       sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682:
         url: https://example.com/repo/packages/hostname
-      sha256:75426b0ba4cd44b349db0533e5d59eb207a273f0b2a4cc7326613317ed39158c:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:7cb8f52fafc3465bc88412019948f599fa1217927861c07ac3f90628772efa55:
         url: https://example.com/repo/packages/exclude:openssl-pkcs11
       sha256:809c2fb94fff223e96477a875bbc1b77e5b020262e8f959d4b49455100a7f9f7:
@@ -314,6 +312,8 @@ sources:
         url: https://example.com/repo/packages/rpm
       sha256:a697ff6e769b4f3d7c9b05d77c96d575c5e001ef923a13395decbe00b7e461bb:
         url: https://example.com/repo/packages/exclude:glibc-langpack-en
+      sha256:aa112e5fa7d230f8d00a0233b80d2bd35ee8debeccde198da1d13214f2136acb:
+        url: https://example.com/passed-arch:aarch64/passed-repo:/v2/mirror/public/el9/cs9-aarch64-baseos
       sha256:aa6d4532f128420f4d741f2834cd8d1d146bbbdc9554aef454b7adb8ff66f748:
         url: https://example.com/repo/packages/gnupg2
       sha256:ae5e2ad3b86239dbf500c630cf88d33d9775e9ce2e32d596910a07d682d97923:

--- a/test/data/images-ref/centos/9/ppc64le/tar/centos_9-ppc64le-tar-empty.yaml
+++ b/test/data/images-ref/centos/9/ppc64le/tar/centos_9-ppc64le-tar-empty.yaml
@@ -20,8 +20,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
-              - id: sha256:1324cffcaa49021bb7da2de54cbe95be0565e2e213ec4bb657a5ab06f9ea5d4f
-              - id: sha256:7b507ea13181aff07a2d7827448ac14aab25f1c82939d72893eb7d06483e335e
+              - id: sha256:c7ca465e8f6e30bbe0611ae7b0e265e290ef9c626f077f17390a321e8693061e
+              - id: sha256:7156b8d8c4c7ded0df2cd3582150b1ae6218a6f35e96a883326dfb90b81f26ec
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -99,8 +99,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
-              - id: sha256:1324cffcaa49021bb7da2de54cbe95be0565e2e213ec4bb657a5ab06f9ea5d4f
-              - id: sha256:7b507ea13181aff07a2d7827448ac14aab25f1c82939d72893eb7d06483e335e
+              - id: sha256:c7ca465e8f6e30bbe0611ae7b0e265e290ef9c626f077f17390a321e8693061e
+              - id: sha256:7156b8d8c4c7ded0df2cd3582150b1ae6218a6f35e96a883326dfb90b81f26ec
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -193,14 +193,12 @@ pipelines:
 sources:
   org.osbuild.curl:
     items:
-      sha256:1324cffcaa49021bb7da2de54cbe95be0565e2e213ec4bb657a5ab06f9ea5d4f:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-ppc64le-appstream
       sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d:
         url: https://example.com/repo/packages/glibc
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
-      sha256:7b507ea13181aff07a2d7827448ac14aab25f1c82939d72893eb7d06483e335e:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-ppc64le-baseos
+      sha256:7156b8d8c4c7ded0df2cd3582150b1ae6218a6f35e96a883326dfb90b81f26ec:
+        url: https://example.com/passed-arch:ppc64le/passed-repo:/v2/mirror/public/el9/cs9-ppc64le-baseos
       sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
         url: https://example.com/repo/packages/platform-python
       sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a:
@@ -215,6 +213,8 @@ sources:
         url: https://example.com/repo/packages/selinux-policy-targeted
       sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:
         url: https://example.com/repo/packages/python3
+      sha256:c7ca465e8f6e30bbe0611ae7b0e265e290ef9c626f077f17390a321e8693061e:
+        url: https://example.com/passed-arch:ppc64le/passed-repo:/v2/mirror/public/el9/cs9-ppc64le-appstream
       sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98:
         url: https://example.com/repo/packages/systemd
       sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62:

--- a/test/data/images-ref/centos/9/s390x/tar/centos_9-s390x-tar-empty.yaml
+++ b/test/data/images-ref/centos/9/s390x/tar/centos_9-s390x-tar-empty.yaml
@@ -20,8 +20,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
-              - id: sha256:b8d091abda67af8480100d621faa0a7648cb9aee4682b0e12606595f0583c639
-              - id: sha256:dabb2041d791bbe2ff130c6b7412f5469083ec6796cd23032bae8eca1d350ac0
+              - id: sha256:2ef3a1f1a9fdba719c2fd4f80df85836c50a7c144aafcb1101aad2f5daae8589
+              - id: sha256:c96a44611625df4b5f7b81f2bed92fbf5990727a2b0b1be4dbed6b4c37462a11
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -99,8 +99,8 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
-              - id: sha256:b8d091abda67af8480100d621faa0a7648cb9aee4682b0e12606595f0583c639
-              - id: sha256:dabb2041d791bbe2ff130c6b7412f5469083ec6796cd23032bae8eca1d350ac0
+              - id: sha256:2ef3a1f1a9fdba719c2fd4f80df85836c50a7c144aafcb1101aad2f5daae8589
+              - id: sha256:c96a44611625df4b5f7b81f2bed92fbf5990727a2b0b1be4dbed6b4c37462a11
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -195,6 +195,8 @@ sources:
     items:
       sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d:
         url: https://example.com/repo/packages/glibc
+      sha256:2ef3a1f1a9fdba719c2fd4f80df85836c50a7c144aafcb1101aad2f5daae8589:
+        url: https://example.com/passed-arch:s390x/passed-repo:/v2/mirror/public/el9/cs9-s390x-appstream
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
       sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
@@ -207,14 +209,12 @@ sources:
         url: https://example.com/repo/packages/policycoreutils
       sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88:
         url: https://example.com/repo/packages/rpm
-      sha256:b8d091abda67af8480100d621faa0a7648cb9aee4682b0e12606595f0583c639:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-s390x-appstream
       sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528:
         url: https://example.com/repo/packages/selinux-policy-targeted
       sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:
         url: https://example.com/repo/packages/python3
-      sha256:dabb2041d791bbe2ff130c6b7412f5469083ec6796cd23032bae8eca1d350ac0:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-s390x-baseos
+      sha256:c96a44611625df4b5f7b81f2bed92fbf5990727a2b0b1be4dbed6b4c37462a11:
+        url: https://example.com/passed-arch:s390x/passed-repo:/v2/mirror/public/el9/cs9-s390x-baseos
       sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98:
         url: https://example.com/repo/packages/systemd
       sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62:

--- a/test/data/images-ref/centos/9/x86_64/ami/centos_9-x86_64-ami-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/ami/centos_9-x86_64-ami-empty.yaml
@@ -30,9 +30,9 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -167,9 +167,9 @@ pipelines:
               - id: sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34
               - id: sha256:e0d9946d02c44f153131552ca5afa5cd0902d0446b0295a329964e78a345327c
               - id: sha256:f2b81e75c964a01a845829b272d95e864a2e271e4fcd409c5e7cf5a83de1f127
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -502,8 +502,6 @@ sources:
     items:
       sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
         url: https://example.com/repo/packages/dosfstools
-      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3:
         url: https://example.com/repo/packages/exclude:iwl3160-firmware
       sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2:
@@ -524,16 +522,18 @@ sources:
         url: https://example.com/repo/packages/exclude:libertas-usb8388-firmware
       sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053:
         url: https://example.com/repo/packages/langpacks-en
+      sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d:
         url: https://example.com/repo/packages/exclude:plymouth
+      sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8:
         url: https://example.com/repo/packages/exclude:iwl7260-firmware
       sha256:368f9ec3b56023c66a7e2a4bd2609dced16bbd5354833cbb3e2eec5c90462133:
         url: https://example.com/repo/packages/gdisk
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
-      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942:
         url: https://example.com/repo/packages/cloud-init
       sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a:
@@ -564,8 +564,6 @@ sources:
         url: https://example.com/repo/packages/exclude:iwl4965-firmware
       sha256:7a5bd1ed08002bc08013ea55c7fffc61047042b3d0979471b6e34d5e5089d334:
         url: https://example.com/repo/packages/redhat-release-eula
-      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0:
         url: https://example.com/repo/packages/exclude:iwl2000-firmware
       sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
@@ -604,6 +602,8 @@ sources:
         url: https://example.com/repo/packages/selinux-policy-targeted
       sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:
         url: https://example.com/repo/packages/python3
+      sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e:
         url: https://example.com/repo/packages/exclude:iwl5000-firmware
       sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b:

--- a/test/data/images-ref/centos/9/x86_64/edge-commit/centos_9-x86_64-edge_commit-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/edge-commit/centos_9-x86_64-edge_commit-empty.yaml
@@ -23,9 +23,9 @@ pipelines:
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:ec924965104fcfdffc6c47b1097bcf63a78989606075c98870d56937969b531d
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -213,9 +213,9 @@ pipelines:
               - id: sha256:557bd0eaadc03a42f7034eaed1acbf4299219213aef48dddee1594d0d0017c37
               - id: sha256:e243470295e7a4ed4c248443bf78f4d827988f58767c47592545f77e76839439
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           dbpath: /usr/share/rpm
           gpgkeys:
@@ -357,8 +357,6 @@ sources:
     items:
       sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
         url: https://example.com/repo/packages/dosfstools
-      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:0a297cf5549425fa4f7cf9236959e92d97dc3ff0c42506ede88c253073891f11:
         url: https://example.com/repo/packages/clevis-luks
       sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb:
@@ -381,8 +379,12 @@ sources:
         url: https://example.com/repo/packages/traceroute
       sha256:2b90c77eadb96acadc4e8fcdd394714af190e7711bff194e1209a683228a3b68:
         url: https://example.com/repo/packages/policycoreutils-python-utils
+      sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:2f259bab93aaaaa2542ba43ef33eb990d0999ee1b9924b557b7be53c0b7a1bb9:
         url: https://example.com/repo/packages/podman
+      sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:3745e8dd111be6023e8fc59dfb541e0de5a9432489285b0c85e1ddf394624c9f:
         url: https://example.com/repo/packages/e2fsprogs
       sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2:
@@ -393,8 +395,6 @@ sources:
         url: https://example.com/repo/packages/fuse-overlayfs
       sha256:3cc2ce65b79da03dbdb0dd90b29f773ed36810fe411347347186840029f631a8:
         url: https://example.com/repo/packages/setools-console
-      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:3fe9a8dfca0f4e96aa36bca306729179202f3854488648a3aca7bdf80bc1bb81:
         url: https://example.com/repo/packages/ignition
       sha256:427e4b79b1f0fc90306cbe064b1297b21dc6835bfa656d3bf46bc156e3f24bb0:
@@ -443,8 +443,6 @@ sources:
         url: https://example.com/repo/packages/skopeo
       sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5:
         url: https://example.com/repo/packages/firewalld
-      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a:
         url: https://example.com/repo/packages/openssh-server
       sha256:7e41bc67e45e9633f10b8c4ab76c6cffba2bd76b9d3859f1fe51337e9978c760:
@@ -509,6 +507,8 @@ sources:
         url: https://example.com/repo/packages/polkit
       sha256:c38a19b3443f7bc00411db2850001c2fa25d751544c364e1802148be05021cc0:
         url: https://example.com/repo/packages/iwl5000-firmware
+      sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:c8d77bf4d8b1a10dd67a283d0c82bd96c9d5609860f84d7fc77692a36ab9b4c2:
         url: https://example.com/repo/packages/gzip
       sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0:

--- a/test/data/images-ref/centos/9/x86_64/image-installer/centos_9-x86_64-image_installer-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/image-installer/centos_9-x86_64-image_installer-empty.yaml
@@ -37,9 +37,9 @@ pipelines:
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
               - id: sha256:f7b582e05483b8a5ecc5804365d363ae91a5cbb5dd4f38f3f10e79634ebcf70c
               - id: sha256:53938ccf86d0954286625faacd6f86ff09bd5d8c3bfaabc284848c80d014e781
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -307,9 +307,9 @@ pipelines:
               - id: sha256:2c3aeb7c716dc15da1e2b05b2e42ff75eace021594deeed9344216511e27e8bc
               - id: sha256:0d3ffa508f3c7375c05551af609738a9d474b3eab32cb2d2194b41870b37f1a9
               - id: sha256:eddfc611c4f74bed09b2ac20b714b54f2e47d9befc7cc8af98b4c679807ba573
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -608,9 +608,9 @@ pipelines:
               - id: sha256:a07b0a6df6f248078ebaf93e5bea115093f8a79e0a830e383b6c0b9f7f1605f5
               - id: sha256:1ec523ebf26771bd12d4da16d6e041b9be98c6999ab8ad53afc8d82afb56e75c
               - id: sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -835,8 +835,6 @@ sources:
         url: https://example.com/repo/packages/net-tools
       sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
         url: https://example.com/repo/packages/dosfstools
-      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:095af8602a457074cf156c608826099e6c2b6d58a4febe0b04bb670cea4d5112:
         url: https://example.com/repo/packages/dbus-x11
       sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3:
@@ -903,6 +901,8 @@ sources:
         url: https://example.com/repo/packages/dmidecode
       sha256:2c43a3f28724ae41ee9c7aaa8531f90a3f164f709d74824cde241762bc9703a2:
         url: https://example.com/repo/packages/xorg-x11-fonts-misc
+      sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:2ee1c183198b2cae042aa65aa5acc2f66ccc56e63036fca331fe79f7cf4b151f:
         url: https://example.com/repo/packages/alsa-tools-firmware
       sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff:
@@ -911,6 +911,8 @@ sources:
         url: https://example.com/repo/packages/nmap-ncat
       sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9:
         url: https://example.com/repo/packages/rng-tools
+      sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901:
         url: https://example.com/repo/packages/oddjob-mkhomedir
       sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c:
@@ -923,8 +925,6 @@ sources:
         url: https://example.com/repo/packages/coreutils
       sha256:3c8aa865cc58cd21ebc9394a5b4216d106ab3a6dacbba30498dd47cc3163a1a1:
         url: https://example.com/repo/packages/bitmap-fangsongti-fonts
-      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:3d8d8add0c096940b0dbde561db4fb803284fdd0c77c3f3433f5503e5956e261:
         url: https://example.com/repo/packages/lohit-gurmukhi-fonts
       sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1:
@@ -1007,8 +1007,6 @@ sources:
         url: https://example.com/repo/packages/qemu-guest-agent
       sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5:
         url: https://example.com/repo/packages/firewalld
-      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:7d02017322fc296d1d3b7a7f79f6f7053a51b062179ef618086509af08a12f5a:
         url: https://example.com/repo/packages/openssh-server
       sha256:7f72cc3ac75a624f94ec606d8ddb4dbf6385595499e5449fd0d369d83fdb6467:
@@ -1111,6 +1109,8 @@ sources:
         url: https://example.com/repo/packages/cockpit-ws
       sha256:c6bfc8d71984ae000030ad824d40cb24a5a2ea0011f17c0e1997d623973ff33c:
         url: https://example.com/repo/packages/ethtool
+      sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:c812201221ab349c76365cd35227389971edfab23a01f4b46f8ece79881dad63:
         url: https://example.com/repo/packages/sil-abyssinica-fonts
       sha256:c9694c21375651122e49ce8afc80f69910c81f7843714dca0f1af12d3cdcd6b0:

--- a/test/data/images-ref/centos/9/x86_64/minimal-raw/centos_9-x86_64-minimal_raw-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/minimal-raw/centos_9-x86_64-minimal_raw-empty.yaml
@@ -27,9 +27,9 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -120,9 +120,9 @@ pipelines:
               - id: sha256:f19322aff95a0dab072e7d976be364f553e46efd51e1a602adae348b7c38af29
               - id: sha256:fc8aa064642e279d6d03beb27074f88fe4e3182c2dfe3a4117f135b9662ae2b7
               - id: sha256:a9c2cd1e4311be8781e7421119b8cdeb9c0f36f7d8c63144a3fb2fd6c0ad1018
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -388,16 +388,16 @@ sources:
     items:
       sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
         url: https://example.com/repo/packages/dosfstools
-      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d:
         url: https://example.com/repo/packages/glibc
       sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49:
         url: https://example.com/repo/packages/xfsprogs
+      sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-rt
+      sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
-      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a:
         url: https://example.com/repo/packages/@core
       sha256:5660f11783e742698cec671d45910e74342fe3e48ddf054f38c0828776b08d00:
@@ -406,8 +406,6 @@ sources:
         url: https://example.com/repo/packages/libxkbcommon
       sha256:6923dd1bc0460082c5d55a831908c24a282860b7f1cd6c2b79cf1bc8857c639c:
         url: https://example.com/repo/packages/kernel
-      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
         url: https://example.com/repo/packages/platform-python
       sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a:
@@ -424,6 +422,8 @@ sources:
         url: https://example.com/repo/packages/selinux-policy-targeted
       sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:
         url: https://example.com/repo/packages/python3
+      sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4:
         url: https://example.com/repo/packages/grub2-efi-x64
       sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98:

--- a/test/data/images-ref/centos/9/x86_64/oci/centos_9-x86_64-oci-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/oci/centos_9-x86_64-oci-empty.yaml
@@ -29,9 +29,9 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -174,9 +174,9 @@ pipelines:
               - id: sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
               - id: sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -435,8 +435,6 @@ sources:
     items:
       sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
         url: https://example.com/repo/packages/dosfstools
-      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3:
         url: https://example.com/repo/packages/exclude:iwl3160-firmware
       sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2:
@@ -459,10 +457,14 @@ sources:
         url: https://example.com/repo/packages/exclude:udisks2
       sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee:
         url: https://example.com/repo/packages/python3-jsonschema
+      sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d:
         url: https://example.com/repo/packages/exclude:plymouth
       sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff:
         url: https://example.com/repo/packages/tcpdump
+      sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901:
         url: https://example.com/repo/packages/oddjob-mkhomedir
       sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8:
@@ -471,8 +473,6 @@ sources:
         url: https://example.com/repo/packages/qemu-img
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
-      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942:
         url: https://example.com/repo/packages/cloud-init
       sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d:
@@ -505,8 +505,6 @@ sources:
         url: https://example.com/repo/packages/redhat-release-eula
       sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5:
         url: https://example.com/repo/packages/qemu-guest-agent
-      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0:
         url: https://example.com/repo/packages/exclude:iwl2000-firmware
       sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747:
@@ -553,6 +551,8 @@ sources:
         url: https://example.com/repo/packages/python3
       sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828:
         url: https://example.com/repo/packages/cockpit-ws
+      sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280:
         url: https://example.com/repo/packages/exclude:langpacks-*
       sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e:

--- a/test/data/images-ref/centos/9/x86_64/ova/centos_9-x86_64-ova-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/ova/centos_9-x86_64-ova-empty.yaml
@@ -31,9 +31,9 @@ pipelines:
               - id: sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c
               - id: sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -130,9 +130,9 @@ pipelines:
               - id: sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb
               - id: sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -422,22 +422,22 @@ sources:
     items:
       sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
         url: https://example.com/repo/packages/dosfstools
-      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d:
         url: https://example.com/repo/packages/glibc
       sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49:
         url: https://example.com/repo/packages/xfsprogs
       sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053:
         url: https://example.com/repo/packages/langpacks-en
+      sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:2ec46eb16ef55156c58b6348c9552f739a616fb6b4e22367486fe62442e3a9c4:
         url: https://example.com/repo/packages/open-vm-tools
+      sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c:
         url: https://example.com/repo/packages/qemu-img
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
-      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942:
         url: https://example.com/repo/packages/cloud-init
       sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a:
@@ -452,8 +452,6 @@ sources:
         url: https://example.com/repo/packages/kernel
       sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5:
         url: https://example.com/repo/packages/firewalld
-      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
         url: https://example.com/repo/packages/platform-python
       sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a:
@@ -474,6 +472,8 @@ sources:
         url: https://example.com/repo/packages/selinux-policy-targeted
       sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:
         url: https://example.com/repo/packages/python3
+      sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4:
         url: https://example.com/repo/packages/grub2-efi-x64
       sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98:

--- a/test/data/images-ref/centos/9/x86_64/qcow2/centos_9-x86_64-qcow2-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/qcow2/centos_9-x86_64-qcow2-empty.yaml
@@ -29,9 +29,9 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -174,9 +174,9 @@ pipelines:
               - id: sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
               - id: sha256:241171773fc64efd040332c534e7f67f3f97e75ab0bb61b09bbe33fc81850a9b
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -435,8 +435,6 @@ sources:
     items:
       sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
         url: https://example.com/repo/packages/dosfstools
-      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3:
         url: https://example.com/repo/packages/exclude:iwl3160-firmware
       sha256:0bdf1ef00f53398361ebaf915f0325ccdc0534447134ba8506a03c71f2c5c9e2:
@@ -459,10 +457,14 @@ sources:
         url: https://example.com/repo/packages/exclude:udisks2
       sha256:292cc2595512fa5eb4a7235bc57d6ef0ea9f976272cbc70c7580331dda04ffee:
         url: https://example.com/repo/packages/python3-jsonschema
+      sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d:
         url: https://example.com/repo/packages/exclude:plymouth
       sha256:3096fd17ccf8ee00173d4d753aa67e476526b800ae6eff06b055d71fc4ce6dff:
         url: https://example.com/repo/packages/tcpdump
+      sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:352db6b0cf337d13b4a9c05b2e4f13bafe02a311cb3dbf756ef2d44d52dca901:
         url: https://example.com/repo/packages/oddjob-mkhomedir
       sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8:
@@ -471,8 +473,6 @@ sources:
         url: https://example.com/repo/packages/qemu-img
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
-      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942:
         url: https://example.com/repo/packages/cloud-init
       sha256:43436865ed2d17b812735341ae5102c5ea86ce1eb70a0a43045a552a755da79d:
@@ -505,8 +505,6 @@ sources:
         url: https://example.com/repo/packages/redhat-release-eula
       sha256:7b4efa9ae15ac908a0e4f0f79b90b322a98f10ab4e0b414e15d7424a270597d5:
         url: https://example.com/repo/packages/qemu-guest-agent
-      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:874ecbebddb9872c2fc949de3be7888f72ad3ae0e7847ee5ce0503c691503ad0:
         url: https://example.com/repo/packages/exclude:iwl2000-firmware
       sha256:8836d54e733450c96ab05b71d619e5bd52693fac5466644fbf39d02b58a09747:
@@ -553,6 +551,8 @@ sources:
         url: https://example.com/repo/packages/python3
       sha256:c62adbb8e41e30631962b2ea5b1ce9d9a8270d3fc7909f4d8ec2fed1348c7828:
         url: https://example.com/repo/packages/cockpit-ws
+      sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:c83c70508d7f2dc81102d86bdad776459f2d9dfd004a2e89ae8f06b7cd8c6280:
         url: https://example.com/repo/packages/exclude:langpacks-*
       sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e:

--- a/test/data/images-ref/centos/9/x86_64/tar/centos_9-x86_64-tar-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/tar/centos_9-x86_64-tar-empty.yaml
@@ -20,9 +20,9 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -100,9 +100,9 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -195,16 +195,14 @@ pipelines:
 sources:
   org.osbuild.curl:
     items:
-      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d:
         url: https://example.com/repo/packages/glibc
+      sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-rt
+      sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
-      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
-      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
         url: https://example.com/repo/packages/platform-python
       sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a:
@@ -219,6 +217,8 @@ sources:
         url: https://example.com/repo/packages/selinux-policy-targeted
       sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:
         url: https://example.com/repo/packages/python3
+      sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98:
         url: https://example.com/repo/packages/systemd
       sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62:

--- a/test/data/images-ref/centos/9/x86_64/vhd/centos_9-x86_64-vhd-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/vhd/centos_9-x86_64-vhd-empty.yaml
@@ -31,9 +31,9 @@ pipelines:
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:48af68b2888775d102da39bebbe05cf07bca2f2ab9f1103dd19359d64083c70b
               - id: sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -189,9 +189,9 @@ pipelines:
               - id: sha256:590ef3ccd31b243b045e9c5f9268d1013b0960060366c76028a23b070b5fb7be
               - id: sha256:9fe43931a7b645b90921b9b72d836e9d06ececc0b3cca1376fa0a297b5f522a5
               - id: sha256:49ec7b34785f32ffd1f252d5cc9a0a015ca074f75c601d2272149a72d50d42df
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -573,8 +573,6 @@ sources:
         url: https://example.com/repo/packages/exclude:NetworkManager-config-server
       sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
         url: https://example.com/repo/packages/dosfstools
-      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:04cb12e072878beef30b2e3560c39bf1cb0e5a8896a545e7f4bfb0ec777196b3:
         url: https://example.com/repo/packages/exclude:iwl3160-firmware
       sha256:09e61bc3a2412f610b1784706d9ed9e8b4d9eb29e8d0e415e888b4172beae8d3:
@@ -599,10 +597,14 @@ sources:
         url: https://example.com/repo/packages/exclude:libertas-usb8388-firmware
       sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053:
         url: https://example.com/repo/packages/langpacks-en
+      sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:2de43b323b1e26fd256368050a89e6f1ab3ca1c7d469b67e134db4d5ffc7929d:
         url: https://example.com/repo/packages/exclude:plymouth
       sha256:3422a5ddd21f999cb3eb595f87aaf7c500d784270e26af097fe409616b2156d9:
         url: https://example.com/repo/packages/rng-tools
+      sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:35a69aa1faeaa821a35f576490244bd7755c226a55e1a93abd0e2b4c7e0401e8:
         url: https://example.com/repo/packages/exclude:iwl7260-firmware
       sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c:
@@ -611,8 +613,6 @@ sources:
         url: https://example.com/repo/packages/gdisk
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
-      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942:
         url: https://example.com/repo/packages/cloud-init
       sha256:476f3ccb0b9ae8b029e7105db14adf652095700dc1c8b87b8caaed29993aab27:
@@ -661,8 +661,6 @@ sources:
         url: https://example.com/repo/packages/hyperv-daemons
       sha256:7a4bff421e4a68b5dadc7bef985c10316dad74015b17b89867f5178321e38876:
         url: https://example.com/repo/packages/exclude:dnf-plugin-spacewalk
-      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:81f29ed6c790aa976572770ecf7b6f0351da3c46c9558640c7a83896b6bf8e05:
         url: https://example.com/repo/packages/exclude:alsa-sof-firmware
       sha256:840109e45bc2504c9f202410bd941dc430bcef1065e1c1a98e5d08506c0c91af:
@@ -711,6 +709,8 @@ sources:
         url: https://example.com/repo/packages/selinux-policy-targeted
       sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:
         url: https://example.com/repo/packages/python3
+      sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:ce5857e0b504bd3e06f80b27dc88064f0bf214127dd5a2ee1ff849ed78e32c9e:
         url: https://example.com/repo/packages/exclude:iwl5000-firmware
       sha256:d8654f2a37c8dd45ed104e5b7c26ec3ee0d74dca488cdd0a400d58a6c4f7875b:

--- a/test/data/images-ref/centos/9/x86_64/vmdk/centos_9-x86_64-vmdk-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/vmdk/centos_9-x86_64-vmdk-empty.yaml
@@ -29,9 +29,9 @@ pipelines:
               - id: sha256:93cd8e20fc07f08337cb9d9fa9996274658f6395574e874379c4c4157e922700
               - id: sha256:bf35d0b80342ad44ca298ed07fcc9d3f8d43a2700964586a4a5e2c0a49766528
               - id: sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -127,9 +127,9 @@ pipelines:
               - id: sha256:aba407b81ed016841ea552feadaf0663c7804a64554ba55d3109b3dc8198cdcb
               - id: sha256:49e9285da13f2be02b3654b01e74cab5840b8c679f7ad4b528a9cf794d3d3e34
               - id: sha256:ec6b0c3970b59b0ca5532cb3dc4dd7239136602223a2d39e7e20fba18298bc62
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -385,22 +385,22 @@ sources:
     items:
       sha256:02b2f585447caaaef59cc58cda1cbf6db27530690fdb13f747f3fdeb762c4b15:
         url: https://example.com/repo/packages/dosfstools
-      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:1b11757d33424678ba2d9d6fbd9eb6293a7bfa196dca15a29af179af778c235d:
         url: https://example.com/repo/packages/glibc
       sha256:21fb8eaa1cfa55dbc0ed009dc98fbbbc9de4ecaef53d51dc41ab1b0ae867ed49:
         url: https://example.com/repo/packages/xfsprogs
       sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053:
         url: https://example.com/repo/packages/langpacks-en
+      sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:2ec46eb16ef55156c58b6348c9552f739a616fb6b4e22367486fe62442e3a9c4:
         url: https://example.com/repo/packages/open-vm-tools
+      sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:360688270679b1c512513cfab6d931c8c715318582a9974caa3c0f88a0ee053c:
         url: https://example.com/repo/packages/qemu-img
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
-      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:3fc8516922a52d754083308fc413432652da40490b0a336294a5d765757be942:
         url: https://example.com/repo/packages/cloud-init
       sha256:443ad85c108c8acb279fc373255ff3444e54cc07c0af87a62962f0adcedd152a:
@@ -415,8 +415,6 @@ sources:
         url: https://example.com/repo/packages/kernel
       sha256:7b50bdd407a8c815d221c01203fc9a241648c79805faa36a0dc70e9d3a46c7e5:
         url: https://example.com/repo/packages/firewalld
-      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:8a1bf05d306aa663e856f3c450c8b2ddc6800116b818c7d3b65503cd89f7682a:
         url: https://example.com/repo/packages/platform-python
       sha256:8ec5e9e6f70bf1a0b5692ef948d1194bdb074342ed14045f9e84820367a98c6a:
@@ -435,6 +433,8 @@ sources:
         url: https://example.com/repo/packages/selinux-policy-targeted
       sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:
         url: https://example.com/repo/packages/python3
+      sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:dbf9956aa9c5ccd4c6d92f0550e959f58bb815fb570c305e9d93645eee2082d4:
         url: https://example.com/repo/packages/grub2-efi-x64
       sha256:e0031c189e34e10d9c202fa8d75f72d3296a239164fe6b07e7dc206c7b723d98:

--- a/test/data/images-ref/centos/9/x86_64/wsl/centos_9-x86_64-wsl-empty.yaml
+++ b/test/data/images-ref/centos/9/x86_64/wsl/centos_9-x86_64-wsl-empty.yaml
@@ -19,9 +19,9 @@ pipelines:
               - id: sha256:9e7ab438597fee20e16e8e441bed0ce966bd59e0fb993fa7c94be31fb1384d88
               - id: sha256:55b591a15e8cd772eeaae5d187bcb8c44c12048aca78478e53db0c50ad09c999
               - id: sha256:90aebae315675cbf04612de4f7d5874850f48e0b8dd82becbeaa47ca93f5ebfb
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -142,9 +142,9 @@ pipelines:
               - id: sha256:10d1e54c16c491abf59ec796854ffa14563d54461ebb9092501da34f5a9184bc
               - id: sha256:c06dba625e4dfb0b49cb4013c2a82c8f314143c833c1306da12fa2d77a12e0c4
               - id: sha256:60e3d9a99e40010bb917f75d9ce99530d1f8b322d0b1aea07fe71257a369d943
-              - id: sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d
-              - id: sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15
-              - id: sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2
+              - id: sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6
+              - id: sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545
+              - id: sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a
         options:
           gpgkeys:
             - '-----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -238,8 +238,6 @@ pipelines:
 sources:
   org.osbuild.curl:
     items:
-      sha256:02eee243dc7e0c9589002cab187f57a444a8bfee4c469eee412c833580ba529d:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:0652d77991ae054286ace9807d7b4b573b99e3be9be7ad126db8d197b5f22a68:
         url: https://example.com/repo/packages/subscription-manager
       sha256:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb:
@@ -258,14 +256,16 @@ sources:
         url: https://example.com/repo/packages/dejavu-sans-fonts
       sha256:2c19d6424bd57628cc917ad414752d0135eb9c333b6671568cca9f6c95b8a053:
         url: https://example.com/repo/packages/langpacks-en
+      sha256:2c7fca95dbf12d65ab1b751c38e674a8003a18f288817d3f81081a13c7079d2a:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:32dcd32054ee4e9ae92eec040bc1385c94d74a0846bb0145b1bdf9958740200a:
         url: https://example.com/repo/packages/curl-minimal
+      sha256:3467780239fa16c778e73eaec177e764de52871964adf7f23b0b03c4b6384da6:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-appstream
       sha256:37d2b12d5d9abc2a364ef9448767ee03938e383c0284193477dc7618f4b7c6c2:
         url: https://example.com/repo/packages/bash
       sha256:3993c379c029014a9c4b2adf5d23397b3c7421467a0cb3575ff925bb6f6329b0:
         url: https://example.com/repo/packages/coreutils
-      sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:40db3e70e48fe4664f019f39fc6a95a211595c7359b3a325ee62b239152b35b1:
         url: https://example.com/repo/packages/dnf
       sha256:41ffca929b95c49690ab8815d1d1a134a5bcdd86bde407c0f46b90eabf556b05:
@@ -290,8 +290,6 @@ sources:
         url: https://example.com/repo/packages/exclude:gawk-all-langpacks
       sha256:7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682:
         url: https://example.com/repo/packages/hostname
-      sha256:7bffc576857b3a9e4a5f3059efeb5b8986118301ff15b5e92f6cc30d566c50e2:
-        url: https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-rt
       sha256:7cb8f52fafc3465bc88412019948f599fa1217927861c07ac3f90628772efa55:
         url: https://example.com/repo/packages/exclude:openssl-pkcs11
       sha256:809c2fb94fff223e96477a875bbc1b77e5b020262e8f959d4b49455100a7f9f7:
@@ -330,6 +328,8 @@ sources:
         url: https://example.com/repo/packages/exclude:redhat-release-eula
       sha256:c1cc69e61c0f1c7ade8df0f2994e582e7c1f2c57d1ec192a0baf9f96b7739d9d:
         url: https://example.com/repo/packages/python3
+      sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545:
+        url: https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-baseos
       sha256:cbdfe23c9cb9c48e031abaceb7fd4f15ac4a88e4e8a3334132838b4627e07b31:
         url: https://example.com/repo/packages/gdb-gdbserver
       sha256:cbf61858f3260072d96d9b1d2e037fc35824944b9c94d0087b1a53385eccaead:

--- a/test/test_gen_depsolve_dnf4.py
+++ b/test/test_gen_depsolve_dnf4.py
@@ -36,9 +36,9 @@ def test_gen_depsolve_dnf4_under_test_mock_data(monkeypatch, capsys):
                 "internal": {
                     "packages": [
                         {
-                            "checksum": "sha256:3cf1c35ad9bcc0ba055e1902a393c4b51cee4294b7d5e17bb20b7a5989054c15",
-                            "name": "https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos",
-                            "remote_location": "https://example.com/pseudo-repo-pkg:/v2/mirror/public/el9/cs9-x86_64-baseos",
+                            "checksum": "sha256:c71d1835b4ce161bb982d7bdefd5e082a6653e15c8b6e1bb684c989052212545",
+                            "name": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-baseos",
+                            "remote_location": "https://example.com/passed-arch:x86_64/passed-repo:/v2/mirror/public/el9/cs9-x86_64-baseos",
                         },
                         {
                             "checksum": "sha256:3d7b91c2dd3273400f26d21a492fcdfdc3dde228cd5627247dfef745ce717755",


### PR DESCRIPTION
This follows https://github.com/osbuild/images/pull/968 to include the architecture name in the generated URLs so that we can test for things like https://github.com/osbuild/otk/pull/255/files#r1782953752

This also requires a rebuild of all reference manifests.

