### PR TITLE
otk/utils: introduce Annotated* objects

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,4 @@ repos:
     hooks:
       - id: pylint
         additional_dependencies: ["PyYAML", "types-PyYAML", "pytest"]
+        args: ["--init-hook", "import sys; sys.path.insert(0, './src')"]

--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -8,7 +8,7 @@ matrix:
       camel-case: true
       mode: markdown
     sources:
-      - "**/*.md|!venv/**"
+      - "**/*.md|!venv*/**"
     dictionary:
       wordlists:
         - .spellcheck-en-custom.txt

--- a/src/otk/annotation.py
+++ b/src/otk/annotation.py
@@ -1,0 +1,253 @@
+import copy
+import os
+import pathlib
+from typing import TypeVar, Generic, Any
+
+
+class AnnotatedBase:
+    """ Implements a base class for annotated objects.
+    The annotations are basically a dict[str, any] of properties to attach to the class.
+    """
+
+    # base directory to calculate relative paths (easier to read)
+    _basedir = os.path.curdir
+
+    def __init__(self) -> None:
+        self._otk_annotations: dict[str, Any] = {}
+        if isinstance(self, list):
+            for idx, value in enumerate(self):
+                self[idx] = self.deep_convert(value)
+        elif isinstance(self, dict):
+            for key, value in self.items():
+                self[key] = self.deep_convert(value)
+
+    def get_annotation(self, key: str, default: Any | None = None) -> Any | None:
+        if key in self._otk_annotations:
+            return self._otk_annotations[key]
+        return default
+
+    def set_annotation(self, key: str, val: Any) -> Any:
+        self._otk_annotations[key] = val
+
+    def get_annotations(self) -> dict[str, Any]:
+        """Returns all annotations"""
+        return self._otk_annotations
+
+    def set_annotations(self, annotations: dict[str, Any]) -> None:
+        """ set all annotations """
+        self._otk_annotations = annotations
+
+    @classmethod
+    def deep_convert(cls, data: Any) -> Any:
+        """Recursively convert nested dicts and lists into AnnotatedDict and HiddenAttrList."""
+        ret = data
+        if isinstance(data, AnnotatedBase):
+            return ret
+        if isinstance(data, dict):
+            ret = AnnotatedDict({key: cls.deep_convert(value) for key, value in data.items()})
+        elif isinstance(data, list):
+            ret = AnnotatedList([cls.deep_convert(item) for item in data])
+        elif isinstance(data, str):
+            ret = AnnotatedStr(data)
+        elif isinstance(data, bool):
+            ret = AnnotatedBool(data)
+        elif isinstance(data, int):
+            ret = AnnotatedInt(data)
+        elif isinstance(data, float):
+            ret = AnnotatedFloat(data)
+
+        # note: "complex" is not implemented as it's not used in YAML
+
+        return ret
+
+    @classmethod
+    def deep_dump(cls, data: Any) -> Any:
+        """ Converting to builtin types is usually not necessary.
+            This special conversion is mainly for json.dumps(). json library needs "bool" to pass the
+            condition "<var> is True" which does not apply to AnnotatedBool,
+            so we'll just convert all
+        """
+        ret = data
+        if isinstance(data, AnnotatedDict):
+            ret = {key: cls.deep_dump(value) for key, value in data.items()}
+        elif isinstance(data, AnnotatedList):
+            ret = [cls.deep_dump(item) for item in data]
+        elif isinstance(data, AnnotatedBool):
+            ret = data.value
+        elif isinstance(data, AnnotatedFloat):
+            ret = float(data)
+        elif isinstance(data, AnnotatedInt):
+            ret = int(data)
+        elif isinstance(data, AnnotatedStr):
+            ret = str(data)
+
+        return ret
+
+    def add_source_attributes(self, key_data, prefix=""):
+        line_number = key_data.start_mark.line + 1
+        line_number_end = key_data.end_mark.line + 1
+        column = key_data.start_mark.column + 1
+        column_end = key_data.end_mark.column + 1
+        filename = os.path.relpath(key_data.start_mark.name, self._basedir)
+        self.set_annotation(f"{prefix}src", f"{filename}:{line_number}")
+        self.set_annotation(f"{prefix}filename", filename)
+        self.set_annotation(f"{prefix}line_number", line_number)
+        self.set_annotation(f"{prefix}line_number_end", line_number_end)
+        self.set_annotation(f"{prefix}column", column)
+        self.set_annotation(f"{prefix}column_end", column_end)
+
+    def __add__(self, o):
+        ret = self.deep_convert(super().__add__(o))  # pylint: disable=E1101
+        ret.set_annotations(self.squash_annotations([self, o]))
+        return ret
+
+    def __iadd__(self, o):
+        return self.__add__(o)
+
+    def __radd__(self, o):
+        return self.deep_convert(o).__add__(self)
+
+    def __deepcopy__(self, memo):
+        if isinstance(self, AnnotatedDict):
+            cls = self.__class__
+            result = cls.__new__(cls)
+            memo[id(self)] = result
+
+            for k, v in self.items():
+                result[k] = copy.deepcopy(v, memo)
+
+        elif isinstance(self, AnnotatedList):
+            cls = self.__class__
+            result = cls.__new__(cls)
+            memo[id(self)] = result
+
+            for v in self:
+                result.append(copy.deepcopy(v, memo))
+        elif isinstance(self, (AnnotatedStr, AnnotatedInt, AnnotatedFloat, AnnotatedBool, AnnotatedPath)):
+            result = copy.copy(self)
+        else:
+            result = None  # just for the linter - that should never happen
+
+        result.set_annotations(self.get_annotations().copy())
+
+        return result
+
+    @classmethod
+    def squash_annotations(cls, annotation_list: list) -> dict:
+        """ just aggregates all annotations in the list.
+
+        new annotation keys get appended to the resulting dict
+
+        duplicate annotations will get converted to string
+        (if you need an exception for a key please implement here)
+
+        for "src" there is an exception
+        this is expected to be in the form "filename:line_number"
+        and will be sanely unified
+        """
+        ret: dict[str, Any] = {}
+        files: dict[str, str] = {}
+        for item in annotation_list:
+            if not isinstance(item, AnnotatedBase):
+                continue
+            annotations = item.get_annotations()
+            for k in annotations.keys():
+                if k == "src":
+                    src = annotations[k].split(":")
+                    if src[0] in files:
+                        files[src[0]] += ", " + src[1]
+                    else:
+                        files[src[0]] = src[1]
+                else:
+                    if k in ret:
+                        ret[k] = str(ret[k]) + str(annotations[k])
+                    else:
+                        ret[k] = annotations[k]
+
+        ret["src"] = "\n".join([f"* {k}:{v}" for k, v in files.items()])
+
+        return ret
+
+
+AnnotatedDictKeyT = TypeVar('AnnotatedDictKeyT')
+AnnotatedDictVarT = TypeVar('AnnotatedDictVarT')
+
+AnnotatedListT = TypeVar('AnnotatedListT')
+
+
+class AnnotatedList(Generic[AnnotatedListT], AnnotatedBase, list):
+    def __init__(self, seq: list[Any] | None = None) -> None:
+        if seq is None:
+            seq = []
+        list.__init__(self, seq)
+        AnnotatedBase.__init__(self)
+
+
+class AnnotatedDict(Generic[AnnotatedDictKeyT, AnnotatedDictVarT], AnnotatedBase, dict):
+    def __init__(self, seq: dict[Any, Any] | None = None, **kwargs: dict[Any, Any]) -> None:
+        if seq is None:
+            seq = {}
+        dict.__init__(self, seq, **kwargs)
+        AnnotatedBase.__init__(self)
+
+
+class AnnotatedPath(AnnotatedBase, pathlib.Path):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pathlib.Path.__init__(self, *args, **kwargs)
+        AnnotatedBase.__init__(self)
+
+    def fspath_with_include(self) -> str:
+        src = None
+        filename = os.path.relpath(os.fspath(self), self._basedir)
+        try:
+            src = self.get_annotation("src")
+        except KeyError:
+            pass
+        if src is not None:
+            return f"{filename} (included from {src})"
+        return filename
+
+
+class AnnotatedStr(AnnotatedBase, str):
+    def __init__(self, *args: str) -> None:  # pylint: disable=W0613
+        str.__init__(self)
+        AnnotatedBase.__init__(self)
+
+
+class AnnotatedInt(AnnotatedBase, int):
+    def __init__(self, *args: int) -> None:  # pylint: disable=W0613
+        int.__init__(self)
+        AnnotatedBase.__init__(self)
+
+    def __str__(self):  # pylint: disable=E0307
+        ret = AnnotatedStr(int.__str__(self))
+        ret.set_annotations(self.get_annotations())
+        return ret
+
+
+class AnnotatedFloat(AnnotatedBase, float):
+    def __init__(self, *args: float) -> None:  # pylint: disable=W0613
+        float.__init__(self)
+        AnnotatedBase.__init__(self)
+
+    def __str__(self):  # pylint: disable=E0307
+        ret = AnnotatedStr(float.__str__(self))
+        ret.set_annotations(self.get_annotations())
+        return ret
+
+
+class AnnotatedBool(AnnotatedBase):
+    """ only bool can't be "subclassed" """
+
+    def __init__(self, value: Any) -> None:
+        self.value: bool = bool(value)
+        AnnotatedBase.__init__(self)
+
+    def __str__(self):  # pylint: disable=E0307
+        ret = AnnotatedStr(bool.__str__(self))
+        ret.set_annotations(self.get_annotations())
+        return ret
+
+    @property  # type: ignore[misc]
+    def __class__(self):
+        return bool

