### PR TITLE
container: fix up build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -26,10 +26,14 @@ RUN dnf install -y \
     && dnf clean all
 
 COPY --from=build /usr/local/bin/otk /usr/local/bin/
-COPY --from=build /usr/local/bin/osbuild* /usr/libexec/otk/external/
 COPY --from=build /usr/local/lib/ /usr/local/lib/
 
-COPY --from=build /src/external/* /usr/local/libexec/otk/external/
+# Since the `src/external` path here includes the Python externals with
+# wrong shebangs we copy those again from the installed version with
+# correct shebangs after the initial copy.
+COPY --from=build /src/external/* /usr/libexec/otk/external/
+COPY --from=build /usr/local/bin/osbuild* /usr/libexec/otk/external/
+
 
 WORKDIR /app
 


### PR DESCRIPTION
When copying in artifacts from the build stage of the container things need to happen in a specific order. Since `/src/external` contains Python stubs that contain a virtual environment specific shebang.

If we copy the installed Python externals *after* we overwrite the ones with broken shebangs.

Closes #284.

Alternatively we could split out the external building into `go` and `python` for the container build as well.