### PR TITLE
otk/ui: introduce some sort of ui

### DIFF
--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -8,7 +8,7 @@ from . import __version__
 from .document import Omnifest
 from . import ui
 
-log = logging.getLogger(__name__)
+log = ui.Terminal(logging.getLogger(__name__))
 
 
 def root() -> int:
@@ -29,7 +29,7 @@ def run(argv: List[str]) -> int:
         print(f"otk {__version__}")
         return 0
 
-    ui.motd()
+    log.motd()
 
     if arguments.command == "compile":
         return compile(arguments)
@@ -52,7 +52,7 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
     else:
         paths = extra + [pathlib.Path(arguments.input)]
 
-    ui.print(f"Compiling {path}")
+    log.info(f"Compiling {path}")
 
     # First pass of resolving the otk file is "shallow", it will not run
     # externals and not resolve anything under otk.target.*
@@ -75,7 +75,7 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
         log.fatal("requested target %r does not exist in INPUT", target_requested)
         return 1
 
-    ui.print(f"Selected the {target_requested} target")
+    log.info(f"Selected the {target_requested} target")
 
     # Now do the real resolve that takes the target into account. It needs
     # a full run so that resolving includes works correctly.
@@ -83,7 +83,7 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
                                for arg in ["duplicate-definition", "all"])
     doc = Omnifest(paths, target=target_requested, warn_duplicated_defs=warn_duplicated_defs)
 
-    ui.print("Done")
+    log.info("Done")
 
     # and then output by writing to the output
     if not dry_run:

--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -52,7 +52,7 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
     else:
         paths = extra + [pathlib.Path(arguments.input)]
 
-    log.info(f"Compiling {path}")
+    log.info(f"Compiling {paths}")
 
     # First pass of resolving the otk file is "shallow", it will not run
     # externals and not resolve anything under otk.target.*

--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -6,6 +6,7 @@ from typing import List
 
 from . import __version__
 from .document import Omnifest
+from . import ui
 
 log = logging.getLogger(__name__)
 
@@ -49,6 +50,8 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
     else:
         paths = extra + [pathlib.Path(arguments.input)]
 
+    ui.print(f"Compiling {path}")
+
     # First pass of resolving the otk file is "shallow", it will not run
     # externals and not resolve anything under otk.target.*
     #
@@ -70,11 +73,15 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
         log.fatal("requested target %r does not exist in INPUT", target_requested)
         return 1
 
+    ui.print(f"Selected the {target_requested} target")
+
     # Now do the real resolve that takes the target into account. It needs
     # a full run so that resolving includes works correctly.
     warn_duplicated_defs = any(arg in getattr(arguments, "warn", [])
                                for arg in ["duplicate-definition", "all"])
     doc = Omnifest(paths, target=target_requested, warn_duplicated_defs=warn_duplicated_defs)
+
+    ui.print("Done")
 
     # and then output by writing to the output
     if not dry_run:

--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -29,6 +29,8 @@ def run(argv: List[str]) -> int:
         print(f"otk {__version__}")
         return 0
 
+    ui.motd()
+
     if arguments.command == "compile":
         return compile(arguments)
     if arguments.command == "validate":

--- a/src/otk/context.py
+++ b/src/otk/context.py
@@ -13,8 +13,9 @@ from .error import (ParseError,
                     TransformVariableIndexRangeError,
                     TransformVariableIndexTypeError,
                     TransformVariableLookupError, TransformVariableTypeError)
+from . import ui
 
-log = logging.getLogger(__name__)
+log = ui.Terminal(logging.getLogger(__name__))
 
 
 def validate_var_name(name):

--- a/src/otk/document.py
+++ b/src/otk/document.py
@@ -1,4 +1,3 @@
-import logging
 import pathlib
 from copy import deepcopy
 from typing import Any
@@ -9,8 +8,6 @@ from .error import NoTargetsError, ParseError, ParseVersionError, OTKError
 from .transform import process_include
 from .traversal import State
 from .target import OSBuildTarget
-
-log = logging.getLogger(__name__)
 
 
 class Omnifest:

--- a/src/otk/external.py
+++ b/src/otk/external.py
@@ -9,9 +9,12 @@ import subprocess
 import os
 from typing import Any
 
+from . import ui
+
 from .constant import PREFIX_EXTERNAL
 from .error import ExternalFailedError
 from .traversal import State
+
 
 log = logging.getLogger(__name__)
 
@@ -26,7 +29,9 @@ def call(state: State, directive: str, tree: Any) -> Any:
         }
     )
 
-    process = subprocess.run([exe], input=data, encoding="utf8", capture_output=True, check=False)
+    with ui.spinner(f"Executing external {os.path.basename(exe)}"):
+        process = subprocess.run([exe], input=data, encoding="utf8", capture_output=True, check=False)
+
     if process.returncode != 0:
         msg = f"call {exe} {directive!r} failed: stdout={process.stdout!r}, stderr={process.stderr!r}"
         log.error(msg)

--- a/src/otk/external.py
+++ b/src/otk/external.py
@@ -16,7 +16,7 @@ from .error import ExternalFailedError
 from .traversal import State
 
 
-log = logging.getLogger(__name__)
+log = ui.Terminal(logging.getLogger(__name__))
 
 
 def call(state: State, directive: str, tree: Any) -> Any:
@@ -29,7 +29,7 @@ def call(state: State, directive: str, tree: Any) -> Any:
         }
     )
 
-    with ui.spinner(f"Executing external {os.path.basename(exe)}"):
+    with log.spinner(f"Executing external {os.path.basename(exe)}"):
         process = subprocess.run([exe], input=data, encoding="utf8", capture_output=True, check=False)
 
     if process.returncode != 0:

--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -223,7 +223,7 @@ def process_include(ctx: Context, state: State, path: pathlib.Path) -> dict:
     if not path.is_absolute():
         cur_path = state.path.parent
         path = (cur_path / pathlib.Path(path)).resolve()
-    log.info("resolving %s", path)
+    log.debug("resolving %s", path)
     try:
         with path.open(encoding="utf8") as fp:
             data = yaml.load(fp, Loader=SafeUniqueKeyLoader)

--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -30,8 +30,9 @@ from .error import (
 )
 from .external import call
 from .traversal import State
+from . import ui
 
-log = logging.getLogger(__name__)
+log = ui.Terminal(logging.getLogger(__name__))
 
 
 # from https://gist.github.com/pypt/94d747fe5180851196eb?permalink_comment_id=4653474#gistcomment-4653474

--- a/src/otk/ui.py
+++ b/src/otk/ui.py
@@ -5,6 +5,8 @@ import threading
 from typing import Optional, Type
 from types import TracebackType
 
+from . import __version__
+
 
 class _Spinner:
     """Render a spinner with an optional prompt to stderr, if stderr isn't a
@@ -58,3 +60,8 @@ def print(text: str) -> None:  # pylint: disable=redefined-builtin
     if sys.stderr.isatty():
         sys.stderr.write(text + "\n")
         sys.stderr.flush()
+
+
+def motd() -> None:
+    # Note, this is the local print function
+    print(f"otk {__version__} -- https://www.osbuild.org/")

--- a/src/otk/ui.py
+++ b/src/otk/ui.py
@@ -6,7 +6,7 @@ from typing import Optional, Type
 from types import TracebackType
 
 
-class Spinner:
+class _Spinner:
     """Render a spinner with an optional prompt to stderr, if stderr isn't a
     tty this only prints the prompt."""
 
@@ -47,3 +47,7 @@ class Spinner:
         self.thread.join()
 
         return True
+
+
+def spinner(prompt: str) -> _Spinner:
+    return _Spinner(prompt)

--- a/src/otk/ui.py
+++ b/src/otk/ui.py
@@ -51,3 +51,10 @@ class _Spinner:
 
 def spinner(prompt: str) -> _Spinner:
     return _Spinner(prompt)
+
+
+def print(text: str) -> None:  # pylint: disable=redefined-builtin
+    """Write a line of text to stderr if it's attached to a tty."""
+    if sys.stderr.isatty():
+        sys.stderr.write(text + "\n")
+        sys.stderr.flush()

--- a/src/otk/ui.py
+++ b/src/otk/ui.py
@@ -1,0 +1,49 @@
+import sys
+import time
+import threading
+
+from typing import Optional, Type
+from types import TracebackType
+
+
+class Spinner:
+    """Render a spinner with an optional prompt to stderr, if stderr isn't a
+    tty this only prints the prompt."""
+
+    active: bool
+    thread: threading.Thread
+
+    def __init__(self, prompt: str) -> None:
+        self.prompt = prompt
+
+    def _loop(self):
+        sys.stderr.write(self.prompt)
+        sys.stderr.flush()
+
+        # No spinner business if we aren't printing to tty's.
+        if sys.stderr.isatty():
+            while self.active:
+                sys.stderr.write(".")
+                sys.stderr.flush()
+                time.sleep(0.1)
+
+        # Only write a newline if the prompt was actually there
+        if self.prompt:
+            sys.stderr.write("\n")
+            sys.stderr.flush()
+
+    def __enter__(self, prompt: str = "") -> None:
+        self.active = True
+        self.thread = threading.Thread(target=self._loop)
+        self.thread.start()
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> bool:
+        self.active = False
+        self.thread.join()
+
+        return True

--- a/src/otk/ui.py
+++ b/src/otk/ui.py
@@ -1,8 +1,9 @@
+import logging
 import sys
 import time
 import threading
 
-from typing import Optional, Type
+from typing import Optional, Type, Any
 from types import TracebackType
 
 from . import __version__
@@ -51,17 +52,18 @@ class _Spinner:
         return True
 
 
-def spinner(prompt: str) -> _Spinner:
-    return _Spinner(prompt)
+class Terminal:
+    def __init__(self, log: logging.Logger):
+        self.log = log
 
+    def motd(self) -> None:
+        # Note, this is the local print function
+        self.log.info(f"otk {__version__} -- https://www.osbuild.org/")
 
-def print(text: str) -> None:  # pylint: disable=redefined-builtin
-    """Write a line of text to stderr if it's attached to a tty."""
-    if sys.stderr.isatty():
-        sys.stderr.write(text + "\n")
-        sys.stderr.flush()
+    def spinner(self, prompt: str) -> _Spinner:
+        return _Spinner(prompt)
 
-
-def motd() -> None:
-    # Note, this is the local print function
-    print(f"otk {__version__} -- https://www.osbuild.org/")
+    # Everything not defined is delegated to our underlying `Logger` instance,
+    # this allows `Terminal` to be used as a `Logger` wrapper.
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.log, name)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -60,7 +60,7 @@ def test_otk_define_empty(tmp_path, caplog):
 
 
 def test_verbose_logs_processed_files(tmp_path, caplog):
-    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.DEBUG)
 
     test_otk = tmp_path / "foo.yaml"
     test_otk.write_text(TEST_OTK)


### PR DESCRIPTION
We've spoken about being nice to users before; @schuellerf is working on adding a lot of annotated data to our data structures, I've spent a morning on writing a tiny bit of UI.

The idea is:
- output goes to stdout
- ui and logging goes to stderr
- when stderr is not a tty (e.g. redirected away) we don't show a ui
- the ui is everything that isn't logging, logging is still there and will intersperse with the ui

Based on #277.