--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-import pathlib
 import sys
 from typing import List
 
@@ -39,9 +38,9 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
         dst = sys.stdout if arguments.output is None else open(arguments.output, "w", encoding="utf-8")
 
     if arguments.input is None:
-        path = pathlib.Path(f"/proc/self/fd/{sys.stdin.fileno()}")
+        path = AnnotatedPath(f"/proc/self/fd/{sys.stdin.fileno()}")
     else:
-        path = pathlib.Path(arguments.input)
+        path = AnnotatedPath(arguments.input)
 
     # First pass of resolving the otk file is "shallow", it will not run
     # externals and not resolve anything under otk.target.*

--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -5,6 +5,7 @@ import sys
 from typing import List
 
 from . import __version__
+from .annotation import AnnotatedPath
 from .document import Omnifest
 
 log = logging.getLogger(__name__)
@@ -24,17 +25,12 @@ def run(argv: List[str]) -> int:
         handlers=[logging.StreamHandler()],
     )
 
-    if arguments.version:
-        print(f"otk {__version__}")
-        return 0
-
     if arguments.command == "compile":
         return compile(arguments)
     if arguments.command == "validate":
         return validate(arguments)
 
-    parser.print_help()
-    return 2
+    raise RuntimeError("Unknown subcommand")
 
 
 def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
