### PR TITLE
externally provided variables

### DIFF
--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -42,10 +42,12 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
         # pylint: disable=R1732
         dst = sys.stdout if arguments.output is None else open(arguments.output, "w", encoding="utf-8")
 
+    extra = [pathlib.Path(p) for p in arguments.extra] if arguments.extra else []
+
     if arguments.input is None:
-        paths = [pathlib.Path(f"/proc/self/fd/{sys.stdin.fileno()}")]
+        paths = extra + [pathlib.Path(f"/proc/self/fd/{sys.stdin.fileno()}")]
     else:
-        paths = [pathlib.Path(p) for p in arguments.input]
+        paths = extra + [pathlib.Path(arguments.input)]
 
     # First pass of resolving the otk file is "shallow", it will not run
     # externals and not resolve anything under otk.target.*
@@ -127,9 +129,16 @@ def parser_create() -> argparse.ArgumentParser:
     parser_compile.add_argument(
         "input",
         metavar="INPUT",
-        nargs="*",
+        nargs="?",
         default=None,
         help="Omnifest to compile to or none for STDIN.",
+    )
+    parser_compile.add_argument(
+        "-e",
+        dest="extra",
+        nargs=1,
+        action="extend",
+        help="Extra files to compile.",
     )
     parser_compile.add_argument(
         "-o",
@@ -148,9 +157,16 @@ def parser_create() -> argparse.ArgumentParser:
     parser_validate.add_argument(
         "input",
         metavar="INPUT",
-        nargs="*",
+        nargs="?",
         default=None,
         help="Omnifest to validate to or none for STDIN.",
+    )
+    parser_validate.add_argument(
+        "-e",
+        dest="extra",
+        nargs=1,
+        action="extend",
+        help="Extra files to compile.",
     )
     parser_validate.add_argument(
         "-t",

--- a/src/otk/command.py
+++ b/src/otk/command.py
@@ -43,16 +43,16 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
         dst = sys.stdout if arguments.output is None else open(arguments.output, "w", encoding="utf-8")
 
     if arguments.input is None:
-        path = pathlib.Path(f"/proc/self/fd/{sys.stdin.fileno()}")
+        paths = [pathlib.Path(f"/proc/self/fd/{sys.stdin.fileno()}")]
     else:
-        path = pathlib.Path(arguments.input)
+        paths = [pathlib.Path(p) for p in arguments.input]
 
     # First pass of resolving the otk file is "shallow", it will not run
     # externals and not resolve anything under otk.target.*
     #
     # It only exists as convenience for the user so that they do not need
     # to use "-t"
-    doc = Omnifest(path)
+    doc = Omnifest(paths)
 
     target_available = doc.targets
     target_requested = arguments.target
@@ -72,7 +72,7 @@ def _process(arguments: argparse.Namespace, dry_run: bool) -> int:
     # a full run so that resolving includes works correctly.
     warn_duplicated_defs = any(arg in getattr(arguments, "warn", [])
                                for arg in ["duplicate-definition", "all"])
-    doc = Omnifest(path, target=target_requested, warn_duplicated_defs=warn_duplicated_defs)
+    doc = Omnifest(paths, target=target_requested, warn_duplicated_defs=warn_duplicated_defs)
 
     # and then output by writing to the output
     if not dry_run:
@@ -127,7 +127,7 @@ def parser_create() -> argparse.ArgumentParser:
     parser_compile.add_argument(
         "input",
         metavar="INPUT",
-        nargs="?",
+        nargs="*",
         default=None,
         help="Omnifest to compile to or none for STDIN.",
     )
@@ -148,7 +148,7 @@ def parser_create() -> argparse.ArgumentParser:
     parser_validate.add_argument(
         "input",
         metavar="INPUT",
-        nargs="?",
+        nargs="*",
         default=None,
         help="Omnifest to validate to or none for STDIN.",
     )

--- a/src/otk/document.py
+++ b/src/otk/document.py
@@ -19,8 +19,9 @@ class Omnifest:
     _osbuild_ctx: OSBuildContext
     _target: str
 
-    def __init__(self, path: pathlib.Path, target: str = "", *, warn_duplicated_defs: bool = False) -> None:
+    def __init__(self, paths: list[pathlib.Path], target: str = "", *, warn_duplicated_defs: bool = False) -> None:
         self._ctx = CommonContext(target_requested=target, warn_duplicated_defs=warn_duplicated_defs)
+
         # XXX: this can be removed once we find a way to deal with unset variables
         self._ctx.define("user.modifications", {})
         self._target = target
@@ -30,7 +31,10 @@ class Omnifest:
                 raise OTKError("only target osbuild supported right now")
             self._osbuild_ctx = OSBuildContext(self._ctx)
         state = State()
-        tree = process_include(self._ctx, state, path)
+
+        for path in paths:
+            tree = process_include(self._ctx, state, path)
+
         # XXX: review this code, the idea is to find top-level keys that
         # have no targets but that of course only works if there are
         # no targets in the resolving. this means we are currently forced

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -6,21 +6,21 @@ from otk.command import parser_create, run
 @pytest.mark.parametrize(
     "command,results",
     [
-        (["compile"], {"command": "compile", "output": None, "input": []}),
-        (["compile", "foo"], {"command": "compile", "output": None, "input": ["foo"]}),
+        (["compile"], {"command": "compile", "output": None, "input": None}),
+        (["compile", "foo"], {"command": "compile", "output": None, "input": "foo"}),
         (
             ["compile", "-o", "output_manifest.yaml"],
-            {"command": "compile", "output": "output_manifest.yaml", "input": []},
+            {"command": "compile", "output": "output_manifest.yaml", "input": None},
         ),
         (
             ["compile", "-o", "output_manifest.yaml", "input_omifest.yaml"],
             {
                 "command": "compile",
                 "output": "output_manifest.yaml",
-                "input": ["input_omifest.yaml"],
+                "input": "input_omifest.yaml",
             },
         ),
-        (["validate", "foo.yaml"], {"command": "validate", "input": ["foo.yaml"]}),
+        (["validate", "foo.yaml"], {"command": "validate", "input": "foo.yaml"}),
     ],
 )
 def test_parse_commands_success(command, results):

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -6,21 +6,21 @@ from otk.command import parser_create, run
 @pytest.mark.parametrize(
     "command,results",
     [
-        (["compile"], {"command": "compile", "output": None, "input": None}),
-        (["compile", "foo"], {"command": "compile", "output": None, "input": "foo"}),
+        (["compile"], {"command": "compile", "output": None, "input": []}),
+        (["compile", "foo"], {"command": "compile", "output": None, "input": ["foo"]}),
         (
             ["compile", "-o", "output_manifest.yaml"],
-            {"command": "compile", "output": "output_manifest.yaml", "input": None},
+            {"command": "compile", "output": "output_manifest.yaml", "input": []},
         ),
         (
             ["compile", "-o", "output_manifest.yaml", "input_omifest.yaml"],
             {
                 "command": "compile",
                 "output": "output_manifest.yaml",
-                "input": "input_omifest.yaml",
+                "input": ["input_omifest.yaml"],
             },
         ),
-        (["validate", "foo.yaml"], {"command": "validate", "input": "foo.yaml"}),
+        (["validate", "foo.yaml"], {"command": "validate", "input": ["foo.yaml"]}),
     ],
 )
 def test_parse_commands_success(command, results):
@@ -41,8 +41,7 @@ def test_parse_commands_success(command, results):
         (
             ["validate", "-o", "output_manifest.yaml", "input_omifest.yaml"],
             2,
-            # deliberately we expect '-o input_omifest.yaml' as argparse acts like this if -o is not defined
-            "error: unrecognized arguments: -o input_omifest.yaml",
+            "error: unrecognized arguments: -o",
         ),
     ],
 )

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -23,7 +23,7 @@ def test_compile_integration_file(tmp_path):
     input_path.write_text(FAKE_OTK_YAML)
     output_path = tmp_path / "output.txt"
 
