### PR TITLE
generator metadata

### DIFF
--- a/example/centos/centos-9-aarch64-ami.yaml
+++ b/example/centos/centos-9-aarch64-ami.yaml
@@ -37,6 +37,10 @@ otk.define:
 otk.include: "common/partition-table/${architecture}/default.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/generic.yaml"
     - name: os

--- a/example/centos/centos-9-aarch64-edge-commit.yaml
+++ b/example/centos/centos-9-aarch64-edge-commit.yaml
@@ -29,6 +29,10 @@ otk.define:
           otk.include: "common/package-set/${architecture}/os/edge-commit.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/tar.yaml"
     - name: os

--- a/example/centos/centos-9-aarch64-image-installer.yaml
+++ b/example/centos/centos-9-aarch64-image-installer.yaml
@@ -50,6 +50,10 @@ otk.define:
           packagename: "kernel"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/tar.yaml"
     - name: anaconda-tree

--- a/example/centos/centos-9-aarch64-minimal-raw.yaml
+++ b/example/centos/centos-9-aarch64-minimal-raw.yaml
@@ -46,6 +46,10 @@ otk.define:
 otk.include: "common/partition-table/${architecture}/minimal-raw.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/generic.yaml"
     - name: os

--- a/example/centos/centos-9-aarch64-qcow2.yaml
+++ b/example/centos/centos-9-aarch64-qcow2.yaml
@@ -37,6 +37,10 @@ otk.define:
 otk.include: "common/partition-table/${architecture}/default.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/generic.yaml"
     - name: os

--- a/example/centos/centos-9-aarch64-tar.yaml
+++ b/example/centos/centos-9-aarch64-tar.yaml
@@ -28,6 +28,10 @@ otk.define:
           otk.include: "common/package-set/noarch/os/tar.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/tar.yaml"
     - name: os

--- a/example/centos/centos-9-aarch64-vhd.yaml
+++ b/example/centos/centos-9-aarch64-vhd.yaml
@@ -37,6 +37,10 @@ otk.define:
 otk.include: "common/partition-table/${architecture}/vhd.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/generic.yaml"
     - name: os

--- a/example/centos/centos-9-aarch64-wsl.yaml
+++ b/example/centos/centos-9-aarch64-wsl.yaml
@@ -23,6 +23,10 @@ otk.define:
           otk.include: "common/package-set/noarch/os/wsl.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: pipeline/build/tar.yaml
     - name: os

--- a/example/centos/centos-9-ppc64le-tar.yaml
+++ b/example/centos/centos-9-ppc64le-tar.yaml
@@ -28,6 +28,10 @@ otk.define:
           otk.include: "common/package-set/noarch/os/tar.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/tar.yaml"
     - name: os

--- a/example/centos/centos-9-s390x-qcow2.yaml
+++ b/example/centos/centos-9-s390x-qcow2.yaml
@@ -109,6 +109,10 @@ otk.define:
 otk.include: "common/partition-table/s390x/default.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/generic.yaml"
     - name: os

--- a/example/centos/centos-9-s390x-tar.yaml
+++ b/example/centos/centos-9-s390x-tar.yaml
@@ -28,6 +28,10 @@ otk.define:
           otk.include: "common/package-set/noarch/os/tar.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/tar.yaml"
     - name: os

--- a/example/centos/centos-9-x86_64-ami.yaml
+++ b/example/centos/centos-9-x86_64-ami.yaml
@@ -47,6 +47,10 @@ otk.define:
 otk.include: "common/partition-table/${architecture}/default.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - name: build
       runner: org.osbuild.centos9

--- a/example/centos/centos-9-x86_64-edge-commit.yaml
+++ b/example/centos/centos-9-x86_64-edge-commit.yaml
@@ -29,6 +29,10 @@ otk.define:
           otk.include: "common/package-set/${architecture}/os/edge-commit.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/tar.yaml"
     - name: os

--- a/example/centos/centos-9-x86_64-image-installer.yaml
+++ b/example/centos/centos-9-x86_64-image-installer.yaml
@@ -50,6 +50,10 @@ otk.define:
           packagename: "kernel"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/tar.yaml"
     - name: anaconda-tree

--- a/example/centos/centos-9-x86_64-minimal-raw.yaml
+++ b/example/centos/centos-9-x86_64-minimal-raw.yaml
@@ -46,6 +46,10 @@ otk.define:
 otk.include: "common/partition-table/${architecture}/minimal-raw.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/generic.yaml"
     - name: os

--- a/example/centos/centos-9-x86_64-ova.yaml
+++ b/example/centos/centos-9-x86_64-ova.yaml
@@ -37,6 +37,10 @@ otk.define:
 otk.include: "common/partition-table/${architecture}/vhd_vmdk_ova.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/tar.yaml"
     - name: os

--- a/example/centos/centos-9-x86_64-qcow2.yaml
+++ b/example/centos/centos-9-x86_64-qcow2.yaml
@@ -37,6 +37,10 @@ otk.define:
 otk.include: "common/partition-table/${architecture}/default.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/generic.yaml"
     - name: os

--- a/example/centos/centos-9-x86_64-tar.yaml
+++ b/example/centos/centos-9-x86_64-tar.yaml
@@ -28,6 +28,10 @@ otk.define:
           otk.include: "common/package-set/noarch/os/tar.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/tar.yaml"
     - name: os