@@ -107,12 +103,6 @@ def parser_create() -> argparse.ArgumentParser:
         help="Sets verbosity. Can be passed multiple times to be more verbose.",
     )
     parser.add_argument(
-        "-V",
-        "--version",
-        action="store_true",
-        help="Print version and exit."
-    )
-    parser.add_argument(
         "-W",
         "--warn",
         action='append',
@@ -121,7 +111,7 @@ def parser_create() -> argparse.ArgumentParser:
     )
 
     # get a subparser action
-    subparsers = parser.add_subparsers(dest="command", required=False, metavar="command")
+    subparsers = parser.add_subparsers(dest="command", required=True, metavar="command")
 
     parser_compile = subparsers.add_parser("compile", help="Compile an omnifest.")
     parser_compile.add_argument(

--- a/src/otk/error.py
+++ b/src/otk/error.py
@@ -1,6 +1,9 @@
 """Error types used by `otk`."""
 
 from typing import Optional, TYPE_CHECKING
+
+from .annotation import AnnotatedBase
+
 if TYPE_CHECKING:
     # required to avoid circular import errors
     from .traversal import State
@@ -9,8 +12,10 @@ if TYPE_CHECKING:
 class OTKError(Exception):
     """Any application raised by `otk` inherits from this."""
 
-    def __init__(self, msg: str, state: Optional['State'] = None) -> None:
-        if state:
+    def __init__(self, msg: str, state: Optional['State'] = None, annotated: Optional['AnnotatedBase'] = None) -> None:
+        if annotated and isinstance(annotated, AnnotatedBase) and annotated.get_annotation("src"):
+            super().__init__(f"{annotated.get_annotation('src')} - {msg}")
+        elif state:
             super().__init__(f"{state.path}: {msg}")
         else:
             super().__init__(msg)

--- a/src/otk/target.py
+++ b/src/otk/target.py
@@ -3,6 +3,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any
 
+from .annotation import AnnotatedBase
 from .context import CommonContext, OSBuildContext
 from .constant import PREFIX_TARGET
 from .error import ParseError
@@ -36,7 +37,7 @@ class OSBuildTarget(Target):
                 "The key 'version' is added by otk internally.")
 
     def as_string(self, context: OSBuildContext, tree: Any, pretty: bool = True) -> str:
-        osbuild_tree = tree[PREFIX_TARGET + context.target_requested]
+        osbuild_tree = AnnotatedBase.deep_dump(tree[PREFIX_TARGET + context.target_requested])
         osbuild_tree["version"] = "2"
 
         return json.dumps(osbuild_tree, indent=2 if pretty else None)

--- a/src/otk/transform.py
+++ b/src/otk/transform.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import itertools
 import logging
 import os.path
-import pathlib
 import re
 from typing import Any
 
@@ -30,6 +29,8 @@ from .error import (
 )
 from .external import call
 from .traversal import State
+from .annotation import AnnotatedDict, AnnotatedList, AnnotatedPath, AnnotatedBase, AnnotatedStr, AnnotatedInt, \
+    AnnotatedFloat
 
 log = logging.getLogger(__name__)
 
@@ -53,15 +54,67 @@ class SafeUniqueKeyLoader(yaml.SafeLoader):
         return super().construct_mapping(node, deep)
 
 
+def _find_data(node_list, key):
+    """ Helper function to find the yaml ScalarNode containing
+    our context information for HiddenAttrList and AnnotatedDict
+    """
+    for node in node_list:
+        if node[0].value == key:
+            return node[0]
+    raise KeyError(key)
+
+
+def annotated_dict_constructor(loader, node):
+    data = loader.construct_mapping(node, deep=True)
+    annotated_data_dict = AnnotatedBase.deep_convert(data)
+
+    # content_ really are the lines of the content, not the tag.
+    annotated_data_dict.add_source_attributes(node, prefix="content_")
+
+    # src will be overwritten if this gets a child node
+    annotated_data_dict.add_source_attributes(node)
+    for key, _ in annotated_data_dict.items():
+        key_data = _find_data(node.value, key)
+        if annotated_data_dict[key]:
+            annotated_data_dict[key].add_source_attributes(key_data)
+    return annotated_data_dict
+
+
+def annotated_list_constructor(loader, node):
+    data = loader.construct_sequence(node, deep=True)
+    annotated_data_list = AnnotatedBase.deep_convert(data)
+    # content_ really are the lines of the content, not the tag.
+    annotated_data_list.add_source_attributes(node, prefix="content_")
+
+    # src will be overwritten if this gets a child node
+    annotated_data_list.add_source_attributes(node)
+    for idx, _ in enumerate(node.value):
+        key_data = node.value[idx]
+        if annotated_data_list[idx]:
+            annotated_data_list[idx].add_source_attributes(key_data)
+    return annotated_data_list
+
+
+def annotated_scalar_constructor(loader, node):
+    data = loader.construct_scalar(node)
+    annotated_data = AnnotatedBase.deep_convert(data)
+    # content_ really are the lines of the content, not the tag.
+    annotated_data.add_source_attributes(node, prefix="content_")
+
+    # src will be overwritten if this gets a child node
+    annotated_data.add_source_attributes(node)
+    return annotated_data
+
+
 def resolve(ctx: Context, state: State, data: Any) -> Any:
     """Resolves a value of any supported type into a new value. Each type has
     its own specific handler to replace the data value."""
 
-    if isinstance(data, dict):
+    if isinstance(data, AnnotatedDict):
         return resolve_dict(ctx, state, data)
-    if isinstance(data, list):
+    if isinstance(data, AnnotatedList):
         return resolve_list(ctx, state, data)