-    arguments = argparse.Namespace(input=[input_path], output=output_path, target="osbuild.qcow2")
+    arguments = argparse.Namespace(input=input_path, output=output_path, target="osbuild.qcow2", extra=None)
     ret = compile(arguments)
     assert ret == 0
 
@@ -37,7 +37,7 @@ def test_compile_integration_stdin(capsys, monkeypatch):
     os.lseek(mocked_stdin, 0, 0)
     monkeypatch.setattr("sys.stdin", os.fdopen(mocked_stdin))
 
-    arguments = argparse.Namespace(input=None, output=None, target="osbuild.qcow2")
+    arguments = argparse.Namespace(input=None, output=None, target="osbuild.qcow2", extra=None)
     ret = compile(arguments)
     assert ret == 0
 

--- a/test/test_compile.py
+++ b/test/test_compile.py
@@ -23,7 +23,7 @@ def test_compile_integration_file(tmp_path):
     input_path.write_text(FAKE_OTK_YAML)
     output_path = tmp_path / "output.txt"
 
-    arguments = argparse.Namespace(input=input_path, output=output_path, target="osbuild.qcow2")
+    arguments = argparse.Namespace(input=[input_path], output=output_path, target="osbuild.qcow2")
     ret = compile(arguments)
     assert ret == 0
 

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -13,7 +13,7 @@ def test_command_compile_on_base_examples(tmp_path, src_yaml, _mirror):
     src_yaml = pathlib.Path(src_yaml)
     dst = tmp_path / "out.json"
 
