### PR TITLE
container: unsplit build containers

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,30 +1,21 @@
-FROM registry.fedoraproject.org/fedora:latest AS build_python
+FROM registry.fedoraproject.org/fedora:latest AS build
 
 RUN dnf install -y \
         python3-pip \
         python3-pyyaml \
+        golang \
         && dnf clean all
 
 WORKDIR /src
 
+COPY Makefile .
 COPY pyproject.toml /src/
 COPY src /src/src
 
 RUN pip install --no-dependencies .
 
-# ----
-FROM registry.fedoraproject.org/fedora:latest AS build_go
-
-WORKDIR /src
-
-RUN dnf install -y \
-        golang
-
-COPY Makefile .
-
 RUN make external
 
-# ----
 # no osbuild-depsolve-dnf here:
 # FROM registry.access.redhat.com/ubi9/ubi-minimal
 FROM registry.fedoraproject.org/fedora:latest
@@ -34,11 +25,11 @@ RUN dnf install -y \
     osbuild-depsolve-dnf \
     && dnf clean all
 
-COPY --from=build_python /usr/local/bin/otk /usr/local/bin/
-COPY --from=build_python /usr/local/bin/osbuild* /usr/libexec/otk/external/
-COPY --from=build_python /usr/local/lib/ /usr/local/lib/
+COPY --from=build /usr/local/bin/otk /usr/local/bin/
+COPY --from=build /usr/local/bin/osbuild* /usr/libexec/otk/external/
+COPY --from=build /usr/local/lib/ /usr/local/lib/
 
-COPY --from=build_go /src/external/* /usr/local/libexec/otk/external/
+COPY --from=build /src/external/* /usr/local/libexec/otk/external/
 
 WORKDIR /app
 


### PR DESCRIPTION
After the introduction of `pyexternals` as a dependency to `external` in the Makefile targets the Go container also wants to build Python externals.

Let's instead turn everything into a single build container.