### PR TITLE
otk: more error context improvements

### DIFF
--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -107,16 +107,17 @@ class CommonContext(Context):
                 value = value[part]
             elif isinstance(value, list):
                 if not part.isnumeric():
-                    raise TransformVariableIndexTypeError("part is not numeric")
+                    raise TransformVariableIndexTypeError(f"part is not numeric but {type(part)}")
 
                 try:
                     value = value[int(part)]
                 except IndexError as exc:
-                    raise TransformVariableIndexRangeError(f"{part} is out of range") from exc
+                    raise TransformVariableIndexRangeError(f"{part} is out of range for {value}") from exc
             else:
                 prefix = ".".join(parts[:i])
                 raise TransformVariableTypeError(
-                    f"tried to look up '{prefix}.{part}', but prefix '{prefix}' value {value!r} is not a dictionary")
+                    f"tried to look up '{prefix}.{part}', but the value of "
+                    f"prefix '{prefix}' is not a dictionary but {type(value)}")
 
         return value
 

--- a/src/otk/external.py
+++ b/src/otk/external.py
@@ -16,7 +16,7 @@ from .traversal import State
 log = logging.getLogger(__name__)
 
 
-def call(_: State, directive: str, tree: Any) -> Any:
+def call(state: State, directive: str, tree: Any) -> Any:
     exe = exe_from_directive(directive)
     exe = path_for(exe)
 
@@ -28,9 +28,9 @@ def call(_: State, directive: str, tree: Any) -> Any:
 
     process = subprocess.run([exe], input=data, encoding="utf8", capture_output=True, check=False)
     if process.returncode != 0:
-        msg = f"call: {exe!r} {directive!r} failed: {process.stdout!r}, {process.stderr!r}"
+        msg = f"call {exe} {directive!r} failed: stdout={process.stdout!r}, stderr={process.stderr!r}"
         log.error(msg)
-        raise ExternalFailedError(msg)
+        raise ExternalFailedError(msg, state)
 
     res = json.loads(process.stdout)
     return res["tree"]

--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -24,7 +24,7 @@ from . import tree
 from .constant import NAME_VERSION, PREFIX, PREFIX_DEFINE, PREFIX_INCLUDE, PREFIX_OP, PREFIX_TARGET
 from .context import Context, validate_var_name
 from .error import (
-    IncludeNotFoundError,
+    IncludeNotFoundError, OTKError,
     ParseError, ParseTypeError, ParseValueError, ParseDuplicatedYamlKeyError,
     TransformDirectiveTypeError, TransformDirectiveUnknownError,
 )
@@ -287,7 +287,11 @@ def substitute_vars(ctx: Context, state: State, data: str) -> Any:
     # return its value directly.
     if m := re.fullmatch(pattern, data):
         validate_var_name(m.group("name"))
-        return ctx.variable(m.group("name"))
+        try:
+            var = ctx.variable(m.group("name"))
+        except OTKError as exc:
+            raise exc.__class__(str(exc), state)
+        return var
 
     if matches := re.finditer(pattern, data):
         for m in matches:

--- a/src/otk/tree.py
+++ b/src/otk/tree.py
@@ -20,7 +20,8 @@ def must_be(kind: Type) -> Callable:
             if not isinstance(args[2], kind):
                 # XXX: this needs state to give proper errors
                 raise TransformDirectiveTypeError(
-                    f"otk.define expects a {kind!r} as its argument but received a `{type(args[2])}`: `{args[2]!r}`")
+                    f"otk.define expects a {kind!r} as its argument but "
+                    f"received a `{type(args[2])}`: `{args[2]!r}`", args[1])
             return function(*args, **kwargs)
 
         return wrapper

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -111,18 +111,27 @@ def test_context_nonexistent():
 
 def test_context_unhappy():
     ctx = CommonContext()
+
+    with pytest.raises(TransformVariableLookupError) as exc:
+        ctx.variable("foo")
+    assert "could not resolve 'foo' as 'foo' is not defined" in str(exc.value)
+
     ctx.define("foo", "foo")
 