-    ns = argparse.Namespace(input=src_yaml, output=dst, target="osbuild")
+    ns = argparse.Namespace(input=[src_yaml], output=dst, target="osbuild")
 
     command.compile(ns)
 
@@ -28,7 +28,7 @@ def test_command_compile_on_base_examples(tmp_path, src_yaml, _mirror):
 def test_errors(src_yaml, _mirror):
     src_yaml = pathlib.Path(src_yaml)
     expected = src_yaml.with_suffix(".err").read_text(encoding="utf8").strip()
-    ns = argparse.Namespace(input=src_yaml, output="/dev/null", target="osbuild")
+    ns = argparse.Namespace(input=[src_yaml], output="/dev/null", target="osbuild")
     with pytest.raises(Exception) as exception:
         command.compile(ns)
     assert expected in str(exception.value)

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -13,7 +13,7 @@ def test_command_compile_on_base_examples(tmp_path, src_yaml, _mirror):
     src_yaml = pathlib.Path(src_yaml)
     dst = tmp_path / "out.json"
 
-    ns = argparse.Namespace(input=[src_yaml], output=dst, target="osbuild")
+    ns = argparse.Namespace(input=src_yaml, output=dst, target="osbuild", extra=None)
 
     command.compile(ns)
 
@@ -28,7 +28,7 @@ def test_command_compile_on_base_examples(tmp_path, src_yaml, _mirror):
 def test_errors(src_yaml, _mirror):
     src_yaml = pathlib.Path(src_yaml)
     expected = src_yaml.with_suffix(".err").read_text(encoding="utf8").strip()
-    ns = argparse.Namespace(input=[src_yaml], output="/dev/null", target="osbuild")
+    ns = argparse.Namespace(input=src_yaml, output="/dev/null", target="osbuild", extra=None)
     with pytest.raises(Exception) as exception:
         command.compile(ns)
     assert expected in str(exception.value)