-    if isinstance(data, str):
+    if isinstance(data, AnnotatedStr):
         return resolve_str(ctx, state, data)
     if isinstance(data, (int, float, bool, type(None))):
         return data
@@ -71,7 +124,7 @@ def resolve(ctx: Context, state: State, data: Any) -> Any:
 
 # XXX: look into this
 # pylint: disable=too-many-branches
-def resolve_dict(ctx: Context, state: State, tree: dict[str, Any]) -> Any:
+def resolve_dict(ctx: Context, state: State, tree: AnnotatedDict[str, Any]) -> Any:
     """
     Dictionaries are iterated through and both the keys and values are processed.
     Keys define how a value is interpreted:
@@ -107,15 +160,20 @@ def resolve_dict(ctx: Context, state: State, tree: dict[str, Any]) -> Any:
                 target = resolve(ctx, state, val)
                 if not isinstance(target, dict):
                     raise ParseError(
-                        f"First level below a 'target' should be a dictionary (not a {type(target).__name__})", state)
+                        f"First level below a 'target' should be a dictionary "
+                        f"(not a {type(target).__name__})", state, target)
 
                 tree.update(target)
                 continue
 
             if key.startswith(PREFIX_INCLUDE):
+                include_src = val.get_annotations()
                 del tree[key]  # replace "otk.include" with resolved included data
 
-                included = process_include(ctx, state, pathlib.Path(val))
+                path = AnnotatedPath(val)
+                path.set_annotations(include_src)
+                included = process_include(ctx, state, path)
+
                 if not isinstance(included, dict):
                     if len(tree) > 0:
                         raise ParseValueError(
@@ -128,7 +186,7 @@ def resolve_dict(ctx: Context, state: State, tree: dict[str, Any]) -> Any:
             # Other directives do *not* allow siblings
             if len(tree) > 1:
                 keys = list(tree.keys())
-                raise ParseError(f"directive {key} should not have siblings: {keys!r}", state)
+                raise ParseError(f"directive {key} should not have siblings: {keys!r}", state, tree)
 
             if key.startswith(PREFIX_OP):
                 # return is fine, no siblings allowed
@@ -145,13 +203,17 @@ def resolve_dict(ctx: Context, state: State, tree: dict[str, Any]) -> Any:
     return tree
 
 
-def resolve_list(ctx: Context, state: State, tree: list[Any]) -> list[Any]:
+def resolve_list(ctx: Context, state: State, tree: AnnotatedList[Any]) -> AnnotatedList[Any]:
     """Resolving a list means applying the resolve function to each element in
     the list."""
 
     log.debug("resolving list %r", tree)
+    new_state = AnnotatedList[Any]([resolve(ctx, state, val) for val in tree])
 
-    return [resolve(ctx, state, val) for val in tree]
+    # list comprehension need a separate copy of all annotations
+    new_state.set_annotations(tree.get_annotations())
+
+    return new_state
 
 
 def resolve_str(ctx: Context, state: State, tree: str) -> Any:
@@ -179,7 +241,7 @@ def process_defines(ctx: Context, state: State, tree: Any) -> None:
         log.warning("empty otk.define in %s", state.path)
         return
     if tree == {}:
-        ctx.define(state.define_subkey(), {})
+        ctx.define(state.define_subkey(), AnnotatedDict())
         return
 
     # Iterate over a copy of the tree so that we can modify it in-place.
@@ -215,28 +277,67 @@ def process_defines(ctx: Context, state: State, tree: Any) -> None:
             ctx.define(state.define_subkey(key), value)
 
 
-def process_include(ctx: Context, state: State, path: pathlib.Path) -> dict:
+overridden_constructors = [
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    yaml.resolver.BaseResolver.DEFAULT_SEQUENCE_TAG,
+    yaml.resolver.BaseResolver.DEFAULT_SCALAR_TAG
+]
+
+
+def save_yaml_constructors():
+    """ Mainly for testcases, save our constructors not to
+        pollute other yaml imports
+    """
+    return {k: yaml.SafeLoader.yaml_constructors[k] for k in overridden_constructors}
+
+
+def restore_yaml_constructors(data):
+    """ Mainly for testcases, remove our constructors not to
+        pollute other yaml imports
+    """
+    for k, v in data.items():
+        yaml.SafeLoader.yaml_constructors[k] = v
+
+
+def process_include(ctx: Context, state: State, path: AnnotatedPath) -> AnnotatedDict:
     """
     Load a yaml file and send it to resolve() for processing.
     """
     # resolve 'path' relative to 'state.path'
     if not path.is_absolute():
         cur_path = state.path.parent
-        path = (cur_path / pathlib.Path(path)).resolve()
+        try:
+            origin = path.get_annotations()
+        except KeyError:
+            origin = None
+        path = AnnotatedPath((cur_path / AnnotatedPath(path)).resolve())
+        if origin:
+            path.set_annotations(origin)
     log.info("resolving %s", path)
+
+    # callbacks to store information about the source of all data in the yaml files
+    saved_constructors = save_yaml_constructors()
+    yaml.SafeLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, annotated_dict_constructor)
+    yaml.SafeLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_SEQUENCE_TAG, annotated_list_constructor)
+    yaml.SafeLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_SCALAR_TAG, annotated_scalar_constructor)
+
     try:
         with path.open(encoding="utf8") as fp:
             data = yaml.load(fp, Loader=SafeUniqueKeyLoader)
     except FileNotFoundError as fnfe:
         cleaned_path = os.fspath(path).removeprefix(
             os.path.commonprefix([path, state.path]))
+        restore_yaml_constructors(saved_constructors)
         raise IncludeNotFoundError(f"file {cleaned_path} was not found", state) from fnfe
     except ParseDuplicatedYamlKeyError as err:
+        restore_yaml_constructors(saved_constructors)
         raise ParseDuplicatedYamlKeyError(f"{err}", state.copy(path=path)) from err
+
+    restore_yaml_constructors(saved_constructors)
 
     if data is not None:
         return resolve(ctx, state.copy(path=path), data)
-    return {}
+    return AnnotatedDict()
 
 
 def op(ctx: Context, state: State, tree: Any, key: str) -> Any:
@@ -247,9 +348,9 @@ def op(ctx: Context, state: State, tree: Any, key: str) -> Any:
     raise TransformDirectiveUnknownError(f"nonexistent op {key!r}", state)
 
 
-@tree.must_be(dict)
+@tree.must_be(AnnotatedDict)
 @tree.must_pass(tree.has_keys(["values"]))
-def op_join(ctx: Context, state: State, tree: dict[str, Any]) -> Any:
+def op_join(ctx: Context, state: State, tree: AnnotatedDict[str, Any]) -> Any:
     """Join a map/seq."""
 
     values = tree["values"]
@@ -262,9 +363,12 @@ def op_join(ctx: Context, state: State, tree: dict[str, Any]) -> Any:
             values[i] = substitute_vars(ctx, state, val)
 
     if all(isinstance(sl, list) for sl in values):
-        return list(itertools.chain.from_iterable(values))
+        ret: AnnotatedList = AnnotatedList(list(itertools.chain.from_iterable(values)))
+        ret.set_annotations(ret.squash_annotations(values))
+        return ret
+
     if all(isinstance(sl, dict) for sl in values):
-        result = {}
+        result: AnnotatedDict = AnnotatedDict()
         # XXX: this will probably need to become recursive *or* we
         # need something like a "merge_strategy" in "otk.op.join"
         for value in values:
@@ -274,7 +378,7 @@ def op_join(ctx: Context, state: State, tree: dict[str, Any]) -> Any:
 
 
 @tree.must_be(str)
-def substitute_vars(ctx: Context, state: State, data: str) -> Any:
+def substitute_vars(ctx: Context, state: State, data: AnnotatedStr) -> Any:
     """Substitute variables in the `data` string.
 
     If `data` consists only of a single `${name}` value then we return the
