### PR TITLE
Fix makefile returncode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # needed for venv
 .ONESHELL:
+SHELL := /bin/bash
+.SHELLFLAGS := -ec -o pipefail
 
 .PHONY: help
 help:


### PR DESCRIPTION
if a command fails in "ONESHELL" mode the script continues and
`make` possibly returns `0` instead of a failure