### PR TITLE
doc: fix anchor

### DIFF
--- a/doc/03-omnifest/index.md
+++ b/doc/03-omnifest/index.md
@@ -7,7 +7,7 @@ An omnifest is the name for the YAML-based format that is used by `otk` as its i
 As omnifests can include other omnifests it is important to note that `otk` treats the entrypoint omnifest differently from included omnifests. The entrypoint omnifest is the file that is passed to `otk compile [file]`. This entrypoint is required to have:
 
 1. An [otk.version](./01-directive.md#otkversion) directive.
-1. An [otk.target](./01-directive.md#otktarget) directive.
+1. An [otk.target](./01-directive.md#otktargetconsumername) directive.
 
 A minimal entrypoint would look like:
 


### PR DESCRIPTION
The import in docs [1] highlighted this anchors name being wrong.

[1]: https://github.com/osbuild/osbuild.github.io/pull/129