### PR TITLE
external: Support multiple external paths

### DIFF
--- a/src/otk/external.py
+++ b/src/otk/external.py
@@ -51,7 +51,7 @@ def path_for(exe):
     env = os.getenv("OTK_EXTERNAL_PATH", None)
 
     if env is not None:
-        paths = [env] + paths
+        paths = env.split(":") + paths
 
     for pathname in paths:
         path = pathlib.Path(pathname) / exe

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -23,31 +23,24 @@ def test_exe_from_directive(text, exe):
     assert exe_from_directive(text) == exe
 
 
-def make_fake_external(tmp_path, script):
-    fake_external_path = tmp_path / "test"
+def make_fake_external(tmp_path, name, script):
+    fake_external_path = tmp_path / name
     fake_external_path.write_text(script)
     os.chmod(fake_external_path, 0o755)
     return fake_external_path
 
 
-def test_external_not_found():
-    fake_directive = "otk.external.not_available"
-    fake_tree = {}
-    with pytest.raises(RuntimeError) as exc:
-        otk.external.call(State(""), fake_directive, fake_tree)
-    assert "could not find 'not_available' in any search path" in str(exc.value)
-
-
-def test_integration_happy(tmp_path):
-    os.environ["OTK_EXTERNAL_PATH"] = os.fspath(tmp_path)
-    fake_external_path = make_fake_external(tmp_path, textwrap.dedent("""\
+def run_fake_external_ok(external_path, name):
+    os.makedirs(external_path, exist_ok=True)
+    fake_external_path = make_fake_external(external_path, name, textwrap.dedent("""\
     #!/bin/sh
     cat - > "$0".stdin
     echo '{"tree": {"some": "result"}}'
     """))
 
-    fake_directive = "otk.external.test"
+    fake_directive = f"otk.external.{name}"
     fake_tree = {
+        "name": name,
         "foo": "bar",
         "sub": {
             "baz": "foobar",
@@ -61,9 +54,28 @@ def test_integration_happy(tmp_path):
     assert json.loads(inp) == {"tree": fake_tree}
 
 
+def test_external_not_found():
+    fake_directive = "otk.external.not_available"
+    fake_tree = {}
+    with pytest.raises(RuntimeError) as exc:
+        otk.external.call(State(""), fake_directive, fake_tree)
+    assert "could not find 'not_available' in any search path" in str(exc.value)
+
+
+def test_integration_happy(tmp_path):
+    os.environ["OTK_EXTERNAL_PATH"] = os.fspath(tmp_path)
+    run_fake_external_ok(tmp_path, "test")
+
+
+def test_external_multipath(tmp_path):
+    os.environ["OTK_EXTERNAL_PATH"] = f"{tmp_path}/dir1:{tmp_path}/dir2"
+    run_fake_external_ok(tmp_path / "dir1", "test-1")
+    run_fake_external_ok(tmp_path / "dir2", "test-2")
+
+
 def test_integration_error(tmp_path):
     os.environ["OTK_EXTERNAL_PATH"] = os.fspath(tmp_path)
-    make_fake_external(tmp_path, textwrap.dedent("""\
+    make_fake_external(tmp_path, "test", textwrap.dedent("""\
     #!/bin/sh
     cat - > "$0".stdin
     echo "some output"


### PR DESCRIPTION
Split the OTK_EXTERNAL_PATH on `:` like normal shell path handling in order to enable adding multiple external paths via the environment. Also adds a test for the new behavior.