### PR TITLE
readme: deduplicate projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@ This is the "Omnifest Toolkit", also known as `otk`. A YAML transpiler to
 take omnifest inputs and translate them into [osbuild](https://osbuild.org)
 manifests.
 
-## Project
-
-* **Website**: https://www.osbuild.org
-* **Bug Tracker**: https://github.com/osbuild/otk/issues
-* **Discussions**: https://github.com/orgs/osbuild/discussions
-
 ## Documentation
 
 You can find `otk`'s documentation in the [/doc](./doc) subdirectory. This README contains a small summary of directly useful information.
@@ -84,6 +78,7 @@ and call `pytest`
 
  * **Website**: https://www.osbuild.org
  * **Bug Tracker**: https://github.com/osbuild/otk/issues
+ * **Discussions**: https://github.com/orgs/osbuild/discussions
  * **Matrix**: #image-builder on [fedoraproject.org](https://matrix.to/#/#image-builder:fedoraproject.org)
  * **Mailing List**: image-builder@redhat.com
  * **Changelog**: https://github.com/osbuild/otk/releases


### PR DESCRIPTION
I missed this in #276 review and we accidentally have double Project headings now. Let's merge them, cc @lzap.