--- a/test/test_preload.py
+++ b/test/test_preload.py
@@ -34,5 +34,5 @@ def test_otk_preload_works(tmp_path):
       lang: ${modifications.language}
     """))
     result_otk = tmp_path / "output.yaml"
-    run(["compile", os.fspath(preload_otk), os.fspath(test_otk), "-o", result_otk.as_posix()])
+    run(["compile", "-e", os.fspath(preload_otk), os.fspath(test_otk), "-o", result_otk.as_posix()])
     assert expected_json == result_otk.read_text()

--- a/test/test_preload.py
+++ b/test/test_preload.py
@@ -1,0 +1,38 @@
+import os
+import textwrap
+
+from otk.command import run
+
+
+def test_otk_preload_works(tmp_path):
+    expected_json = textwrap.dedent("""\
+    {
+      "lang": "nl_NL.UTF-8",
+      "version": "2"
+    }""")
+    preload_otk = tmp_path / "preload.yaml"
+    preload_otk.write_text(textwrap.dedent("""
+    otk.define:
+      user:
+        modifications:
+          language: nl_NL.UTF-8
+    """))
+
+    test_otk = tmp_path / "foo.yaml"
+    test_otk.write_text(textwrap.dedent("""
+    otk.version: 1
+    otk.define:
+      default:
+        modifications:
+          language: en_US.UTF-8
+      modifications:
+        otk.op.join:
+          values:
+            - ${default.modifications}
+            - ${user.modifications}
+    otk.target.osbuild:
+      lang: ${modifications.language}
+    """))
+    result_otk = tmp_path / "output.yaml"
+    run(["compile", os.fspath(preload_otk), os.fspath(test_otk), "-o", result_otk.as_posix()])
+    assert expected_json == result_otk.read_text()

--- a/test/test_validate.py
+++ b/test/test_validate.py
@@ -10,7 +10,7 @@ from otk.command import validate
     [
         # "GENERATE" is a placeholder to append "tmp_path" from pytest
         (
-            argparse.Namespace(input="GENERATE", output="GENERATE", target=None),
+            argparse.Namespace(input="GENERATE", output="GENERATE", target=None, extra=None),
             """otk.version: 1
 otk.target.osbuild.qcow2: { test: 1 }
 """,
@@ -18,7 +18,7 @@ otk.target.osbuild.qcow2: { test: 1 }
             None,
         ),
         (
-            argparse.Namespace(input="GENERATE", output=None, target=None),
+            argparse.Namespace(input="GENERATE", output=None, target=None, extra=None),
             """otk.version: 1
 otk.target.osbuild.qcow2: { test: 1 }
 """,
@@ -26,7 +26,7 @@ otk.target.osbuild.qcow2: { test: 1 }
             None,
         ),
         (
-            argparse.Namespace(input="GENERATE", output="GENERATE", target=None),
+            argparse.Namespace(input="GENERATE", output="GENERATE", target=None, extra=None),
             """otk.version: 1
 otk.target.osbuild.qcow2: { test: 1 }
 otk.target.osbuild.ami: { test: 2 }
@@ -42,7 +42,7 @@ def test_validate(tmp_path, caplog, arguments, input_data, sys_exit_code, log_me
         input_path = os.path.join(tmp_path, input_filename)
         with open(input_path, "w", encoding="utf8") as f:
             f.write(input_data)
-        arguments.input = [input_path]
+        arguments.input = input_path
 
     if arguments.output == "GENERATE":
         # fix path so we only write to tmp_path

--- a/test/test_validate.py
+++ b/test/test_validate.py
@@ -39,9 +39,10 @@ otk.target.osbuild.ami: { test: 2 }
 def test_validate(tmp_path, caplog, arguments, input_data, sys_exit_code, log_message):  # pylint: disable=too-many-arguments
     if arguments.input == "GENERATE":
         input_filename = "input.yaml"
-        arguments.input = os.path.join(tmp_path, input_filename)
-        with open(arguments.input, "w", encoding="utf8") as f:
+        input_path = os.path.join(tmp_path, input_filename)
+        with open(input_path, "w", encoding="utf8") as f:
             f.write(input_data)
+        arguments.input = [input_path]
 
     if arguments.output == "GENERATE":
         # fix path so we only write to tmp_path


### PR DESCRIPTION
Allow defining variables from external sources such as the command-line.

This can be used for customizations (see #242) and build systems to provide, for example, repositories.

```bash
otk compile something.yaml omnifest.yaml
```

(needs additional testcase)