### PR TITLE
otk/external: `osbuild-make-ostree-source`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ EXTERNAL_GO_EXECUTABLES:= osbuild-gen-partition-table \
                           osbuild-resolve-containers \
                           osbuild-resolve-ostree-commit \
                           osbuild-make-partition-mounts-devices \
-                          osbuild-make-partition-stages
+                          osbuild-make-partition-stages \
+                          osbuild-make-ostree-source
 
 EXTERNAL_GO_EXECUTABLES_FULLPATH:=$(addprefix $(EXTERNAL_DIR)/, $(EXTERNAL_GO_EXECUTABLES))
 


### PR DESCRIPTION
Include the recently merged [1] external to create ostree source references.

[1]: https://github.com/osbuild/images/pull/960/files