@@ -306,17 +410,23 @@ def substitute_vars(ctx: Context, state: State, data: str) -> Any:
 
             value = ctx.variable(name)
             # We know how to turn ints and floats into str's
-            if isinstance(value, (int, float)):
-                value = str(value)
+            if isinstance(value, (AnnotatedInt, AnnotatedFloat)):
+                # TBD find out why the __str__() implementation of AnnotatedInt doesn't work
+                # so "origin" is not necessary
+                origin = value.get_annotations()
+                value = AnnotatedStr(str(value))
+                value.set_annotations(origin)
 
             # Any other type we do not
-            if not isinstance(value, str):
+            if not isinstance(value, AnnotatedStr):
                 raise TransformDirectiveTypeError(
-                    f"string {data!r} resolves to an incorrect type, "
-                    f"expected int, float, or str but got {type(value).__name__}", state)
+                    f"expected int, float, or str. Can not use {type(value).__name__} "
+                    f"to resolve string {data!r} ({data.get_annotation('src')})", state, value)
 
             # Replace all occurences of this name in the str
-            data = re.sub(bracket % re.escape(name), value, data)
+            data_origin = f"variable from {value.get_annotation('src')} applied to {data.get_annotation('src')}"
+            data = AnnotatedStr(re.sub(bracket % re.escape(name), value, data))
+            data.set_annotation("src", data_origin)
             log.debug("substituting %r as substring to %r", name, data)
 
     return data

--- a/test/data/error/01-circular.err
+++ b/test/data/error/01-circular.err
@@ -1,1 +1,6 @@
-circular include from
+circular include detected:
+test/data/error/01-circular.yaml ->
+test/data/error/01-circular/a.yaml (included from test/data/error/01-circular.yaml:3) ->
+test/data/error/01-circular/b.yaml (included from test/data/error/01-circular/a.yaml:1) ->
+test/data/error/01-circular/subdir/c.yaml (included from test/data/error/01-circular/b.yaml:1) ->
+test/data/error/01-circular/a.yaml (included from test/data/error/01-circular/subdir/c.yaml:1)

--- a/test/data/error/03-lonely-keys.err
+++ b/test/data/error/03-lonely-keys.err
@@ -1,1 +1,2 @@
-otk file contains top-level keys ['targetless'] without a target
+otk file contains top-level keys without a target:
+ * "targetless" in test/data/error/03-lonely-keys.yaml:6

--- a/test/data/error/03-target-should-not-be-list.err
+++ b/test/data/error/03-target-should-not-be-list.err
@@ -1,1 +1,1 @@
-03-target-should-not-be-list.yaml: First level below a 'target' should be a dictionary (not a list)
+test/data/error/03-target-should-not-be-list.yaml:3 - First level below a 'target' should be a dictionary (not a AnnotatedList)

--- a/test/data/error/04-target-should-not-be-string.err
+++ b/test/data/error/04-target-should-not-be-string.err
@@ -1,1 +1,1 @@
-First level below a 'target' should be a dictionary (not a str)
+First level below a 'target' should be a dictionary (not a AnnotatedStr)

