### PR TITLE
README: remove mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,5 @@ To run the tests, you can run `make test`.
  * **Website**: https://www.osbuild.org
  * **Bug Tracker**: https://github.com/osbuild/otk/issues
  * **Discussions**: https://github.com/orgs/osbuild/discussions
- * **Matrix**: #image-builder on [fedoraproject.org](https://matrix.to/#/#image-builder:fedoraproject.org)
- * **Mailing List**: image-builder@redhat.com
+ * **Matrix**: [#image-builder on fedoraproject.org](https://matrix.to/#/#image-builder:fedoraproject.org)
  * **Changelog**: https://github.com/osbuild/otk/releases


### PR DESCRIPTION
The mailing list was sunset by the IT department and was rarely used, so we'll replace it with matrix & discussions.