### PR TITLE
plumbing: package python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 [project]
 name = "otk"
-version = "2024.0.0"
 requires-python = ">= 3.9"
-
 dependencies = [
     "pyyaml >= 6.0",
 ]
+dynamic = ["version"]
 
 [project.scripts]
 otk = "otk.command:root"
@@ -28,7 +27,7 @@ dev = [
 
 
 [build-system]
-requires = ["setuptools >= 61.0"]
+requires = ["setuptools >= 61.0", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.autopep8]

--- a/src/otk/__init__.py
+++ b/src/otk/__init__.py
@@ -1,0 +1,6 @@
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("otk")
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -4,6 +4,7 @@ import pathlib
 import sys
 from typing import List
 
+from . import __version__
 from .document import Omnifest
 
 log = logging.getLogger(__name__)
@@ -23,12 +24,17 @@ def run(argv: List[str]) -> int:
         handlers=[logging.StreamHandler()],
     )
 
+    if arguments.version:
+        print(f"otk {__version__}")
+        return 0
+
     if arguments.command == "compile":
         return compile(arguments)
     if arguments.command == "validate":
         return validate(arguments)
 
-    raise RuntimeError("Unknown subcommand")
+    parser.print_help()
+    return 2
 
 
 def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
@@ -99,6 +105,12 @@ def parser_create() -> argparse.ArgumentParser:
         help="Sets verbosity. Can be passed multiple times to be more verbose.",
     )
     parser.add_argument(
+        "-V",
+        "--version",
+        action="store_true",
+        help="Print version and exit."
+    )
+    parser.add_argument(
         "-W",
         "--warn",
         action='append',
@@ -107,7 +119,7 @@ def parser_create() -> argparse.ArgumentParser:
     )
 
     # get a subparser action
-    subparsers = parser.add_subparsers(dest="command", required=True, metavar="command")
+    subparsers = parser.add_subparsers(dest="command", required=False, metavar="command")
 
     parser_compile = subparsers.add_parser("compile", help="Compile an omnifest.")
     parser_compile.add_argument(

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -3,17 +3,6 @@ import pytest
 from otk.command import parser_create, run
 
 
-def test_parse_no_command(capsys):
-    p = parser_create()
-    with pytest.raises(SystemExit) as sys_exit:
-        p.parse_args([])
-    assert sys_exit.type == SystemExit
-    assert sys_exit.value.code == 2
-
-    captured_stderr = capsys.readouterr().err
-    assert "the following arguments are required: command" in captured_stderr
-
-
 @pytest.mark.parametrize(
     "command,results",
     [


### PR DESCRIPTION
Adds the dynamic versioning scheme supported by our build system; also adds a new `-V/--version` to the root `otk` command.