--- a/test/data/error/06-no-two-externals.err
+++ b/test/data/error/06-no-two-externals.err
@@ -1,1 +1,1 @@
-06-no-two-externals.yaml: directive otk.external.mirror should not have siblings: ['otk.external.mirror', 'otk.external.other']
+test/data/error/06-no-two-externals.yaml:4 - directive otk.external.mirror should not have siblings: ['otk.external.mirror', 'otk.external.other']

--- a/test/data/error/07-no-two-op-joins.err
+++ b/test/data/error/07-no-two-op-joins.err
@@ -1,1 +1,1 @@
-07-no-two-op-joins.yaml: directive otk.op.join should not have siblings: ['otk.op.join', 'otk.op.noop']
+test/data/error/07-no-two-op-joins.yaml:3 - directive otk.op.join should not have siblings: ['otk.op.join', 'otk.op.noop']

--- a/test/data/error/12-two-lonely-keys.err
+++ b/test/data/error/12-two-lonely-keys.err
@@ -1,0 +1,3 @@
+otk file contains top-level keys without a target:
+ * "targetless" in test/data/error/12-two-lonely-keys.yaml:6
+ * "targetless2" in test/data/error/12-two-lonely-keys.yaml:9

--- a/test/data/error/12-two-lonely-keys.yaml
+++ b/test/data/error/12-two-lonely-keys.yaml
@@ -1,0 +1,10 @@
+otk.version: 1
+
+otk.target.osbuild.foo:
+  a: 1
+
+targetless:
+  key: value
+
+targetless2:
+  key2: value2

--- a/test/test_against_images_refs.py
+++ b/test/test_against_images_refs.py
@@ -9,6 +9,8 @@ import pytest
 from otk.command import run
 
 TEST_DATA_PATH = pathlib.Path(__file__).parent / "data"
+TEST_EXAMPLE_PATH = pathlib.Path(__file__).parent.parent / "example"
+OTK_EXTERNAL_PATH = pathlib.Path(__file__).parent.parent / "external"
 
 
 class _TestCase:
@@ -20,8 +22,8 @@ class _TestCase:
 
     def as_example_yaml(self):
         # keep in sync with our "example" folder
-        p = pathlib.Path(__file__).parent.parent
-        return p / f"example/{self.distro_name}/{self.distro_name}-{self.distro_ver}-{self.arch}-{self.img_type}.yaml"
+        return (f"{TEST_EXAMPLE_PATH}/{self.distro_name}/"
+                f"{self.distro_name}-{self.distro_ver}-{self.arch}-{self.img_type}.yaml")
 
     def __str__(self):
         return f"{self.distro_name}-{self.distro_ver}-{self.arch}-{self.img_type}-{self.customizations}"
@@ -82,7 +84,7 @@ def test_normalize_rpm_refs():
 @pytest.mark.parametrize("tc", reference_manifests("empty"))
 def test_images_ref_no_customizations(tmp_path, monkeypatch, tc):
     monkeypatch.setenv("OSBUILD_TESTING_RNG_SEED", "0")
-    monkeypatch.setenv("OTK_EXTERNAL_PATH", "./external")
+    monkeypatch.setenv("OTK_EXTERNAL_PATH", str(OTK_EXTERNAL_PATH))
     monkeypatch.setenv("OTK_UNDER_TEST", "1")
 
     with tc.ref_yaml_path.open() as fp:

