### PR TITLE
github/workflows/test: add test to build the container

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,15 @@ jobs:
           pip install .[dev]
       - name: Run unit tests
         run: PYTHONPATH=./src make test
+
+  test-container-build:
+    name: "Assure that Containerfile can be built"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Clone Repository"
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt install -y podman
+      - name: Check if building the container works
+        run: make container

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,7 @@ SRC_CONTAINER_FILES=$(shell find src 2>/dev/null|| echo "src") \
 container_built.info: Containerfile $(SRC_CONTAINER_FILES) # internal rule to avoid rebuilding if not necessary
 	podman build --build-arg CONTAINERS_STORAGE_THIN_TAGS="$(CONTAINERS_STORAGE_THIN_TAGS)" \
 	             --build-arg IMAGES_REF="$(IMAGES_REF)" \
-	             --tag otk \
-	             --pull=newer . &&
+	             --tag otk . &&
 	echo "Container last built on" > $@ &&
 	date >> $@
 


### PR DESCRIPTION
Avoid regressions where building the container breaks
Followup of #273 
let's see how much this slows down the tests