### PR TITLE
otk/command: fix racecondition in tests

### DIFF
--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -77,6 +77,8 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
     # and then output by writing to the output
     if not dry_run:
         dst.write(doc.as_target_string())
+        if arguments.output is not None:
+            dst.close()
 
     return 0
 


### PR DESCRIPTION
Sometimes in my local IDE testing, the lazy close
of the dst file, leads to the test failing because it's not (yet) seeing the result.
So we'll close it, when done.