--- a/test/test_annotation.py
+++ b/test/test_annotation.py
@@ -1,0 +1,178 @@
+import copy
+from unittest.mock import Mock
+
+from otk.annotation import AnnotatedDict, AnnotatedList, AnnotatedStr, AnnotatedInt, AnnotatedPath, AnnotatedBase
+
+from otk.context import CommonContext
+from otk.transform import process_include
+from otk.traversal import State
+
+# pylint has problems with class decorators
+# pylint: disable=no-member
+
+
+# pylint: disable=too-many-locals,R0915
+def test_annotated_classes():
+    # Attribute Access
+    obj = AnnotatedDict(a="some_value", sub={"x": "sub_value"}, sub2="hello")
+    assert obj['a'] == "some_value"
+    assert obj['sub']['x'] == "sub_value"
+
+    # Hidden Attribute Access
+    obj.set_annotation("src", "file_of_obj:1")
+    obj['sub'].set_annotation("src", "file_of_sub:2")
+
+    assert obj.get_annotation("src") == "file_of_obj:1"
+    assert obj['sub'].get_annotation("src") == "file_of_sub:2"
+
+    # deep copy
+    obj2 = copy.deepcopy(obj)
+    assert obj2['a'] == "some_value"
+    assert obj2['sub']['x'] == "sub_value"
+    assert obj2.get_annotation("src") == "file_of_obj:1"
+    assert obj2['sub'].get_annotation("src") == "file_of_sub:2"
+
+    obj['a'].set_annotation("src", "file_of_a_and_sub2:2")
+    obj['sub2'].set_annotation("src", "file_of_a_and_sub2:10")
+
+    # check squash "src"
+    assert obj.squash_annotations(list(obj.values())) == {"src": "* file_of_a_and_sub2:2, 10\n* file_of_sub:2"}
+
+    # Nested Structure
+    nested_obj = AnnotatedDict(a="level_1", b={"level_2": {"level_3": "deep_value"}})
+    assert nested_obj['b']['level_2']['level_3'] == "deep_value"
+
+    # List with Hidden Attributes
+    list_obj = AnnotatedDict(my_list=[{"x": "value1"}, {"y": "value2"}])
+    assert list_obj['my_list'][0]['x'] == "value1"
+    assert list_obj['my_list'][1]['y'] == "value2"
+
+    # Recursively converted
+    assert isinstance(list_obj['my_list'], AnnotatedList)
+
+    list_obj['my_list'].set_annotation("src", "hidden_source_for_my_list:5")
+    assert list_obj['my_list'].get_annotation("src") == "hidden_source_for_my_list:5"
+
+    # dict with all primitives
+    dict_with_builtins = AnnotatedDict(s="string", i=5, f=0.5, b=True)
+
+    # set_annotation would fail on builtin types
+    dict_with_builtins['s'].set_annotation("src", "hidden_source_for_string:1")
+    dict_with_builtins['i'].set_annotation("src", "hidden_source_for_int:1")
+    dict_with_builtins['f'].set_annotation("src", "hidden_source_for_float:1")
+    dict_with_builtins['b'].set_annotation("src", "hidden_source_for_bool:1")
+
+    # still behave like builtins
+    assert isinstance(dict_with_builtins['s'], str)
+    assert isinstance(dict_with_builtins['i'], int)
+    assert isinstance(dict_with_builtins['f'], float)
+    assert isinstance(dict_with_builtins['b'], bool)
+
+    # special conversion test - pyyaml needs "bool" to pass "var is True"
+    # which does not apply to AnnotatedBase, so we need to convert
+    dumped = AnnotatedBase.deep_dump(dict_with_builtins)
+    assert dumped['b'] is True
+    assert dumped['b']
+
+    # test builtin operations
+    s1 = AnnotatedStr("s1")
+    s2 = AnnotatedStr("s2")
+    s1.set_annotation("src", "hidden_source_for_strings:1")
+    s2.set_annotation("src", "hidden_source_for_strings:2")
+
+    s3 = s1 + s2
+    assert s3 == "s1s2"
+    assert s3.get_annotation("src") == "* hidden_source_for_strings:1, 2"
+
+    s3 = s1 + "_hello"
+    assert s3 == "s1_hello"
+    src = s3.get_annotation("src")
+    assert src == "* hidden_source_for_strings:1"
+
+    s3 = "hello_" + s2
+    assert s3 == "hello_s2"
+    src = s3.get_annotation("src")
+    assert src == "* hidden_source_for_strings:2"
+
+    s2 += "_hello"
+    assert s2 == "s2_hello"
+    src = s2.get_annotation("src")
+    assert src == "* hidden_source_for_strings:2"
+
+    string = "test_"
+    string += s1
+    assert string == "test_s1"
+    src = string.get_annotation("src")
+    assert src == "* hidden_source_for_strings:1"
+
+    # test add_source_attributes
+    data = AnnotatedDict()
+    mock_data = Mock(start_mark=Mock(line=0, column=10, name="myfilename"),
+                     end_mark=Mock(line=0, column=10, name="myfilename"))
+    # seems to be a "feature" in Mock() that name needs to be set separately to get a string
+    mock_data.start_mark.name = "myfilename"
+    mock_data.start_end.name = "myfilename"
+    data.add_source_attributes(mock_data)
+    assert data.get_annotation("src") == "myfilename:1"
+
+    # list iterator
+    iter_test = AnnotatedList([1, 2, 3])
+    iter_test[0].set_annotation("key", "value")
+    iter_test[1].set_annotation("key", "value")
+    iter_test[2].set_annotation("key", "value")
+    for i in iter(iter_test):
+        assert i.get_annotation("key") == "value"
+        assert isinstance(i, AnnotatedInt)
+
+    # list append
+    iter_test.append(AnnotatedInt(4))
+    assert isinstance(iter_test[3], AnnotatedInt)
+
+    # deepcopy of path in list
+
+    p1 = AnnotatedPath("file1")
+    p1.set_annotation("src", "src1")
+    p2 = AnnotatedPath("file2")
+    p2.set_annotation("src", "src2")
+    list_of_paths = AnnotatedList([p1, p2])
+    assert list_of_paths[0].get_annotation("src") == "src1"
+    assert list_of_paths[1].get_annotation("src") == "src2"
+
+    list_copy = copy.deepcopy(list_of_paths)
+    assert list_copy[0].get_annotation("src") == "src1"
+    assert list_copy[1].get_annotation("src") == "src2"
+
+    # TBD test str(AnnotatedInt())
+
+    # TBD test json.dumps(sample_tree, indent=2)
+
+
+TEST_YAML = """\
+otk.version: 1
+
+otk.target.osbuild:
+  list:
+    - 1
+    - 2
+  dict:
+   nested_dict:
+    foo: bar
+"""
+
+
+def test_annotate(tmp_path):
+    test_yaml_path = tmp_path / "test.yaml"
+    test_yaml_path.write_text(TEST_YAML)
+
+    # set cur dir - to get nice paths
+    AnnotatedBase._basedir = tmp_path
+
+    ctx = CommonContext(target_requested="osbuild")
+    state = State()
+    tree = process_include(ctx, state, test_yaml_path)
+
+    assert tree.get_annotation("src") == "test.yaml:1"
+    assert tree["otk.target.osbuild"].get_annotation("src") == "test.yaml:3"
+    assert tree["otk.target.osbuild"]["list"].get_annotation("src") == "test.yaml:4"
+    assert tree["otk.target.osbuild"]["list"][0].get_annotation("src") == "test.yaml:5"
+    assert tree["otk.target.osbuild"]["dict"].get_annotation("src") == "test.yaml:7"

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -120,8 +120,8 @@ def test_context_unhappy():
 
     with pytest.raises(TransformVariableTypeError) as exc:
         ctx.variable("foo.bar")