--- a/example/centos/centos-9-x86_64-vhd.yaml
+++ b/example/centos/centos-9-x86_64-vhd.yaml
@@ -36,6 +36,10 @@ otk.define:
 otk.include: "common/partition-table/${architecture}/vhd_vmdk_ova.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/generic.yaml"
     - name: os

--- a/example/centos/centos-9-x86_64-vmdk.yaml
+++ b/example/centos/centos-9-x86_64-vmdk.yaml
@@ -36,6 +36,10 @@ otk.define:
 otk.include: "common/partition-table/${architecture}/vhd_vmdk_ova.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: "pipeline/build/generic.yaml"
     - name: os

--- a/example/centos/centos-9-x86_64-wsl.yaml
+++ b/example/centos/centos-9-x86_64-wsl.yaml
@@ -23,6 +23,10 @@ otk.define:
           otk.include: "common/package-set/noarch/os/wsl.yaml"
 
 otk.target.osbuild:
+  metadata:
+    generator:
+      - otk.external.osbuild-make-generator-metadata:
+
   pipelines:
     - otk.include: pipeline/build/tar.yaml
     - name: os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ osbuild-make-depsolve-dnf4-curl-source = "otk_external_osbuild.command.make_deps
 osbuild-get-dnf4-package-info = "otk_external_osbuild.command.get_dnf4_package_info:main"
 osbuild-gen-inline-files = "otk_external_osbuild.command.gen_inline_files:main"
 osbuild-make-inline-source = "otk_external_osbuild.command.make_inline_source:main"
+osbuild-make-generator-metadata = "otk_external_osbuild.command.make_generator_metadata:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/otk_external_osbuild/command/make_generator_metadata.py
+++ b/src/otk_external_osbuild/command/make_generator_metadata.py
@@ -1,0 +1,22 @@
+import json
+import sys
+
+import otk
+
+
+def root() -> None:
+    sys.stdout.write(
+        json.dumps(
+            {
+                "tree": f"otk {otk.__version__}",
+            }
+        )
+    )
+
+
+def main():
+    root()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_against_images_refs.py
+++ b/test/test_against_images_refs.py
@@ -35,6 +35,26 @@ def reference_manifests(customizations: str) -> list:
     return tc
 
 
+def remove_metadata(manifest):
+    """Remove any metadata if present. The metadata between the
+       reference and otk are different by expectation."""
+
+    if "metadata" in manifest:
+        del manifest["metadata"]
+
+
+def test_remove_metadata():
+    fake_manifest = {
+        "metadata": {
+            "generators": ["testcase",],
+        }
+    }
+
+    remove_metadata(fake_manifest)
+
+    assert "metadata" not in fake_manifest
+
+
 def normalize_rpm_refs(manifest):
     """Normalize the rpm references, i.e. sort and remove duplicationed
     hashes.
@@ -88,6 +108,7 @@ def test_images_ref_no_customizations(tmp_path, monkeypatch, tc):
     with tc.ref_yaml_path.open() as fp:
         ref_manifest = yaml.safe_load(fp)
         normalize_rpm_refs(ref_manifest)
+        remove_metadata(ref_manifest)
 
     otk_json = tmp_path / "manifest-otk.json"
     run(["compile",
@@ -97,6 +118,7 @@ def test_images_ref_no_customizations(tmp_path, monkeypatch, tc):
     with otk_json.open() as fp:
         manifest = json.load(fp)
         normalize_rpm_refs(manifest)
+        remove_metadata(manifest)
 
     assert manifest == ref_manifest
 
@@ -121,6 +143,7 @@ def test_images_ref_full_customizations(tmp_path, monkeypatch, tc):
     with tc.ref_yaml_path.open() as fp:
         ref_manifest = yaml.safe_load(fp)
         normalize_rpm_refs(ref_manifest)
+        remove_metadata(ref_manifest)
 
     otk_json = tmp_path / "manifest-otk.json"
     run(["compile",
@@ -130,5 +153,6 @@ def test_images_ref_full_customizations(tmp_path, monkeypatch, tc):
     with otk_json.open() as fp:
         manifest = json.load(fp)
         normalize_rpm_refs(manifest)
+        remove_metadata(manifest)
 
     assert manifest == ref_manifest

--- a/test/test_make_generator_metadata.py
+++ b/test/test_make_generator_metadata.py
@@ -1,0 +1,12 @@
+import json
+
+import otk
+from otk_external_osbuild.command.make_generator_metadata import root
+
+
+def test_make_inline_source(capsys):
+    root()
+    output = json.loads(capsys.readouterr().out)
+    assert output == {
+        "tree": f"otk {otk.__version__}",
+    }

--- a/test/test_make_generator_metadata.py
+++ b/test/test_make_generator_metadata.py
@@ -4,7 +4,7 @@ import otk
 from otk_external_osbuild.command.make_generator_metadata import root
 
 
-def test_make_inline_source(capsys):
+def test_make_generator_metadata(capsys):
     root()
     output = json.loads(capsys.readouterr().out)
     assert output == {


### PR DESCRIPTION
`osbuild` [grew](https://github.com/osbuild/osbuild/pull/1900) the ability to include generator metadata. Let's actually write that metadata in `otk`.