### PR TITLE
src/otk/context.py: improve error on missing entry in a dictionary

### DIFF
--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -100,7 +100,7 @@ class CommonContext(Context):
         for i, part in enumerate(parts):
             if isinstance(value, dict):
                 if part not in value:
-                    raise TransformVariableLookupError(f"could not find {parts!r}")
+                    raise TransformVariableLookupError(f"could not resolve '{name}' as '{part}' is not defined")
 
                 # TODO how should we deal with integer keys, convert them
                 # TODO on KeyError? Check for existence of both?

--- a/test/test_substitute_vars.py
+++ b/test/test_substitute_vars.py
@@ -44,10 +44,15 @@ def test_sub_var_multiple():
 def test_sub_var_missing_var_in_context():
     context = CommonContext()
     # toplevel
-    expected_err = r"could not find \['a'\]"
+    expected_err = r"could not resolve 'a' as 'a' is not defined"
     with pytest.raises(TransformVariableLookupError, match=expected_err):
         substitute_vars(context, "${a}")
-    # subtree
+    # different subtree
+    context.define("a", {"there-is-no-b": True})
+    expected_err = r"could not resolve 'a.b' as 'b' is not defined"
+    with pytest.raises(TransformVariableLookupError, match=expected_err):
+        substitute_vars(context, "${a.b}")
+    # no subtree
     context.define("a", "foo")
     expected_err = r"tried to look up 'a.b', but prefix 'a' value 'foo' is not a dictionary"
     with pytest.raises(TransformVariableTypeError, match=expected_err):


### PR DESCRIPTION
until now the error message was like this:

`otk.error.TransformVariableLookupError: could not find ['fs_options', 'devices', 'device', 'options', 'start']`

with this PR the error helps in finding which fragment is the problem:

`otk.error.TransformVariableLookupError: could not resolve 'fs_options.devices.device.options.start' as 'device' is not defined`

Do you think this change is useful?