-    assert "tried to look up 'foo.bar', but the value of prefix 'foo' is not a dictionary but <class 'str'>" in str(
-        exc.value)
+    assert ("tried to look up 'foo.bar', but the value of prefix 'foo' "
+            "is not a dictionary but <class 'otk.annotation.AnnotatedStr'>") in str(exc.value)
 
     ctx.define("bar", ["bar"])
 

--- a/test/test_directive.py
+++ b/test/test_directive.py
@@ -1,4 +1,6 @@
 import pytest
+
+from otk.annotation import AnnotatedDict, AnnotatedBase
 from otk.context import CommonContext
 from otk.error import (TransformDirectiveArgumentError,
                        TransformDirectiveTypeError)
@@ -13,7 +15,7 @@ def test_op_seq_join():
     l1 = [1, 2, 3]
     l2 = [4, 5, 6]
 
-    d = {"values": [l1, l2]}
+    d = AnnotatedBase.deep_convert({"values": [l1, l2]})
 
     assert op_join(ctx, state, d) == [1, 2, 3, 4, 5, 6]
 
@@ -23,29 +25,29 @@ def test_op_join_unhappy():
     state = State("foo.yaml")
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, state, 1)
+        op_join(ctx, state, AnnotatedBase.deep_convert(1))
 
     with pytest.raises(TransformDirectiveArgumentError):
-        op_join(ctx, state, {})
+        op_join(ctx, state, AnnotatedBase.deep_convert({}))
 
     with pytest.raises(TransformDirectiveTypeError) as exc:
-        op_join(ctx, state, {"values": 1})
+        op_join(ctx, state, AnnotatedBase.deep_convert({"values": 1}))
     assert "foo.yaml: seq join received values of the wrong type, " in str(exc.value)
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, state, {"values": [1, {2: 3}]})
+        op_join(ctx, state, AnnotatedBase.deep_convert({"values": [1, {2: 3}]}))
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, state, 1)
+        op_join(ctx, state, AnnotatedBase.deep_convert(1))
 
     with pytest.raises(TransformDirectiveArgumentError):
-        op_join(ctx, state, {})
+        op_join(ctx, state, AnnotatedBase.deep_convert({}))
 
     with pytest.raises(TransformDirectiveTypeError):
-        op_join(ctx, state, {"values": 1})
+        op_join(ctx, state, AnnotatedBase.deep_convert({"values": 1}))
 
     with pytest.raises(TransformDirectiveTypeError) as exc:
-        op_join(ctx, state, {"values": [1, {2: 3}]})
+        op_join(ctx, state, AnnotatedBase.deep_convert({"values": [1, {2: 3}]}))
     assert "foo.yaml: cannot join " in str(exc.value)
 
 
@@ -56,6 +58,6 @@ def test_op_map_join():
     d1 = {"foo": "bar"}
     d2 = {"bar": "foo"}
 
-    d = {"values": [d1, d2]}
+    d = AnnotatedBase.deep_convert({"values": [d1, d2]})
 
-    assert op_join(ctx, state, d) == {"foo": "bar", "bar": "foo"}
+    assert op_join(ctx, state, d) == AnnotatedDict({"foo": "bar", "bar": "foo"})

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -4,13 +4,17 @@ import pathlib
 
 import pytest
 from otk import command
+from otk.annotation import AnnotatedBase, AnnotatedPath
 from .fake_externals import mirror as _mirror
 
 
 @pytest.mark.parametrize("src_yaml",
                          [str(path) for path in (pathlib.Path(__file__).parent / "data/base").glob("*.yaml")])
 def test_command_compile_on_base_examples(tmp_path, src_yaml, _mirror):
-    src_yaml = pathlib.Path(src_yaml)
+
+    AnnotatedBase._basedir = tmp_path
+
+    src_yaml = AnnotatedPath(src_yaml)
     dst = tmp_path / "out.json"
 
     ns = argparse.Namespace(input=src_yaml, output=dst, target="osbuild")
@@ -25,8 +29,11 @@ def test_command_compile_on_base_examples(tmp_path, src_yaml, _mirror):
 
 @pytest.mark.parametrize("src_yaml",
                          [str(path) for path in (pathlib.Path(__file__).parent / "data/error").glob("*.yaml")])
-def test_errors(src_yaml, _mirror):
+def test_errors(src_yaml, _mirror, request):
     src_yaml = pathlib.Path(src_yaml)
+    # set basedir to the source location
+    # so we get nice relative path
+    AnnotatedBase._basedir = request.config.invocation_dir
     expected = src_yaml.with_suffix(".err").read_text(encoding="utf8").strip()
     ns = argparse.Namespace(input=src_yaml, output="/dev/null", target="osbuild")
     with pytest.raises(Exception) as exception:

--- a/test/test_external.py
+++ b/test/test_external.py
@@ -6,6 +6,7 @@ import textwrap
 import pytest
 
 import otk.external
+from otk.annotation import AnnotatedDict
 from otk.error import ExternalFailedError
 from otk.external import exe_from_directive
 from otk.traversal import State
@@ -47,7 +48,7 @@ def run_fake_external_ok(external_path, name):
         },
     }
 
-    res = otk.external.call(State(""), fake_directive, fake_tree)
+    res = otk.external.call(State(""), fake_directive, AnnotatedDict(fake_tree))
     assert res == {"some": "result"}
 
     inp = fake_external_path.with_suffix(".stdin").read_text()


### PR DESCRIPTION
The Objects (in `src/otk/annotation.py`) represent all basic types
but with "hidden" annotations to be able to
track the source of the data from the originating
yaml file.

Some of the annotations are already used in error messages, other error messages can be extended in the future with this information.

This is replacing the initial approach #271 