-    with pytest.raises(TransformVariableTypeError):
+    with pytest.raises(TransformVariableTypeError) as exc:
         ctx.variable("foo.bar")
+    assert "tried to look up 'foo.bar', but the value of prefix 'foo' is not a dictionary but <class 'str'>" in str(
+        exc.value)
 
     ctx.define("bar", ["bar"])
 
-    with pytest.raises(TransformVariableIndexTypeError):
+    with pytest.raises(TransformVariableIndexTypeError) as exc:
         ctx.variable("bar.bar")
+    assert "part is not numeric but <class 'str'>" in str(exc.value)
 
-    with pytest.raises(TransformVariableIndexRangeError):
+    with pytest.raises(TransformVariableIndexRangeError) as exc:
         ctx.variable("bar.3")
+    assert "3 is out of range for ['bar']" in str(exc.value)
 
 
 @pytest.mark.parametrize(

--- a/test/test_substitute_vars.py
+++ b/test/test_substitute_vars.py
@@ -47,7 +47,7 @@ def test_sub_var_multiple():
 
 
 def test_sub_var_missing_var_in_context():
-    state = State("")
+    state = State("foo.yaml")
     context = CommonContext()
     # toplevel
     expected_err = r"could not resolve 'a' as 'a' is not defined"
@@ -60,7 +60,8 @@ def test_sub_var_missing_var_in_context():
         substitute_vars(context, state, "${a.b}")
     # no subtree
     context.define("a", "foo")
-    expected_err = r"tried to look up 'a.b', but the value of prefix 'a' is not a dictionary but <class 'str'>"
+    expected_err = r"foo.yaml: tried to look up 'a.b', but the value of " \
+        "prefix 'a' is not a dictionary but <class 'str'>"
     with pytest.raises(TransformVariableTypeError, match=expected_err):
         substitute_vars(context, state, "${a.b}")
 
@@ -127,12 +128,16 @@ def test_substitute_vars():
 
 
 def test_substitute_vars_unhappy():
-    state = State("")
+    state = State("foo.yaml")
     ctx = CommonContext()
     ctx.define("dict", {})
 
-    with pytest.raises(TransformDirectiveTypeError):
+    with pytest.raises(TransformDirectiveTypeError) as exc:
         substitute_vars(ctx, state, 1)
+    assert "foo.yaml: otk.define expects a <class 'str'> as its argument but received a `<class 'int'>" in str(
+        exc.value)
 
-    with pytest.raises(TransformDirectiveTypeError):
+    with pytest.raises(TransformDirectiveTypeError) as exc:
         substitute_vars(ctx, state, "a${dict}b")
+    assert "foo.yaml: string 'a${dict}b' resolves to an incorrect type, " \
+        "expected int, float, or str but got dict" in str(exc.value)

--- a/test/test_substitute_vars.py
+++ b/test/test_substitute_vars.py
@@ -60,7 +60,7 @@ def test_sub_var_missing_var_in_context():
         substitute_vars(context, state, "${a.b}")
     # no subtree
     context.define("a", "foo")
-    expected_err = r"tried to look up 'a.b', but prefix 'a' value 'foo' is not a dictionary"
+    expected_err = r"tried to look up 'a.b', but the value of prefix 'a' is not a dictionary but <class 'str'>"
     with pytest.raises(TransformVariableTypeError, match=expected_err):
         substitute_vars(context, state, "${a.b}")
 


### PR DESCRIPTION
otk: add file to variable substitution errors too

This commit adds file context for errors from variable substitution
too.

----

context: tweak erros and add tests for context lookup errors

This commit tweaks the error message for the conext generated
errors and adds tests.

----

otk: include `state` in errors from externals

When an external fails, include the file that called the external
as well by just reusing the new OTKError(state=state) exceptions.

This also adds a test for the external errors and tweaks the
exception a bit based on the test output.
